### PR TITLE
fix(llm,web): chat and completion prompts keep the active model's full context, embedding cold starts and deploy windows stop breaking chat, and API/error responses report real status codes

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#1a1a18" />
     <meta name="color-scheme" content="dark light" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Java Chat" />

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@types/dompurify": "^3.0.5",
-        "dompurify": "^3.3.1",
+        "dompurify": "^3.4.0",
         "highlight.js": "^11.10.0",
         "marked": "^15.0.0",
         "zod": "^3.25.76"
@@ -26,10 +26,10 @@
         "oxfmt": "^0.27.0",
         "oxlint": "1.42.0",
         "oxlint-tsgolint": "^0.11.2",
-        "svelte": "^5.0.0",
+        "svelte": "^5.55.7",
         "svelte-check": "^4.0.0",
         "typescript": "^5.6.0",
-        "vite": "^6.0.0",
+        "vite": "^6.4.2",
         "vitest": "^4.0.18"
       },
       "engines": {
@@ -806,9 +806,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "peer": true,
@@ -893,9 +893,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "peer": true,
@@ -1379,9 +1379,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.56.0.tgz",
-      "integrity": "sha512-LNKIPA5k8PF1+jAFomGe3qN3bbIgJe/IlpDBwuVjrDKrJhVWywgnJvflMt/zkbVNLFtF1+94SljYQS6e99klnw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
       "cpu": [
         "arm"
       ],
@@ -1393,9 +1393,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.56.0.tgz",
-      "integrity": "sha512-lfbVUbelYqXlYiU/HApNMJzT1E87UPGvzveGg2h0ktUNlOCxKlWuJ9jtfvs1sKHdwU4fzY7Pl8sAl49/XaEk6Q==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
       "cpu": [
         "arm64"
       ],
@@ -1407,9 +1407,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.56.0.tgz",
-      "integrity": "sha512-EgxD1ocWfhoD6xSOeEEwyE7tDvwTgZc8Bss7wCWe+uc7wO8G34HHCUH+Q6cHqJubxIAnQzAsyUsClt0yFLu06w==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
       "cpu": [
         "arm64"
       ],
@@ -1421,9 +1421,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.56.0.tgz",
-      "integrity": "sha512-1vXe1vcMOssb/hOF8iv52A7feWW2xnu+c8BV4t1F//m9QVLTfNVpEdja5ia762j/UEJe2Z1jAmEqZAK42tVW3g==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
       "cpu": [
         "x64"
       ],
@@ -1435,9 +1435,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.56.0.tgz",
-      "integrity": "sha512-bof7fbIlvqsyv/DtaXSck4VYQ9lPtoWNFCB/JY4snlFuJREXfZnm+Ej6yaCHfQvofJDXLDMTVxWscVSuQvVWUQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
       "cpu": [
         "arm64"
       ],
@@ -1449,9 +1449,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.56.0.tgz",
-      "integrity": "sha512-KNa6lYHloW+7lTEkYGa37fpvPq+NKG/EHKM8+G/g9WDU7ls4sMqbVRV78J6LdNuVaeeK5WB9/9VAFbKxcbXKYg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
       "cpu": [
         "x64"
       ],
@@ -1463,9 +1463,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.56.0.tgz",
-      "integrity": "sha512-E8jKK87uOvLrrLN28jnAAAChNq5LeCd2mGgZF+fGF5D507WlG/Noct3lP/QzQ6MrqJ5BCKNwI9ipADB6jyiq2A==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
       "cpu": [
         "arm"
       ],
@@ -1477,9 +1477,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.56.0.tgz",
-      "integrity": "sha512-jQosa5FMYF5Z6prEpTCCmzCXz6eKr/tCBssSmQGEeozA9tkRUty/5Vx06ibaOP9RCrW1Pvb8yp3gvZhHwTDsJw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
       "cpu": [
         "arm"
       ],
@@ -1491,9 +1491,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.56.0.tgz",
-      "integrity": "sha512-uQVoKkrC1KGEV6udrdVahASIsaF8h7iLG0U0W+Xn14ucFwi6uS539PsAr24IEF9/FoDtzMeeJXJIBo5RkbNWvQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
       "cpu": [
         "arm64"
       ],
@@ -1505,9 +1505,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.56.0.tgz",
-      "integrity": "sha512-vLZ1yJKLxhQLFKTs42RwTwa6zkGln+bnXc8ueFGMYmBTLfNu58sl5/eXyxRa2RarTkJbXl8TKPgfS6V5ijNqEA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
       "cpu": [
         "arm64"
       ],
@@ -1519,9 +1519,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.56.0.tgz",
-      "integrity": "sha512-FWfHOCub564kSE3xJQLLIC/hbKqHSVxy8vY75/YHHzWvbJL7aYJkdgwD/xGfUlL5UV2SB7otapLrcCj2xnF1dg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
       "cpu": [
         "loong64"
       ],
@@ -1533,9 +1533,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.56.0.tgz",
-      "integrity": "sha512-z1EkujxIh7nbrKL1lmIpqFTc/sr0u8Uk0zK/qIEFldbt6EDKWFk/pxFq3gYj4Bjn3aa9eEhYRlL3H8ZbPT1xvA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
       "cpu": [
         "loong64"
       ],
@@ -1547,9 +1547,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.56.0.tgz",
-      "integrity": "sha512-iNFTluqgdoQC7AIE8Q34R3AuPrJGJirj5wMUErxj22deOcY7XwZRaqYmB6ZKFHoVGqRcRd0mqO+845jAibKCkw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
       "cpu": [
         "ppc64"
       ],
@@ -1561,9 +1561,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.56.0.tgz",
-      "integrity": "sha512-MtMeFVlD2LIKjp2sE2xM2slq3Zxf9zwVuw0jemsxvh1QOpHSsSzfNOTH9uYW9i1MXFxUSMmLpeVeUzoNOKBaWg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
       "cpu": [
         "ppc64"
       ],
@@ -1575,9 +1575,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.56.0.tgz",
-      "integrity": "sha512-in+v6wiHdzzVhYKXIk5U74dEZHdKN9KH0Q4ANHOTvyXPG41bajYRsy7a8TPKbYPl34hU7PP7hMVHRvv/5aCSew==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
       "cpu": [
         "riscv64"
       ],
@@ -1589,9 +1589,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.56.0.tgz",
-      "integrity": "sha512-yni2raKHB8m9NQpI9fPVwN754mn6dHQSbDTwxdr9SE0ks38DTjLMMBjrwvB5+mXrX+C0npX0CVeCUcvvvD8CNQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
       "cpu": [
         "riscv64"
       ],
@@ -1603,9 +1603,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.56.0.tgz",
-      "integrity": "sha512-zhLLJx9nQPu7wezbxt2ut+CI4YlXi68ndEve16tPc/iwoylWS9B3FxpLS2PkmfYgDQtosah07Mj9E0khc3Y+vQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
       "cpu": [
         "s390x"
       ],
@@ -1617,9 +1617,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.56.0.tgz",
-      "integrity": "sha512-MVC6UDp16ZSH7x4rtuJPAEoE1RwS8N4oK9DLHy3FTEdFoUTCFVzMfJl/BVJ330C+hx8FfprA5Wqx4FhZXkj2Kw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
       "cpu": [
         "x64"
       ],
@@ -1631,9 +1631,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.56.0.tgz",
-      "integrity": "sha512-ZhGH1eA4Qv0lxaV00azCIS1ChedK0V32952Md3FtnxSqZTBTd6tgil4nZT5cU8B+SIw3PFYkvyR4FKo2oyZIHA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
       "cpu": [
         "x64"
       ],
@@ -1645,9 +1645,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.56.0.tgz",
-      "integrity": "sha512-O16XcmyDeFI9879pEcmtWvD/2nyxR9mF7Gs44lf1vGGx8Vg2DRNx11aVXBEqOQhWb92WN4z7fW/q4+2NYzCbBA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
       "cpu": [
         "x64"
       ],
@@ -1659,9 +1659,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.56.0.tgz",
-      "integrity": "sha512-LhN/Reh+7F3RCgQIRbgw8ZMwUwyqJM+8pXNT6IIJAqm2IdKkzpCh/V9EdgOMBKuebIrzswqy4ATlrDgiOwbRcQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
       "cpu": [
         "arm64"
       ],
@@ -1673,9 +1673,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.56.0.tgz",
-      "integrity": "sha512-kbFsOObXp3LBULg1d3JIUQMa9Kv4UitDmpS+k0tinPBz3watcUiV2/LUDMMucA6pZO3WGE27P7DsfaN54l9ing==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
       "cpu": [
         "arm64"
       ],
@@ -1687,9 +1687,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.56.0.tgz",
-      "integrity": "sha512-vSSgny54D6P4vf2izbtFm/TcWYedw7f8eBrOiGGecyHyQB9q4Kqentjaj8hToe+995nob/Wv48pDqL5a62EWtg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
       "cpu": [
         "ia32"
       ],
@@ -1701,9 +1701,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.56.0.tgz",
-      "integrity": "sha512-FeCnkPCTHQJFbiGG49KjV5YGW/8b9rrXAM2Mz2kiIoktq2qsJxRD5giEMEOD2lPdgs72upzefaUvS+nc8E3UzQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
       "cpu": [
         "x64"
       ],
@@ -1715,9 +1715,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.56.0.tgz",
-      "integrity": "sha512-H8AE9Ur/t0+1VXujj90w0HrSOuv0Nq9r1vSZF2t5km20NTfosQsGGUXDaKdQZzwuLts7IyL1fYT4hM95TI9c4g==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
       "cpu": [
         "x64"
       ],
@@ -2566,9 +2566,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.2.tgz",
-      "integrity": "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2580,9 +2580,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
-      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -2992,9 +2992,9 @@
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "peer": true,
@@ -3059,13 +3059,21 @@
       }
     },
     "node_modules/esrap": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.2.tgz",
