### PR TITLE
fix(frontend): hardcode Simple Analytics for javachat.ai domain

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -21,7 +21,8 @@ function buildSimpleAnalyticsTags(mode: string): HtmlTagDescriptor[] {
     return []
   }
 
-  const noScriptImageUrl = `${SIMPLE_ANALYTICS_QUEUE_ORIGIN}/noscript.gif`
+  const noScriptImageUrl =
+    `${SIMPLE_ANALYTICS_QUEUE_ORIGIN}/noscript.gif?hostname=${encodeURIComponent(SIMPLE_ANALYTICS_HOSTNAME)}`
 
   return [
     {


### PR DESCRIPTION
Simple Analytics traffic was being sent without an explicit production hostname, which can cause events to be attributed to the wrong site identity in the dashboard. This commit makes analytics wiring deterministic by hardcoding the canonical javachat.ai hostname in the injected script and noscript pixel.

It also switches to explicit HTML tag descriptors for the injection logic and keeps analytics disabled in development mode to avoid polluting production data during local testing.

- Replace dynamic script filename logic with a fixed production script URL
- Inject data-hostname="javachat.ai" on the analytics script tag
- Add a hostname-qualified noscript pixel URL for non-JS tracking
- Move analytics injection into a dedicated buildSimpleAnalyticsTags() helper
- Use Vite HtmlTagDescriptor typing for safer transform output