### PR TITLE
Scope completion truncation to active provider

### DIFF
--- a/src/main/java/com/williamcallahan/javachat/service/OpenAIStreamingService.java
+++ b/src/main/java/com/williamcallahan/javachat/service/OpenAIStreamingService.java
@@ -168,7 +168,6 @@ public class OpenAIStreamingService {
      * @return completion text from the first successful provider attempt
      */
     public Mono<String> complete(String prompt, double temperature) {
-        String truncatedPrompt = requestFactory.truncatePromptForCompletion(prompt);
         return Mono.<String>defer(() -> {
                     List<OpenAiProviderCandidate> availableProviders =
                             providerRoutingService.selectAvailableProviderCandidates(clientPrimary, clientSecondary);
@@ -185,7 +184,7 @@ public class OpenAIStreamingService {
                         RateLimitService.ApiProvider activeProvider = providerCandidate.provider();
 
                         ResponseCreateParams requestParameters =
-                                requestFactory.buildCompletionRequest(truncatedPrompt, temperature, activeProvider);
+                                requestFactory.buildCompletionRequest(prompt, temperature, activeProvider);
                         try {
                             log.info("[LLM] Complete started (providerId={})", activeProvider.ordinal());
                             RequestOptions requestOptions = RequestOptions.builder()

--- a/src/main/java/com/williamcallahan/javachat/service/OpenAiRequestFactory.java
+++ b/src/main/java/com/williamcallahan/javachat/service/OpenAiRequestFactory.java
@@ -114,7 +114,8 @@ public class OpenAiRequestFactory {
             String prompt, double temperature, RateLimitService.ApiProvider provider) {
         boolean useGitHubModels = provider == RateLimitService.ApiProvider.GITHUB_MODELS;
         String modelId = normalizedModelId(useGitHubModels);
-        return buildResponseParams(prompt, temperature, modelId);
+        String truncatedPrompt = truncatePromptForCompletion(prompt, modelId);
+        return buildResponseParams(truncatedPrompt, temperature, modelId);
     }
 
     /**
@@ -124,16 +125,29 @@ public class OpenAiRequestFactory {
      * @return original prompt when no truncation is required, otherwise a notice-prefixed prompt
      */
     public String truncatePromptForCompletion(String prompt) {
+        return truncatePromptForCompletion(prompt, RateLimitService.ApiProvider.OPENAI);
+    }
+
+    /**
+     * Truncates completion prompts to token limits for the selected provider's model.
+     *
+     * @param prompt full completion prompt
+     * @param provider provider chosen for this request attempt
+     * @return original prompt when no truncation is required, otherwise a notice-prefixed prompt
+     */
+    public String truncatePromptForCompletion(String prompt, RateLimitService.ApiProvider provider) {
+        boolean useGitHubModels = provider == RateLimitService.ApiProvider.GITHUB_MODELS;
+        String modelId = normalizedModelId(useGitHubModels);
+        return truncatePromptForCompletion(prompt, modelId);
+    }
+
+    private String truncatePromptForCompletion(String prompt, String modelId) {
         if (prompt == null || prompt.isEmpty()) {
             return prompt;
         }
 
-        String openaiModelId = normalizedModelId(false);
-        String githubModelId = normalizedModelId(true);
-        boolean gpt5Family = isGpt5Family(openaiModelId) || isGpt5Family(githubModelId);
-        boolean reasoningModel = gpt5Family
-                || canonicalModelName(openaiModelId).startsWith("o")
-                || canonicalModelName(githubModelId).startsWith("o");
+        boolean gpt5Family = isGpt5Family(modelId);
+        boolean reasoningModel = gpt5Family || canonicalModelName(modelId).startsWith("o");
 
         int tokenLimit = reasoningModel ? MAX_TOKENS_GPT5_INPUT : MAX_TOKENS_DEFAULT_INPUT;
         String truncatedPrompt = chunker.keepLastTokens(prompt, tokenLimit);

--- a/src/test/java/com/williamcallahan/javachat/service/OpenAiRequestFactoryTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/OpenAiRequestFactoryTest.java
@@ -48,4 +48,29 @@ class OpenAiRequestFactoryTest {
         assertTrue(responseCreateParams.maxOutputTokens().isEmpty());
         assertEquals(0.25, responseCreateParams.temperature().orElseThrow(), 0.000_001);
     }
+
+    @Test
+    void truncatePromptForCompletionUsesSelectedOpenAiModelLimit() {
+        OpenAiRequestFactory requestFactory =
+                new OpenAiRequestFactory(new Chunker(), new PromptTruncator(), "gpt-4o", "openai/gpt-5", "");
+        String prompt = "context ".repeat(8_000);
+
+        String truncatedPrompt =
+                requestFactory.truncatePromptForCompletion(prompt, RateLimitService.ApiProvider.OPENAI);
+
+        assertEquals(prompt, truncatedPrompt);
+    }
+
+    @Test
+    void truncatePromptForCompletionUsesSelectedGitHubModelsLimit() {
+        OpenAiRequestFactory requestFactory =
+                new OpenAiRequestFactory(new Chunker(), new PromptTruncator(), "gpt-4o", "gpt-5", "");
+        String prompt = "context ".repeat(8_000);
+
+        String truncatedPrompt =
+                requestFactory.truncatePromptForCompletion(prompt, RateLimitService.ApiProvider.GITHUB_MODELS);
+
+        assertTrue(truncatedPrompt.startsWith("[Context truncated due to GPT-5 8K input limit]"));
+        assertTrue(truncatedPrompt.length() < prompt.length());
+    }
 }


### PR DESCRIPTION
## Summary
- scopes completion prompt truncation to the provider selected for the current request attempt
- moves completion truncation into `buildCompletionRequest` so fallback providers use their own model limits
- adds regression coverage for OpenAI `gpt-4o` alongside the default GitHub Models `openai/gpt-5`

Fixes #40.

## Verification
- `JAVA_HOME=C:\Users\Admin\AppData\Local\Codex\jdks\temurin-25\jdk-25.0.3+9 ./gradlew.bat test --tests com.williamcallahan.javachat.service.OpenAiRequestFactoryTest`
- `JAVA_HOME=C:\Users\Admin\AppData\Local\Codex\jdks\temurin-25\jdk-25.0.3+9 ./gradlew.bat test --tests com.williamcallahan.javachat.service.OpenAIStreamingServiceTest`
- `JAVA_HOME=C:\Users\Admin\AppData\Local\Codex\jdks\temurin-25\jdk-25.0.3+9 ./gradlew.bat spotlessCheck`
- `git diff --check`

Full `./gradlew.bat test` runs 244 tests but fails on the existing Windows environment because `EnvironmentVariablePrecedenceTest` hardcodes `/bin/bash`, which is not present here.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes issue #40 by moving prompt truncation inside `buildCompletionRequest` so that each provider attempt uses its own model's token limits, rather than applying a single pre-loop truncation derived from the union of both providers' characteristics.

- `OpenAIStreamingService.complete()` now passes the raw prompt to `buildCompletionRequest`, which calls the private `truncatePromptForCompletion(String, String)` with the resolved model ID for the active provider.
- `OpenAiRequestFactory` gains a public provider-arg overload of `truncatePromptForCompletion` and a private model-ID overload that contains the actual logic; the original no-arg public method now delegates to the OPENAI provider by default.
- Two new tests verify that `gpt-4o` (OpenAI) leaves an ~8K-token prompt untouched while `openai/gpt-5` (GitHub Models) truncates it with the appropriate notice.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core logic change is correct and well-tested for the targeted scenarios.

The refactor correctly scopes truncation to the active provider on each attempt. Two dead public overloads have no production callers after the change, and the o-series 7K limit assumption silently under-serves larger-context models. Neither issue affects correctness for the currently configured models.

OpenAiRequestFactory.java — the dead public overloads and the o-series token limit assumption are worth a second look before this code path grows further.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/main/java/com/williamcallahan/javachat/service/OpenAIStreamingService.java | Removes pre-loop truncation and passes the raw prompt to buildCompletionRequest; correct and minimal change. |
| src/main/java/com/williamcallahan/javachat/service/OpenAiRequestFactory.java | Moves per-provider truncation into buildCompletionRequest; introduces two public overloads that have no production callers after the refactor (dead API), and the o-series branch still applies GPT-5's 7K limit. |
| src/test/java/com/williamcallahan/javachat/service/OpenAiRequestFactoryTest.java | Adds two tests for the new public provider-arg overload; integration between buildCompletionRequest and truncation for GitHub Models provider is not directly covered. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Caller
    participant S as OpenAIStreamingService
    participant F as OpenAiRequestFactory
    participant P as ProviderRoutingService

    C->>S: complete(prompt, temperature)
    S->>P: selectAvailableProviderCandidates(...)
    P-->>S: [providerCandidate, ...]

    loop for each providerCandidate
        S->>F: buildCompletionRequest(prompt, temperature, activeProvider)
        Note over F: normalizedModelId(useGitHubModels)
        F->>F: truncatePromptForCompletion(prompt, modelId)
        Note over F: gpt5Family / reasoningModel check
        F-->>S: ResponseCreateParams (with truncated prompt)
        S->>P: client.responses().create(requestParameters)
        alt success
            P-->>S: Response
            S-->>C: Mono.just(text)
        else RuntimeException
            S->>P: recordProviderFailure(...)
            Note over S: fallback to next provider if eligible
        end
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/main/java/com/williamcallahan/javachat/service/OpenAiRequestFactory.java:127-129
**Dead public API after this refactor**

The no-arg `truncatePromptForCompletion(String prompt)` no longer has any production caller — its only call site in `OpenAIStreamingService.complete()` was removed by this PR, and `buildCompletionRequest` now invokes the private `truncatePromptForCompletion(String, String)` directly. Keeping the method conflicts with [AB1d] ("Delete unused code instead of keeping it 'just in case'") and [RC1b] ("No compatibility shims that hide defects"). The same applies to the new two-arg public overload at line 138, which is also reachable only from tests — `buildCompletionRequest` bypasses it and calls the private method itself.

Consider removing both public overloads and testing via `buildCompletionRequest` directly, which exercises the full provider-to-model-id path, or make the provider-arg overload the single public entry point.

### Issue 2 of 2
src/main/java/com/williamcallahan/javachat/service/OpenAiRequestFactory.java:149-152
**`o`-series models receive GPT-5's 7K token limit regardless of context window**

`canonicalModelName(modelId).startsWith("o")` captures `o1`, `o3`, `o3-mini`, etc. and routes them to `MAX_TOKENS_GPT5_INPUT` (7 000 tokens). Many o-series models expose far larger context windows and this mismatch silently truncates prompts that would fit. This was also true before the PR, but the refactor now makes this path the single authoritative one for both providers, so the blast radius is wider. At minimum the assumption should be documented; at best, o-series models should have their own named constant and explicit limit.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Scope completion truncation to active pr..."](https://github.com/williamagh/java-chat/commit/146bfb1102d8432eaabca698a1eb63c69dce2344) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32476694)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=c73518f6-94f2-4eb4-a597-3be5ff49a896))
- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=275e475f-38e9-4168-b8d1-f30416e03dd3))

<!-- /greptile_comment -->