-      "integrity": "sha512-zA6497ha+qKvoWIK+WM9NAh5ni17sKZKhbS5B3PoYbBvaYHZWoS33zmFybmyqpn07RLUxSmn+RCls2/XF+d0oQ==",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.9.tgz",
+      "integrity": "sha512-4KijP+NxCWthMCUC3qHbE6n4vCjqgJS1uAYKhuT/GWfFTf1Qyive2TgOjep+gzbSzRfnNyaN/UU9YmdOt8Eg0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
       }
     },
     "node_modules/esrecurse": {
@@ -3257,9 +3265,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC",
       "peer": true
@@ -3963,9 +3971,9 @@
       }
     },
     "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4012,13 +4020,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -4324,9 +4332,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4511,9 +4519,9 @@
       "license": "MIT"
     },
     "node_modules/rollup": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.56.0.tgz",
-      "integrity": "sha512-9FwVqlgUHzbXtDg9RCMgodF3Ua4Na6Gau+Sdt9vyCN4RhHfVKX2DCHy3BjMLTDd47ITDhYAnTwGulWTblJSDLg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4527,31 +4535,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.56.0",
-        "@rollup/rollup-android-arm64": "4.56.0",
-        "@rollup/rollup-darwin-arm64": "4.56.0",
-        "@rollup/rollup-darwin-x64": "4.56.0",
-        "@rollup/rollup-freebsd-arm64": "4.56.0",
-        "@rollup/rollup-freebsd-x64": "4.56.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.56.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.56.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.56.0",
-        "@rollup/rollup-linux-arm64-musl": "4.56.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.56.0",
-        "@rollup/rollup-linux-loong64-musl": "4.56.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.56.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.56.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.56.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.56.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.56.0",
-        "@rollup/rollup-linux-x64-gnu": "4.56.0",
-        "@rollup/rollup-linux-x64-musl": "4.56.0",
-        "@rollup/rollup-openbsd-x64": "4.56.0",
-        "@rollup/rollup-openharmony-arm64": "4.56.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.56.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.56.0",
-        "@rollup/rollup-win32-x64-gnu": "4.56.0",
-        "@rollup/rollup-win32-x64-msvc": "4.56.0",
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
         "fsevents": "~2.3.2"
       }
     },
