### PR TITLE
fix(chat): expanded sources stay visible and embedding warm-up probes keep cadence without pipeline logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN npm run build
 # BACKEND BUILD STAGE
 # ================================
 FROM public.ecr.aws/docker/library/eclipse-temurin:25-jdk AS builder
+ARG SOURCE_COMMIT=unknown
 WORKDIR /app
 
 # 1. Gradle wrapper (rarely changes)
@@ -51,13 +52,14 @@ COPY --from=frontend-builder /app/src/main/resources/static ./src/main/resources
 
 # 6. Build application with cache mount
 RUN --mount=type=cache,target=/root/.gradle \
-    ./gradlew clean build -x test --no-daemon && \
+    SOURCE_COMMIT="${SOURCE_COMMIT}" ./gradlew clean build -x test --no-daemon && \
     cp $(ls build/libs/*.jar | grep -v '\-plain\.jar' | head -n 1) build/app.jar
 
 # ================================
 # RUNTIME STAGE
 # ================================
 FROM public.ecr.aws/docker/library/eclipse-temurin:25-jre AS runtime
+ARG SOURCE_COMMIT=unknown
 
 # 1. System packages (never changes) - FIRST for maximum cache reuse
 RUN apt-get update && apt-get install -y --no-install-recommends curl \
@@ -79,6 +81,7 @@ ENV APP_KILL_ON_CONFLICT=false
 ENV DOCS_SNAPSHOT_DIR=/app/data/snapshots
 ENV DOCS_PARSED_DIR=/app/data/parsed
 ENV DOCS_INDEX_DIR=/app/data/index
+ENV SOURCE_COMMIT=${SOURCE_COMMIT}
 
 # 5. Application JAR (changes every build) - LAST for optimal caching
 COPY --from=builder /app/build/app.jar app.jar

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,9 +12,17 @@ plugins {
 val spotbugsToolVersion = "4.9.8"
 val pmdToolVersion = "7.20.0"
 val palantirVersion = "2.85.0"
+val sourceCommitEnvironmentVariable = "SOURCE_COMMIT"
+val missingSourceCommit = "unknown"
+val sourceCommit = providers.environmentVariable(sourceCommitEnvironmentVariable).orElse(missingSourceCommit)
 
 springBoot {
     mainClass.set("com.williamcallahan.javachat.JavaChatApplication")
+    buildInfo {
+        properties {
+            additional.put("commit", sourceCommit)
+        }
+    }
 }
 
 group = "com.williamcallahan"

--- a/frontend/src/lib/components/CitationPanel.svelte
+++ b/frontend/src/lib/components/CitationPanel.svelte
@@ -19,6 +19,16 @@
   let { citations, visible = true, panelId }: Props = $props()
 
   let isExpanded = $state(false)
+  let citationListElement = $state<HTMLUListElement | null>(null)
+
+  // The trigger usually sits at the very bottom of a scrollable container
+  // (chat messages, lesson panel, mobile drawer). The list expands downward,
+  // so without this the new content renders below the fold and stays hidden.
+  $effect(() => {
+    if (isExpanded && citationListElement) {
+      citationListElement.scrollIntoView({ block: 'nearest' })
+    }
+  })
 
   /**
    * Simple hash for deterministic ID generation from citation content.
@@ -75,7 +85,7 @@
     </button>
 
     {#if isExpanded}
-      <ul id={citationListId} class="citation-list" role="list">
+      <ul id={citationListId} class="citation-list" role="list" bind:this={citationListElement}>
         {#each uniqueCitations as citation (citation.url)}
           {@const citationType = getCitationType(citation.url)}
           {@const displaySource = getDisplaySource(citation.url)}
@@ -201,6 +211,9 @@
     flex-direction: column;
     gap: var(--citation-list-gap);
     animation: slide-down var(--citation-transition-normal) ease-out;
+    /* Clearance for scrollIntoView: must exceed the slide-down translateY(-4px)
+       start offset, since the scroll happens while the entry animation runs. */
+    scroll-margin-bottom: var(--space-3, 12px);
   }
 
   @keyframes slide-down {

--- a/frontend/src/lib/components/CitationPanel.test.ts
+++ b/frontend/src/lib/components/CitationPanel.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import { tick } from "svelte";
+import CitationPanel from "./CitationPanel.svelte";
+import type { Citation } from "../services/chat";
+
+const SINGLE_CITATION: Citation[] = [
+  {
+    url: "https://example.com/pdfs/think-java.pdf",
+    title: "Think Java: How to Think Like a Computer Scientist",
+    snippet: "Think Java 2nd Edition Book",
+  },
+];
+
+describe("CitationPanel", () => {
+  // The prototype polyfill lives in src/test/setup.ts; spying here captures calls
+  // from the panel revealing the expanded list inside its scroll container.
+  const scrollIntoViewSpy = vi.spyOn(HTMLElement.prototype, "scrollIntoView");
+
+  beforeEach(() => {
+    scrollIntoViewSpy.mockClear();
+  });
+
+  it("expands the citation list when the trigger is clicked", async () => {
+    const { getByRole, container } = render(CitationPanel, {
+      props: { citations: SINGLE_CITATION },
+    });
+
+    const trigger = getByRole("button", { name: /1 source/i });
+    expect(container.querySelector(".citation-list")).toBeNull();
+
+    await fireEvent.click(trigger);
+    await tick();
+
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(container.querySelector(".citation-list")).not.toBeNull();
+  });
+
+  it("scrolls the expanded list into view so it is never hidden below the fold", async () => {
+    const { getByRole } = render(CitationPanel, {
+      props: { citations: SINGLE_CITATION },
+    });
+
+    await fireEvent.click(getByRole("button", { name: /1 source/i }));
+    await tick();
+
+    expect(scrollIntoViewSpy).toHaveBeenCalledWith(expect.objectContaining({ block: "nearest" }));
+  });
+
+  it("does not scroll when collapsing the list", async () => {
+    const { getByRole } = render(CitationPanel, {
+      props: { citations: SINGLE_CITATION },
+    });
+
+    const trigger = getByRole("button", { name: /1 source/i });
+    await fireEvent.click(trigger);
+    await tick();
+    scrollIntoViewSpy.mockClear();
+
+    await fireEvent.click(trigger);
+    await tick();
+
+    expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -24,6 +24,7 @@
         role="tab"
         class="nav-tab"
         class:active={currentView === 'chat'}
+        aria-label="Chat"
         aria-selected={currentView === 'chat'}
         onclick={() => currentView = 'chat'}
       >
@@ -38,6 +39,7 @@
         role="tab"
         class="nav-tab"
         class:active={currentView === 'learn'}
+        aria-label="Learn"
         aria-selected={currentView === 'learn'}
         onclick={() => currentView = 'learn'}
       >

--- a/frontend/src/lib/components/Header.test.ts
+++ b/frontend/src/lib/components/Header.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/svelte";
+import Header from "./Header.svelte";
+
+describe("Header navigation accessibility", () => {
+  it("names icon-only mobile navigation tabs", () => {
+    const { getByRole } = render(Header, {
+      props: { currentView: "chat" },
+    });
+
+    expect(getByRole("tab", { name: "Chat" })).toHaveAttribute("aria-selected", "true");
+    expect(getByRole("tab", { name: "Learn" })).toHaveAttribute("aria-selected", "false");
+  });
+});

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -22,6 +22,13 @@ Object.defineProperty(HTMLElement.prototype, "scrollTo", {
   value: () => {},
 });
 
+// jsdom doesn't implement scrollIntoView; CitationPanel uses it to reveal the expanded list.
+// oxlint-disable-next-line no-extend-native -- jsdom polyfill, not production code
+Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+  writable: true,
+  value: () => {},
+});
+
 // requestAnimationFrame is used for post-update DOM adjustments; provide a safe fallback.
 if (typeof window.requestAnimationFrame !== "function") {
   window.requestAnimationFrame = (callback: FrameRequestCallback) =>

--- a/src/main/java/com/williamcallahan/javachat/service/EmbeddingClient.java
+++ b/src/main/java/com/williamcallahan/javachat/service/EmbeddingClient.java
@@ -37,4 +37,19 @@ public interface EmbeddingClient {
      * @return embedding vector dimensions
      */
     int dimensions();
+
+    /**
+     * Issues a minimal embedding request so the provider keeps its model resident.
+     *
+     * <p>Distinct from {@link #embed(List)} so scheduled warm-up probes are not
+     * advised by the RAG pipeline logging aspect (which matches {@code embed}
+     * executions): the internal call below is a self-invocation on the target
+     * and bypasses the Spring AOP proxy, keeping "STEP 1" pipeline logs scoped
+     * to real requests.</p>
+     *
+     * @throws EmbeddingServiceUnavailableException when the provider cannot serve the probe
+     */
+    default void warmUp() {
+        embed(List.of("embedding model warm-up probe"));
+    }
 }

--- a/src/main/java/com/williamcallahan/javachat/service/EmbeddingClient.java
+++ b/src/main/java/com/williamcallahan/javachat/service/EmbeddingClient.java
@@ -7,6 +7,8 @@ import java.util.Objects;
  * Defines the application's embedding port independent from Spring AI abstractions.
  */
 public interface EmbeddingClient {
+    /** Minimal provider input used by keep-alive probes. */
+    String EMBEDDING_WARM_UP_PROBE_TEXT = "embedding model warm-up probe";
 
     /**
      * Produces one dense embedding vector per input text, preserving input order.
@@ -41,15 +43,12 @@ public interface EmbeddingClient {
     /**
      * Issues a minimal embedding request so the provider keeps its model resident.
      *
-     * <p>Distinct from {@link #embed(List)} so scheduled warm-up probes are not
-     * advised by the RAG pipeline logging aspect (which matches {@code embed}
-     * executions): the internal call below is a self-invocation on the target
-     * and bypasses the Spring AOP proxy, keeping "STEP 1" pipeline logs scoped
-     * to real requests.</p>
+     * <p>Implementations must call their provider-specific request path directly instead
+     * of delegating to {@link #embed(List)}. The RAG pipeline logging aspect advises
+     * public {@code embed} executions, so routing scheduled probes around that method
+     * keeps "STEP 1" pipeline logs scoped to real requests.</p>
      *
      * @throws EmbeddingServiceUnavailableException when the provider cannot serve the probe
      */
-    default void warmUp() {
-        embed(List.of("embedding model warm-up probe"));
-    }
+    void warmUp();
 }

--- a/src/main/java/com/williamcallahan/javachat/service/EmbeddingModelKeepAlive.java
+++ b/src/main/java/com/williamcallahan/javachat/service/EmbeddingModelKeepAlive.java
@@ -1,6 +1,5 @@
 package com.williamcallahan.javachat.service;
 
-import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -31,7 +30,7 @@ public class EmbeddingModelKeepAlive {
     /** Probe latency above this means the model was cold and a reload just happened. */
     private static final long COLD_MODEL_WARN_THRESHOLD_MILLIS = 5_000L;
 
-    private static final List<String> KEEP_ALIVE_PROBE_TEXTS = List.of("embedding keep-alive probe");
+    private static final long NANOS_PER_MILLISECOND = 1_000_000L;
 
     private final EmbeddingClient embeddingClient;
 
@@ -49,17 +48,19 @@ public class EmbeddingModelKeepAlive {
      * and the next tick retries. Unexpected runtime failures propagate to the scheduler's
      * error handler rather than being swallowed here.</p>
      */
-    @Scheduled(initialDelay = STARTUP_WARMUP_DELAY_MILLIS, fixedDelay = KEEP_ALIVE_INTERVAL_MILLIS)
+    // fixedRate keeps probe *starts* on the cadence: with fixedDelay a slow cold
+    // start would push the next probe past the provider's idle-unload TTL.
+    @Scheduled(initialDelay = STARTUP_WARMUP_DELAY_MILLIS, fixedRate = KEEP_ALIVE_INTERVAL_MILLIS)
     public void keepEmbeddingModelWarm() {
-        long probeStartMillis = System.currentTimeMillis();
+        long probeStartNanos = System.nanoTime();
         try {
-            embeddingClient.embed(KEEP_ALIVE_PROBE_TEXTS);
+            embeddingClient.warmUp();
         } catch (EmbeddingServiceUnavailableException exception) {
             log.warn(
                     "[EMBEDDING] Keep-alive probe failed; the next chat request may pay a model cold start", exception);
             return;
         }
-        long probeDurationMillis = System.currentTimeMillis() - probeStartMillis;
+        long probeDurationMillis = (System.nanoTime() - probeStartNanos) / NANOS_PER_MILLISECOND;
         if (probeDurationMillis > COLD_MODEL_WARN_THRESHOLD_MILLIS) {
             log.warn(
                     "[EMBEDDING] Keep-alive probe took {}ms — embedding model was cold and has been reloaded",

--- a/src/main/java/com/williamcallahan/javachat/service/LocalEmbeddingClient.java
+++ b/src/main/java/com/williamcallahan/javachat/service/LocalEmbeddingClient.java
@@ -70,6 +70,15 @@ public final class LocalEmbeddingClient implements EmbeddingClient {
         if (texts == null || texts.isEmpty()) {
             return List.of();
         }
+        return fetchValidatedEmbeddings(texts);
+    }
+
+    @Override
+    public void warmUp() {
+        fetchValidatedEmbeddings(List.of(EMBEDDING_WARM_UP_PROBE_TEXT));
+    }
+
+    private List<float[]> fetchValidatedEmbeddings(List<String> texts) {
         try {
             return callEmbeddingApi(texts);
         } catch (org.springframework.web.client.RestClientResponseException apiException) {

--- a/src/main/java/com/williamcallahan/javachat/service/OpenAiCompatibleEmbeddingClient.java
+++ b/src/main/java/com/williamcallahan/javachat/service/OpenAiCompatibleEmbeddingClient.java
@@ -85,6 +85,15 @@ public class OpenAiCompatibleEmbeddingClient implements EmbeddingClient, AutoClo
         if (texts == null || texts.isEmpty()) {
             return List.of();
         }
+        return createEmbeddings(texts);
+    }
+
+    @Override
+    public void warmUp() {
+        createEmbeddings(List.of(EMBEDDING_WARM_UP_PROBE_TEXT));
+    }
+
+    private List<float[]> createEmbeddings(List<String> texts) {
         EmbeddingCreateParams.Builder embeddingRequestBuilder =
                 EmbeddingCreateParams.builder().model(modelName).inputOfArrayOfStrings(texts);
         if (supportsDimensionOverride(modelName)) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -145,6 +145,10 @@ app.cors.max-age-seconds=3600
 
 # Actuator
 management.endpoints.web.exposure.include=health,info,metrics
+management.info.build.enabled=true
+management.info.env.enabled=true
+info.application.name=${spring.application.name}
+info.deployment.commit=${SOURCE_COMMIT:unknown}
 # Reduce Qdrant client warning verbosity via logging
 logging.level.io.qdrant=ERROR
 # Suppress PDFBox font mapping warnings (these are harmless)

--- a/src/test/java/com/williamcallahan/javachat/service/EmbeddingModelKeepAliveTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/EmbeddingModelKeepAliveTest.java
@@ -18,8 +18,7 @@ class EmbeddingModelKeepAliveTest {
 
         new EmbeddingModelKeepAlive(recordingEmbeddingClient).keepEmbeddingModelWarm();
 
-        // warmUp() routes through embed(List) by default, so one probe = one embed call
-        assertEquals(1, recordingEmbeddingClient.embedInvocationCount);
+        assertEquals(1, recordingEmbeddingClient.warmUpInvocationCount);
     }
 
     @Test
@@ -30,12 +29,16 @@ class EmbeddingModelKeepAliveTest {
     }
 
     private static final class RecordingEmbeddingClient implements EmbeddingClient {
-        private int embedInvocationCount;
+        private int warmUpInvocationCount;
 
         @Override
         public List<float[]> embed(List<String> texts) {
-            embedInvocationCount++;
-            return List.of(new float[] {0.0f});
+            throw new AssertionError("keep-alive probes must not call embed(List)");
+        }
+
+        @Override
+        public void warmUp() {
+            warmUpInvocationCount++;
         }
 
         @Override
@@ -47,6 +50,11 @@ class EmbeddingModelKeepAliveTest {
     private static final class UnavailableEmbeddingClient implements EmbeddingClient {
         @Override
         public List<float[]> embed(List<String> texts) {
+            throw new EmbeddingServiceUnavailableException("provider offline for test");
+        }
+
+        @Override
+        public void warmUp() {
             throw new EmbeddingServiceUnavailableException("provider offline for test");
         }
 

--- a/src/test/java/com/williamcallahan/javachat/service/EmbeddingModelKeepAliveTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/EmbeddingModelKeepAliveTest.java
@@ -18,6 +18,7 @@ class EmbeddingModelKeepAliveTest {
 
         new EmbeddingModelKeepAlive(recordingEmbeddingClient).keepEmbeddingModelWarm();
 
+        // warmUp() routes through embed(List) by default, so one probe = one embed call
         assertEquals(1, recordingEmbeddingClient.embedInvocationCount);
     }
 


### PR DESCRIPTION
## Summary
Expanded citation source lists now scroll into view inside chat containers, so users can see sources immediately after opening them. Embedding keep-alive probes now start on a fixed cadence and use provider-specific warm-up paths that avoid RAG pipeline logging, reducing cold-start risk without making scheduled probes look like user retrieval work.

## Changes

### Bug Fixes
- **Source lists stay visible after expansion**: Opening a collapsed source list now scrolls the citation list into the nearest scroll container instead of rendering it below the fold (`CitationPanel.svelte`).
- **Embedding warm-up probes keep their idle-prevention cadence**: Scheduled probes now run at fixed-rate starts and use monotonic timing so a slow cold start does not push later probes past the provider idle window (`EmbeddingModelKeepAlive.keepEmbeddingModelWarm`).
- **Warm-up probes no longer look like user retrieval work in logs**: Keep-alive requests call the warm-up port, and concrete providers issue the probe through private/provider request paths instead of the advised `embed(List)` method (`EmbeddingClient.warmUp`, `LocalEmbeddingClient.warmUp`, `OpenAiCompatibleEmbeddingClient.warmUp`).

### Tests
- **Citation expansion behavior is covered in the frontend suite**: Tests verify expansion, scroll reveal, and collapse behavior with a jsdom `scrollIntoView` polyfill (`CitationPanel.test.ts`, `frontend/src/test/setup.ts`).
- **Keep-alive logging regression is covered in the backend suite**: The keep-alive test fails if scheduled warm-up calls `embed(List)` instead of the warm-up port (`EmbeddingModelKeepAliveTest`).

## Breaking Changes
None

## Related Issues
None