@@ -4802,9 +4810,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.48.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.48.0.tgz",
-      "integrity": "sha512-+NUe82VoFP1RQViZI/esojx70eazGF4u0O/9ucqZ4rPcOZD+n5EVp17uYsqwdzjUjZyTpGKunHbDziW6AIAVkQ==",
+      "version": "5.55.7",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.7.tgz",
+      "integrity": "sha512-ymI5ykLPwIHW839E053FQbI1G+jnRFJEw3Kv5Y4njixVWywQBx+NUFpkkKyk5LIb36Fg9DVXSYpqiGekLD0hyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4812,13 +4820,14 @@
         "@jridgewell/sourcemap-codec": "^1.5.0",
         "@sveltejs/acorn-typescript": "^1.0.5",
         "@types/estree": "^1.0.5",
+        "@types/trusted-types": "^2.0.7",
         "acorn": "^8.12.1",
-        "aria-query": "^5.3.1",
+        "aria-query": "5.3.1",
         "axobject-query": "^4.1.0",
         "clsx": "^2.1.1",
-        "devalue": "^5.6.2",
+        "devalue": "^5.8.1",
         "esm-env": "^1.2.1",
-        "esrap": "^2.2.1",
+        "esrap": "^2.2.4",
         "is-reference": "^3.0.3",
         "locate-character": "^3.0.0",
         "magic-string": "^0.30.11",
@@ -4850,6 +4859,16 @@
       "peerDependencies": {
         "svelte": "^4.0.0 || ^5.0.0-next.0",
         "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/svelte/node_modules/aria-query": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+      "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/symbol-tree": {
@@ -5025,9 +5044,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@types/dompurify": "^3.0.5",
-    "dompurify": "^3.3.1",
+    "dompurify": "^3.4.0",
     "highlight.js": "^11.10.0",
     "marked": "^15.0.0",
     "zod": "^3.25.76"
@@ -39,10 +39,10 @@
     "oxfmt": "^0.27.0",
     "oxlint": "1.42.0",
     "oxlint-tsgolint": "^0.11.2",
-    "svelte": "^5.0.0",
+    "svelte": "^5.55.7",
     "svelte-check": "^4.0.0",
     "typescript": "^5.6.0",
-    "vite": "^6.0.0",
+    "vite": "^6.4.2",
     "vitest": "^4.0.18"
   },
   "overrides": {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2,6 +2,20 @@ import { mount } from "svelte";
 import App from "./App.svelte";
 import "./styles/global.css";
 
+const RELOAD_GUARD_STORAGE_KEY = "vite-preload-error-reloaded";
+
+// During a rolling deploy the old container can 404 lazily-loaded chunks that
+// the new build's index.html references (Vite docs: vite:preloadError). One
+// guarded reload fetches the fresh index.html instead of leaving a dead page;
+// the sessionStorage guard prevents a reload loop when the failure persists.
+window.addEventListener("vite:preloadError", (preloadErrorEvent) => {
+  if (sessionStorage.getItem(RELOAD_GUARD_STORAGE_KEY) === null) {
+    preloadErrorEvent.preventDefault();
+    sessionStorage.setItem(RELOAD_GUARD_STORAGE_KEY, "true");
+    window.location.reload();
+  }
+});
+
 const app = mount(App, {
   target: document.getElementById("app")!,
 });

--- a/src/main/java/com/williamcallahan/javachat/config/WebMvcConfig.java
+++ b/src/main/java/com/williamcallahan/javachat/config/WebMvcConfig.java
@@ -68,10 +68,15 @@ public class WebMvcConfig implements WebMvcConfigurer {
         // SPA fallback: forward non-file routes to index.html
         // This allows client-side routing to work with direct URL access
         // Pattern [^\\.]*  matches path segments without dots (excludes static assets)
+        // The (?!api$) guard keeps the /api namespace out of the SPA fallback so an
+        // unknown API path reaches CustomErrorController's JSON branch as a real 404
+        // instead of answering 200 with the index.html shell.
         // Explicitly define depth levels as PathPatternParser forbids /**/{regex}
         registry.addViewController("/").setViewName("forward:/index.html");
-        registry.addViewController("/{path:[^\\.]*}").setViewName("forward:/index.html");
-        registry.addViewController("/*/{path:[^\\.]*}").setViewName("forward:/index.html");
-        registry.addViewController("/*/*/{path:[^\\.]*}").setViewName("forward:/index.html");
+        registry.addViewController("/{spaRoot:(?!api$)[^\\.]*}").setViewName("forward:/index.html");
+        registry.addViewController("/{spaRoot:(?!api$)[^\\.]*}/{spaPath:[^\\.]*}")
+                .setViewName("forward:/index.html");
+        registry.addViewController("/{spaRoot:(?!api$)[^\\.]*}/*/{spaPath:[^\\.]*}")
+                .setViewName("forward:/index.html");
     }
 }

--- a/src/main/java/com/williamcallahan/javachat/service/EmbeddingModelKeepAlive.java
+++ b/src/main/java/com/williamcallahan/javachat/service/EmbeddingModelKeepAlive.java
@@ -1,0 +1,71 @@
+package com.williamcallahan.javachat.service;
+
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Keeps the configured embedding model resident by probing the provider on a fixed cadence.
+ *
+ * <p>OpenAI-compatible embedding providers scale to zero when idle: serverless cloud hosts
+ * (Novita) spin the model down between bursts, and self-hosted servers (LM Studio, Ollama)
+ * unload after an idle TTL. The first request after either pays the full model spin-up on
+ * the user's critical path — observed in production at 53.5s on a live chat turn and
+ * reproduced at 23.7s cold versus 1.0s warm against the same provider. A probe cadence
+ * below common scale-down windows keeps the model resident so user requests never pay the
+ * cold start. Probe failures are logged as a cold-start risk and never affect request
+ * handling.</p>
+ */
+@Component
+public class EmbeddingModelKeepAlive {
+    private static final Logger log = LoggerFactory.getLogger(EmbeddingModelKeepAlive.class);
+
+    /** Probe cadence below the 5-minute idle-unload default of common model servers. */
+    private static final long KEEP_ALIVE_INTERVAL_MILLIS = 240_000L;
+
+    /** Delay before the first probe so the provider warms up right after startup. */
+    private static final long STARTUP_WARMUP_DELAY_MILLIS = 5_000L;
+
+    /** Probe latency above this means the model was cold and a reload just happened. */
+    private static final long COLD_MODEL_WARN_THRESHOLD_MILLIS = 5_000L;
+
+    private static final List<String> KEEP_ALIVE_PROBE_TEXTS = List.of("embedding keep-alive probe");
+
+    private final EmbeddingClient embeddingClient;
+
+    /**
+     * Creates the keep-alive prober for the active embedding provider.
+     */
+    public EmbeddingModelKeepAlive(EmbeddingClient embeddingClient) {
+        this.embeddingClient = embeddingClient;
+    }
+
+    /**
+     * Probes the embedding provider so the model stays loaded between user requests.
+     *
+     * <p>A failed probe is a monitoring signal, not a request failure: it is logged at WARN
+     * and the next tick retries. Unexpected runtime failures propagate to the scheduler's
+     * error handler rather than being swallowed here.</p>
+     */
+    @Scheduled(initialDelay = STARTUP_WARMUP_DELAY_MILLIS, fixedDelay = KEEP_ALIVE_INTERVAL_MILLIS)
+    public void keepEmbeddingModelWarm() {
+        long probeStartMillis = System.currentTimeMillis();
+        try {
+            embeddingClient.embed(KEEP_ALIVE_PROBE_TEXTS);
+        } catch (EmbeddingServiceUnavailableException exception) {
+            log.warn(
+                    "[EMBEDDING] Keep-alive probe failed; the next chat request may pay a model cold start", exception);
+            return;
+        }
+        long probeDurationMillis = System.currentTimeMillis() - probeStartMillis;
+        if (probeDurationMillis > COLD_MODEL_WARN_THRESHOLD_MILLIS) {
+            log.warn(
+                    "[EMBEDDING] Keep-alive probe took {}ms — embedding model was cold and has been reloaded",
+                    probeDurationMillis);
+        } else {
+            log.debug("[EMBEDDING] Keep-alive probe completed in {}ms", probeDurationMillis);
+        }
+    }
+}

--- a/src/main/java/com/williamcallahan/javachat/service/OpenAIStreamingService.java
+++ b/src/main/java/com/williamcallahan/javachat/service/OpenAIStreamingService.java
@@ -168,7 +168,6 @@ public class OpenAIStreamingService {
      * @return completion text from the first successful provider attempt
      */
     public Mono<String> complete(String prompt, double temperature) {
-        String truncatedPrompt = requestFactory.truncatePromptForCompletion(prompt);
         return Mono.<String>defer(() -> {
                     List<OpenAiProviderCandidate> availableProviders =
                             providerRoutingService.selectAvailableProviderCandidates(clientPrimary, clientSecondary);
@@ -185,7 +184,7 @@ public class OpenAIStreamingService {
                         RateLimitService.ApiProvider activeProvider = providerCandidate.provider();
 
                         ResponseCreateParams requestParameters =
-                                requestFactory.buildCompletionRequest(truncatedPrompt, temperature, activeProvider);
+                                requestFactory.buildCompletionRequest(prompt, temperature, activeProvider);
                         try {
                             log.info("[LLM] Complete started (providerId={})", activeProvider.ordinal());
                             RequestOptions requestOptions = RequestOptions.builder()

--- a/src/main/java/com/williamcallahan/javachat/service/OpenAiRequestFactory.java
+++ b/src/main/java/com/williamcallahan/javachat/service/OpenAiRequestFactory.java
@@ -32,8 +32,13 @@ public class OpenAiRequestFactory {
     private static final String DEFAULT_OPENAI_MODEL = "gpt-5.2";
     private static final String DEFAULT_GITHUB_MODELS_MODEL = "openai/gpt-5";
 
-    /** Safe token budget for GPT-5.2 input (8K limit). */
-    private static final int MAX_TOKENS_GPT5_INPUT = 7000;
+    /**
+     * Safe token budget under GitHub Models' 8K input tier for its GPT-5 catalog entry.
+     * The constraint belongs to that provider tier, not the GPT-5 family: the same family
+     * served by OpenAI direct or the LLM gateway accepts far larger inputs and uses
+     * {@link #MAX_TOKENS_DEFAULT_INPUT}.
+     */
+    private static final int MAX_TOKENS_GITHUB_MODELS_GPT5_INPUT = 7000;
 
     /** Generous token budget for high-context models. */
     private static final int MAX_TOKENS_DEFAULT_INPUT = 100_000;
@@ -84,11 +89,11 @@ public class OpenAiRequestFactory {
             StructuredPrompt structuredPrompt, double temperature, RateLimitService.ApiProvider provider) {
         boolean useGitHubModels = provider == RateLimitService.ApiProvider.GITHUB_MODELS;
         String modelId = normalizedModelId(useGitHubModels);
-        boolean gpt5Family = isGpt5Family(modelId);
-        int tokenLimit = gpt5Family ? MAX_TOKENS_GPT5_INPUT : MAX_TOKENS_DEFAULT_INPUT;
+        boolean githubModelsGpt5Constrained = useGitHubModels && isGpt5Family(modelId);
+        int tokenLimit = githubModelsGpt5Constrained ? MAX_TOKENS_GITHUB_MODELS_GPT5_INPUT : MAX_TOKENS_DEFAULT_INPUT;
 
         PromptTruncator.TruncatedPrompt truncatedPrompt =
-                promptTruncator.truncate(structuredPrompt, tokenLimit, gpt5Family);
+                promptTruncator.truncate(structuredPrompt, tokenLimit, githubModelsGpt5Constrained);
         if (truncatedPrompt.wasTruncated()) {
             log.info(
                     "[LLM] Prompt truncated for streaming (providerId={}, model={}, contextDocs={}, conversationTurns={})",
@@ -114,25 +119,25 @@ public class OpenAiRequestFactory {
             String prompt, double temperature, RateLimitService.ApiProvider provider) {
         boolean useGitHubModels = provider == RateLimitService.ApiProvider.GITHUB_MODELS;
         String modelId = normalizedModelId(useGitHubModels);
-        String truncatedPrompt = truncatePromptForCompletion(prompt, modelId);
+        String truncatedPrompt = truncatePromptForCompletion(prompt, modelId, useGitHubModels);
         return buildResponseParams(truncatedPrompt, temperature, modelId);
     }
 
-    private String truncatePromptForCompletion(String prompt, String modelId) {
+    private String truncatePromptForCompletion(String prompt, String modelId, boolean useGitHubModels) {
         if (prompt == null || prompt.isEmpty()) {
             return prompt;
         }
 
-        boolean gpt5Family = isGpt5Family(modelId);
-
-        // The 7K cap accommodates GPT-5's 8K input tier on GitHub Models. o-series
-        // reasoning models accept >=128K input tokens, so they take the default cap;
-        // the GPT-5 limit must not leak to them (PR #49 review finding).
-        int tokenLimit = gpt5Family ? MAX_TOKENS_GPT5_INPUT : MAX_TOKENS_DEFAULT_INPUT;
+        // The 7K cap accommodates GitHub Models' 8K input tier for its GPT-5 entry.
+        // GPT-5 family on OpenAI direct/the gateway and o-series reasoning models
+        // accept >=128K input tokens, so both take the default cap (PR #49 review
+        // finding; gateway gpt-5.4 over-truncation).
+        boolean githubModelsGpt5Constrained = useGitHubModels && isGpt5Family(modelId);
+        int tokenLimit = githubModelsGpt5Constrained ? MAX_TOKENS_GITHUB_MODELS_GPT5_INPUT : MAX_TOKENS_DEFAULT_INPUT;
         String truncatedPrompt = chunker.keepLastTokens(prompt, tokenLimit);
 
         if (truncatedPrompt.length() < prompt.length()) {
-            String truncationNotice = gpt5Family ? TRUNCATION_NOTICE_GPT5 : TRUNCATION_NOTICE_GENERIC;
+            String truncationNotice = githubModelsGpt5Constrained ? TRUNCATION_NOTICE_GPT5 : TRUNCATION_NOTICE_GENERIC;
             return truncationNotice + truncatedPrompt;
         }
 

--- a/src/main/java/com/williamcallahan/javachat/service/OpenAiRequestFactory.java
+++ b/src/main/java/com/williamcallahan/javachat/service/OpenAiRequestFactory.java
@@ -118,29 +118,6 @@ public class OpenAiRequestFactory {
         return buildResponseParams(truncatedPrompt, temperature, modelId);
     }
 
-    /**
-     * Truncates completion prompts to conservative model-safe token limits.
-     *
-     * @param prompt full completion prompt
-     * @return original prompt when no truncation is required, otherwise a notice-prefixed prompt
-     */
-    public String truncatePromptForCompletion(String prompt) {
-        return truncatePromptForCompletion(prompt, RateLimitService.ApiProvider.OPENAI);
-    }
-
-    /**
-     * Truncates completion prompts to token limits for the selected provider's model.
-     *
-     * @param prompt full completion prompt
-     * @param provider provider chosen for this request attempt
-     * @return original prompt when no truncation is required, otherwise a notice-prefixed prompt
-     */
-    public String truncatePromptForCompletion(String prompt, RateLimitService.ApiProvider provider) {
-        boolean useGitHubModels = provider == RateLimitService.ApiProvider.GITHUB_MODELS;
-        String modelId = normalizedModelId(useGitHubModels);
-        return truncatePromptForCompletion(prompt, modelId);
-    }
-
     private String truncatePromptForCompletion(String prompt, String modelId) {
         if (prompt == null || prompt.isEmpty()) {
             return prompt;

--- a/src/main/java/com/williamcallahan/javachat/service/OpenAiRequestFactory.java
+++ b/src/main/java/com/williamcallahan/javachat/service/OpenAiRequestFactory.java
@@ -114,7 +114,8 @@ public class OpenAiRequestFactory {
             String prompt, double temperature, RateLimitService.ApiProvider provider) {
         boolean useGitHubModels = provider == RateLimitService.ApiProvider.GITHUB_MODELS;
         String modelId = normalizedModelId(useGitHubModels);
-        return buildResponseParams(prompt, temperature, modelId);
+        String truncatedPrompt = truncatePromptForCompletion(prompt, modelId);
+        return buildResponseParams(truncatedPrompt, temperature, modelId);
     }
 
     /**
@@ -124,16 +125,29 @@ public class OpenAiRequestFactory {
      * @return original prompt when no truncation is required, otherwise a notice-prefixed prompt
      */
     public String truncatePromptForCompletion(String prompt) {
+        return truncatePromptForCompletion(prompt, RateLimitService.ApiProvider.OPENAI);
+    }
+
+    /**
+     * Truncates completion prompts to token limits for the selected provider's model.
+     *
+     * @param prompt full completion prompt
+     * @param provider provider chosen for this request attempt
+     * @return original prompt when no truncation is required, otherwise a notice-prefixed prompt
+     */
+    public String truncatePromptForCompletion(String prompt, RateLimitService.ApiProvider provider) {
+        boolean useGitHubModels = provider == RateLimitService.ApiProvider.GITHUB_MODELS;
+        String modelId = normalizedModelId(useGitHubModels);
+        return truncatePromptForCompletion(prompt, modelId);
+    }
+
+    private String truncatePromptForCompletion(String prompt, String modelId) {
         if (prompt == null || prompt.isEmpty()) {
             return prompt;
         }
 
-        String openaiModelId = normalizedModelId(false);
-        String githubModelId = normalizedModelId(true);
-        boolean gpt5Family = isGpt5Family(openaiModelId) || isGpt5Family(githubModelId);
-        boolean reasoningModel = gpt5Family
-                || canonicalModelName(openaiModelId).startsWith("o")
-                || canonicalModelName(githubModelId).startsWith("o");
+        boolean gpt5Family = isGpt5Family(modelId);
+        boolean reasoningModel = gpt5Family || canonicalModelName(modelId).startsWith("o");
 
         int tokenLimit = reasoningModel ? MAX_TOKENS_GPT5_INPUT : MAX_TOKENS_DEFAULT_INPUT;
         String truncatedPrompt = chunker.keepLastTokens(prompt, tokenLimit);

--- a/src/main/java/com/williamcallahan/javachat/service/OpenAiRequestFactory.java
+++ b/src/main/java/com/williamcallahan/javachat/service/OpenAiRequestFactory.java
@@ -124,9 +124,11 @@ public class OpenAiRequestFactory {
         }
 
         boolean gpt5Family = isGpt5Family(modelId);
-        boolean reasoningModel = gpt5Family || canonicalModelName(modelId).startsWith("o");
 
-        int tokenLimit = reasoningModel ? MAX_TOKENS_GPT5_INPUT : MAX_TOKENS_DEFAULT_INPUT;
+        // The 7K cap accommodates GPT-5's 8K input tier on GitHub Models. o-series
+        // reasoning models accept >=128K input tokens, so they take the default cap;
+        // the GPT-5 limit must not leak to them (PR #49 review finding).
+        int tokenLimit = gpt5Family ? MAX_TOKENS_GPT5_INPUT : MAX_TOKENS_DEFAULT_INPUT;
         String truncatedPrompt = chunker.keepLastTokens(prompt, tokenLimit);
 
         if (truncatedPrompt.length() < prompt.length()) {

--- a/src/main/java/com/williamcallahan/javachat/web/CustomErrorController.java
+++ b/src/main/java/com/williamcallahan/javachat/web/CustomErrorController.java
@@ -133,6 +133,10 @@ public class CustomErrorController implements ErrorController {
             resolvedStatus = HttpStatus.INTERNAL_SERVER_ERROR;
         }
         modelAndView.setViewName(resolveErrorViewName(resolvedStatus));
+        // Carry the real status onto the forwarded error view: without this the
+        // forward renders with 200, so a missing hashed asset returns 200 text/html
+        // and browsers raise a strict-MIME module error instead of a clean 404.
+        modelAndView.setStatus(resolvedStatus);
 
         return modelAndView;
     }

--- a/src/main/java/com/williamcallahan/javachat/web/CustomErrorController.java
+++ b/src/main/java/com/williamcallahan/javachat/web/CustomErrorController.java
@@ -88,7 +88,7 @@ public class CustomErrorController implements ErrorController {
         }
 
         // Determine if this is an API request or a page request
-        boolean isApiRequest = uri.startsWith("/api/");
+        boolean isApiRequest = uri.equals("/api") || uri.startsWith("/api/");
 
         if (isApiRequest) {
             // Return JSON error response for API requests

--- a/src/main/java/com/williamcallahan/javachat/web/ErrorDocumentationController.java
+++ b/src/main/java/com/williamcallahan/javachat/web/ErrorDocumentationController.java
@@ -1,9 +1,14 @@
 package com.williamcallahan.javachat.web;
 
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,10 +22,18 @@ import org.springframework.web.bind.annotation.RestController;
  * <p>Maps extension-less URLs (e.g., {@code /errors/not-found}) to static HTML files
  * (e.g., {@code /static/errors/not-found.html}) so that ProblemDetail type URIs
  * resolve to human-readable documentation.
+ *
+ * <p>These pages serve two roles: browsed directly they are documentation (200), but
+ * {@link CustomErrorController} also forwards error dispatches here to render the same
+ * HTML as the error response body. In that case the original error status MUST be
+ * preserved — answering 200 for a missing resource makes browsers treat a failed
+ * module-script fetch as success and fail with a strict-MIME error instead of a 404.</p>
  */
 @RestController
 @RequestMapping("/errors")
 public class ErrorDocumentationController {
+
+    private static final Logger log = LoggerFactory.getLogger(ErrorDocumentationController.class);
 
     private static final String ERRORS_PATH = "static/errors/";
     private static final String ERROR_SLUG_PATTERN = "^[a-z0-9-]+$";
@@ -37,8 +50,8 @@ public class ErrorDocumentationController {
     @GetMapping(
             value = {ROOT_PATH, ROOT_SLASH},
             produces = MediaType.TEXT_HTML_VALUE)
-    public ResponseEntity<String> index() {
-        return serveHtmlFile(INDEX_FILE);
+    public ResponseEntity<String> index(HttpServletRequest request) {
+        return serveHtmlFile(INDEX_FILE, request);
     }
 
     /**
@@ -48,23 +61,44 @@ public class ErrorDocumentationController {
      * @return HTML for the requested error type
      */
     @GetMapping(value = "/{errorType}", produces = MediaType.TEXT_HTML_VALUE)
-    public ResponseEntity<String> errorType(@PathVariable String errorType) {
+    public ResponseEntity<String> errorType(@PathVariable String errorType, HttpServletRequest request) {
         if (!errorType.matches(ERROR_SLUG_PATTERN)) {
             return ResponseEntity.notFound().build();
         }
-        return serveHtmlFile(errorType + HTML_EXTENSION);
+        return serveHtmlFile(errorType + HTML_EXTENSION, request);
     }
 
-    private ResponseEntity<String> serveHtmlFile(String filename) {
+    private ResponseEntity<String> serveHtmlFile(String filename, HttpServletRequest request) {
         ClassPathResource resource = new ClassPathResource(ERRORS_PATH + filename);
         if (!resource.exists()) {
             return ResponseEntity.notFound().build();
         }
         try (InputStream inputStream = resource.getInputStream()) {
             String content = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
-            return ResponseEntity.ok().contentType(MediaType.TEXT_HTML).body(content);
+            return ResponseEntity.status(resolveResponseStatus(request))
+                    .contentType(MediaType.TEXT_HTML)
+                    .body(content);
         } catch (IOException exception) {
+            log.error("Failed to read error documentation page {}", filename, exception);
             return ResponseEntity.internalServerError().build();
         }
+    }
+
+    /**
+     * Preserves the original error status when rendering as an error-dispatch body.
+     *
+     * <p>The {@code ERROR_STATUS_CODE} attribute survives {@link CustomErrorController}'s
+     * forward because it is set on the same request; it is absent when a reader browses
+     * the documentation directly, which keeps direct visits at 200.</p>
+     */
+    private HttpStatus resolveResponseStatus(HttpServletRequest request) {
+        Object errorStatusCode = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
+        if (errorStatusCode instanceof Integer statusCodeValue) {
+            HttpStatus resolvedStatus = HttpStatus.resolve(statusCodeValue);
+            if (resolvedStatus != null) {
+                return resolvedStatus;
+            }
+        }
+        return HttpStatus.OK;
     }
 }

--- a/src/test/java/com/williamcallahan/javachat/service/EmbeddingModelKeepAliveTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/EmbeddingModelKeepAliveTest.java
@@ -1,0 +1,57 @@
+package com.williamcallahan.javachat.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the keep-alive probe contacts the embedding provider and treats provider
+ * unavailability as a logged monitoring signal rather than a propagated failure.
+ */
+class EmbeddingModelKeepAliveTest {
+
+    @Test
+    void keepEmbeddingModelWarmProbesTheEmbeddingProvider() {
+        RecordingEmbeddingClient recordingEmbeddingClient = new RecordingEmbeddingClient();
+
+        new EmbeddingModelKeepAlive(recordingEmbeddingClient).keepEmbeddingModelWarm();
+
+        assertEquals(1, recordingEmbeddingClient.embedInvocationCount);
+    }
+
+    @Test
+    void keepEmbeddingModelWarmDoesNotPropagateProviderUnavailability() {
+        EmbeddingModelKeepAlive keepAlive = new EmbeddingModelKeepAlive(new UnavailableEmbeddingClient());
+
+        assertDoesNotThrow(keepAlive::keepEmbeddingModelWarm);
+    }
+
+    private static final class RecordingEmbeddingClient implements EmbeddingClient {
+        private int embedInvocationCount;
+
+        @Override
+        public List<float[]> embed(List<String> texts) {
+            embedInvocationCount++;
+            return List.of(new float[] {0.0f});
+        }
+
+        @Override
+        public int dimensions() {
+            return 1;
+        }
+    }
+
+    private static final class UnavailableEmbeddingClient implements EmbeddingClient {
+        @Override
+        public List<float[]> embed(List<String> texts) {
+            throw new EmbeddingServiceUnavailableException("provider offline for test");
+        }
+
+        @Override
+        public int dimensions() {
+            return 1;
+        }
+    }
+}

--- a/src/test/java/com/williamcallahan/javachat/service/OpenAiRequestFactoryTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/OpenAiRequestFactoryTest.java
@@ -50,26 +50,27 @@ class OpenAiRequestFactoryTest {
     }
 
     @Test
-    void truncatePromptForCompletionUsesSelectedOpenAiModelLimit() {
+    void buildCompletionRequestKeepsPromptWithinSelectedOpenAiModelLimit() {
         OpenAiRequestFactory requestFactory =
                 new OpenAiRequestFactory(new Chunker(), new PromptTruncator(), "gpt-4o", "openai/gpt-5", "");
         String prompt = "context ".repeat(8_000);
 
-        String truncatedPrompt =
-                requestFactory.truncatePromptForCompletion(prompt, RateLimitService.ApiProvider.OPENAI);
+        ResponseCreateParams responseCreateParams =
+                requestFactory.buildCompletionRequest(prompt, 0.4, RateLimitService.ApiProvider.OPENAI);
 
-        assertEquals(prompt, truncatedPrompt);
+        assertEquals(prompt, responseCreateParams.input().orElseThrow().asText());
     }
 
     @Test
-    void truncatePromptForCompletionUsesSelectedGitHubModelsLimit() {
+    void buildCompletionRequestTruncatesPromptForSelectedGitHubModelsLimit() {
         OpenAiRequestFactory requestFactory =
                 new OpenAiRequestFactory(new Chunker(), new PromptTruncator(), "gpt-4o", "gpt-5", "");
         String prompt = "context ".repeat(8_000);
 
-        String truncatedPrompt =
-                requestFactory.truncatePromptForCompletion(prompt, RateLimitService.ApiProvider.GITHUB_MODELS);
+        ResponseCreateParams responseCreateParams =
+                requestFactory.buildCompletionRequest(prompt, 0.4, RateLimitService.ApiProvider.GITHUB_MODELS);
 
+        String truncatedPrompt = responseCreateParams.input().orElseThrow().asText();
         assertTrue(truncatedPrompt.startsWith("[Context truncated due to GPT-5 8K input limit]"));
         assertTrue(truncatedPrompt.length() < prompt.length());
     }

--- a/src/test/java/com/williamcallahan/javachat/service/OpenAiRequestFactoryTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/OpenAiRequestFactoryTest.java
@@ -48,4 +48,29 @@ class OpenAiRequestFactoryTest {
         assertTrue(responseCreateParams.maxOutputTokens().isEmpty());
         assertEquals(0.25, responseCreateParams.temperature().orElseThrow(), 0.000_001);
     }
+
+    @Test
+    void truncatePromptForCompletionUsesSelectedOpenAiModelLimit() {
+        OpenAiRequestFactory requestFactory =
+                new OpenAiRequestFactory(new Chunker(), new PromptTruncator(), "gpt-4o", "openai/gpt-5", "");
+        String prompt = "context ".repeat(8_000);
+
+        String truncatedPrompt =
+                requestFactory.truncatePromptForCompletion(prompt, RateLimitService.ApiProvider.OPENAI);
+
+        assertEquals(prompt, truncatedPrompt);
+    }
+
+    @Test
+    void truncatePromptForCompletionUsesSelectedGitHubModelsLimit() {
+        OpenAiRequestFactory requestFactory =
+                new OpenAiRequestFactory(new Chunker(), new PromptTruncator(), "gpt-4o", "gpt-5", "");
+        String prompt = "context ".repeat(8_000);
+
+        String truncatedPrompt =
+                requestFactory.truncatePromptForCompletion(prompt, RateLimitService.ApiProvider.GITHUB_MODELS);
+
+        assertTrue(truncatedPrompt.startsWith("[Context truncated due to GPT-5 8K input limit]"));
+        assertTrue(truncatedPrompt.length() < prompt.length());
+    }
 }

--- a/src/test/java/com/williamcallahan/javachat/service/OpenAiRequestFactoryTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/OpenAiRequestFactoryTest.java
@@ -62,6 +62,18 @@ class OpenAiRequestFactoryTest {
     }
 
     @Test
+    void buildCompletionRequestDoesNotApplyGpt5LimitToOSeriesModels() {
+        OpenAiRequestFactory requestFactory =
+                new OpenAiRequestFactory(new Chunker(), new PromptTruncator(), "o3-mini", "openai/gpt-5", "");
+        String prompt = "context ".repeat(8_000);
+
+        ResponseCreateParams responseCreateParams =
+                requestFactory.buildCompletionRequest(prompt, 0.4, RateLimitService.ApiProvider.OPENAI);
+
+        assertEquals(prompt, responseCreateParams.input().orElseThrow().asText());
+    }
+
+    @Test
     void buildCompletionRequestTruncatesPromptForSelectedGitHubModelsLimit() {
         OpenAiRequestFactory requestFactory =
                 new OpenAiRequestFactory(new Chunker(), new PromptTruncator(), "gpt-4o", "gpt-5", "");

--- a/src/test/java/com/williamcallahan/javachat/service/OpenAiRequestFactoryTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/OpenAiRequestFactoryTest.java
@@ -62,6 +62,18 @@ class OpenAiRequestFactoryTest {
     }
 
     @Test
+    void buildCompletionRequestDoesNotApplyGitHubModelsCapToOpenAiGpt5Family() {
+        OpenAiRequestFactory requestFactory =
+                new OpenAiRequestFactory(new Chunker(), new PromptTruncator(), "gpt-5.4", "openai/gpt-5", "");
+        String prompt = "context ".repeat(8_000);
+
+        ResponseCreateParams responseCreateParams =
+                requestFactory.buildCompletionRequest(prompt, 0.4, RateLimitService.ApiProvider.OPENAI);
+
+        assertEquals(prompt, responseCreateParams.input().orElseThrow().asText());
+    }
+
+    @Test
     void buildCompletionRequestDoesNotApplyGpt5LimitToOSeriesModels() {
         OpenAiRequestFactory requestFactory =
                 new OpenAiRequestFactory(new Chunker(), new PromptTruncator(), "o3-mini", "openai/gpt-5", "");


### PR DESCRIPTION
## Summary
Latency and correctness fixes across the LLM path and web layer: prompts now truncate to the limits of the model actually serving each request (previously every GPT-5-family chat — including gateway `gpt-5.4` with 400K context — was silently cut to 7K tokens), live chat turns no longer pay 20–60s serverless embedding cold starts, error and API responses report real status codes, the SPA survives rolling deploys with a guarded auto-reload, and the frontend picks up the grouped Dependabot security bumps.

## Changes

### Bug Fixes
- **GPT-5-family chats through OpenAI direct/the LLM gateway keep their full context**: the 7K input cap modeled GitHub Models' 8K tier but was applied family-wide on both the streaming and completion paths, truncating every `gpt-5.4` chat turn to 7K tokens; the cap now applies only when GitHub Models serves a GPT-5 model, and the truncation notice no longer claims an 8K limit for a 100K truncation (`OpenAiRequestFactory.prepareStreamingRequest/buildCompletionRequest`)
- **Completion prompts no longer truncate to the unused provider's limit**: truncation moved inside `buildCompletionRequest`, keyed to the active provider's model; fallback re-truncates with the fallback model's own limit (`OpenAIStreamingService.complete`; fixes #40, contributed in #49 by @pntech20)
- **o-series models keep their full input window**: `o1`/`o3`/`o3-mini` use the default 100K cap instead of inheriting the GPT-5 tier cap (`OpenAiRequestFactory`)
- **Chat turns no longer absorb serverless embedding cold starts**: a 4-minute keep-alive probe plus startup warmup keeps the remote embedding model resident (reproduced: 23.7s cold vs 1.0s warm); slow probes log WARN as a cold-start record (`EmbeddingModelKeepAlive`)
- **Missing assets and error pages return their real HTTP status instead of 200**: the error-dispatch status now survives the forward to the error documentation pages, so deploy-window asset misses surface as clean 404s instead of browser strict-MIME module errors; directly-browsed docs stay 200 and the swallowed IOException logs (`ErrorDocumentationController`, `CustomErrorController`)
- **Unknown `/api` paths return JSON 404 instead of the SPA shell with 200**: a `(?!api$)` guard keeps the API namespace out of the SPA fallback patterns, and bare `/api` joins the JSON error branch (`WebMvcConfig`, `CustomErrorController`)
- **The SPA recovers from rolling-deploy chunk failures**: a `vite:preloadError` listener reloads once per session (sessionStorage-guarded) to pick up the fresh build instead of leaving a dead page (`frontend/src/main.ts`)
- **Chrome's deprecated-meta warning silenced**: `mobile-web-app-capable` added alongside the apple variant (`frontend/index.html`)

### Dependencies
- **Frontend npm group bump (Dependabot #50)**: `dompurify` 3.3.1→3.4.0 (markdown sanitizer; verified its `FORBID_TAGS`/`ADD_ATTR` changes don't intersect with our single static config), `svelte` 5.48→5.55, `vite` 6.4.1→6.4.2, plus transitive security patches; validated with clean install, lint, svelte-check, production build, and 80/80 tests (`frontend/package.json`, lockfile)

### Refactoring
- **Removed the two orphaned public truncation overloads** left after the provider-scoped fix; regression tests exercise `buildCompletionRequest`, covering the full provider-to-model-id truncation path (`OpenAiRequestFactory`, `OpenAiRequestFactoryTest`)

## Breaking Changes
None

## Related Issues
Closes #40