### PR TITLE
fix(runtime): shared Gemma routing, bounded structured reranking, embedding health, and attributed errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,8 +29,8 @@ OPENAI_API_KEY=
 # For OpenAI direct: https://api.openai.com
 # For the Researchly shared LLM gateway, set OPENAI_BASE_URL to
 # https://api.llm-gateway.iocloudhost.net/v1, OPENAI_MODEL to
-# gemma-4-26b-a4b, and use an lgw-* key. This model is a gateway alias and
-# may fail over across providers configured for it by the gateway.
+# google/gemma-4-26b-a4b, and use an lgw-* key. This cloud-only alias keeps
+# user-facing streams off on-prem providers until model readiness is proven.
 OPENAI_BASE_URL=https://api.openai.com
 OPENAI_MODEL=gpt-5.2
 # OPENAI_REASONING_EFFORT=high

--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,10 @@ GITHUB_MODELS_CHAT_MODEL=gpt-5
 # LLM_GATEWAY_TIER=production-z
 OPENAI_API_KEY=
 # For OpenAI direct: https://api.openai.com
-# For the Researchly LLM gateway: https://api.llm-gateway.iocloudhost.net/v1 (model gpt-5.4, key lgw-*)
+# For the Researchly shared LLM gateway, set OPENAI_BASE_URL to
+# https://api.llm-gateway.iocloudhost.net/v1, OPENAI_MODEL to
+# gemma-4-26b-a4b, and use an lgw-* key. This model is a gateway alias and
+# may fail over across providers configured for it by the gateway.
 OPENAI_BASE_URL=https://api.openai.com
 OPENAI_MODEL=gpt-5.2
 # OPENAI_REASONING_EFFORT=high

--- a/.env.example
+++ b/.env.example
@@ -27,10 +27,11 @@ GITHUB_MODELS_CHAT_MODEL=gpt-5
 # LLM_GATEWAY_TIER=production-z
 OPENAI_API_KEY=
 # For OpenAI direct: https://api.openai.com
-# For the Researchly shared LLM gateway, set OPENAI_BASE_URL to
-# https://api.llm-gateway.iocloudhost.net/v1, OPENAI_MODEL to
-# google/gemma-4-26b-a4b, and use an lgw-* key. This cloud-only alias keeps
-# user-facing streams off on-prem providers until model readiness is proven.
+# For the Researchly shared LLM gateway, set LLM_PRIMARY_PROVIDER=openai,
+# OPENAI_BASE_URL=https://api.llm-gateway.iocloudhost.net/v1,
+# OPENAI_MODEL=google/gemma-4-26b-a4b, and OPENAI_API_KEY to an lgw-* key.
+# This cloud-only alias keeps user-facing streams off on-prem providers until
+# model readiness is proven.
 OPENAI_BASE_URL=https://api.openai.com
 OPENAI_MODEL=gpt-5.2
 # OPENAI_REASONING_EFFORT=high

--- a/.env.example
+++ b/.env.example
@@ -29,9 +29,8 @@ OPENAI_API_KEY=
 # For OpenAI direct: https://api.openai.com
 # For the Researchly shared LLM gateway, set LLM_PRIMARY_PROVIDER=openai,
 # OPENAI_BASE_URL=https://api.llm-gateway.iocloudhost.net/v1,
-# OPENAI_MODEL=google/gemma-4-26b-a4b, and OPENAI_API_KEY to an lgw-* key.
-# This cloud-only alias keeps user-facing streams off on-prem providers until
-# model readiness is proven.
+# OPENAI_MODEL=gemma-4-26b-a4b, and OPENAI_API_KEY to an lgw-* key.
+# This alias may fail over across the gateway providers configured for it.
 OPENAI_BASE_URL=https://api.openai.com
 OPENAI_MODEL=gpt-5.2
 # OPENAI_REASONING_EFFORT=high

--- a/docs/api.md
+++ b/docs/api.md
@@ -43,7 +43,7 @@ curl -N -H "Content-Type: application/json" \
 - GET `/api/guided/lesson?slug=...`
 - GET `/api/guided/citations?slug=...`
 - GET `/api/guided/enrich?slug=...`
-- GET `/api/guided/content/stream?slug=...` (SSE, raw markdown)
+- GET `/api/guided/content/stream?slug=...` (SSE `text` events, JSON-wrapped chunks)
 - GET `/api/guided/content?slug=...` (JSON)
 - GET `/api/guided/content/html?slug=...` (HTML)
 - POST `/api/guided/stream` (SSE; request includes `sessionId`, `slug`, `latest`)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,7 +25,7 @@ Common variables:
 - `GITHUB_MODELS_CHAT_MODEL` (default `openai/gpt-5`)
 - `OPENAI_API_KEY` (OpenAI auth)
 - `OPENAI_BASE_URL` (default `https://api.openai.com/v1`)
-- `OPENAI_MODEL` (application fallback default `gpt-5.2`; shared-gateway alias `gemma-4-26b-a4b`)
+- `OPENAI_MODEL` (application fallback default `gpt-5.2`; shared-gateway cloud alias `google/gemma-4-26b-a4b`)
 - `OPENAI_REASONING_EFFORT` (optional, GPT‑5 family)
 - `OPENAI_STREAMING_REQUEST_TIMEOUT_SECONDS` (default `600`)
 - `OPENAI_STREAMING_READ_TIMEOUT_SECONDS` (default `75`)
@@ -38,10 +38,10 @@ Configure chat through the shared gateway with:
 LLM_PRIMARY_PROVIDER=openai
 OPENAI_API_KEY=lgw-...
 OPENAI_BASE_URL=https://api.llm-gateway.iocloudhost.net/v1
-OPENAI_MODEL=gemma-4-26b-a4b
+OPENAI_MODEL=google/gemma-4-26b-a4b
 ```
 
-`gemma-4-26b-a4b` is a gateway alias and may fail over across upstream providers configured for that alias. This gateway-side routing is separate from Java Chat's `LLM_PRIMARY_PROVIDER` ordering. `OPENAI_BASE_URL` remains the chat base URL; embeddings keep their existing explicit provider selection and use `OPENAI_EMBEDDING_BASE_URL` or `REMOTE_EMBEDDING_SERVER_URL` rather than the chat gateway URL.
+`google/gemma-4-26b-a4b` is the gateway's cloud-only Gemma alias. It keeps user-facing streams off the mixed on-prem fleet until that fleet's model-aware readiness is proven. Gateway-side routing is separate from Java Chat's `LLM_PRIMARY_PROVIDER` ordering. `OPENAI_BASE_URL` remains the chat base URL; embeddings keep their existing explicit provider selection and use `OPENAI_EMBEDDING_BASE_URL` or `REMOTE_EMBEDDING_SERVER_URL` rather than the chat gateway URL.
 
 ### Provider notes
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,7 +25,7 @@ Common variables:
 - `GITHUB_MODELS_CHAT_MODEL` (default `openai/gpt-5`)
 - `OPENAI_API_KEY` (OpenAI auth)
 - `OPENAI_BASE_URL` (default `https://api.openai.com/v1`)
-- `OPENAI_MODEL` (application fallback default `gpt-5.2`; shared-gateway cloud alias `google/gemma-4-26b-a4b`)
+- `OPENAI_MODEL` (application fallback default `gpt-5.2`; shared-gateway alias `gemma-4-26b-a4b`)
 - `OPENAI_REASONING_EFFORT` (optional, GPT‑5 family)
 - `OPENAI_STREAMING_REQUEST_TIMEOUT_SECONDS` (default `600`)
 - `OPENAI_STREAMING_READ_TIMEOUT_SECONDS` (default `75`)
@@ -38,10 +38,10 @@ Configure chat through the shared gateway with:
 LLM_PRIMARY_PROVIDER=openai
 OPENAI_API_KEY=lgw-...
 OPENAI_BASE_URL=https://api.llm-gateway.iocloudhost.net/v1
-OPENAI_MODEL=google/gemma-4-26b-a4b
+OPENAI_MODEL=gemma-4-26b-a4b
 ```
 
-`google/gemma-4-26b-a4b` is the gateway's cloud-only Gemma alias. It keeps user-facing streams off the mixed on-prem fleet until that fleet's model-aware readiness is proven. Gateway-side routing is separate from Java Chat's `LLM_PRIMARY_PROVIDER` ordering. `OPENAI_BASE_URL` remains the chat base URL; embeddings keep their existing explicit provider selection and use `OPENAI_EMBEDDING_BASE_URL` or `REMOTE_EMBEDDING_SERVER_URL` rather than the chat gateway URL.
+`gemma-4-26b-a4b` is the gateway's regular Gemma alias and may fail over across the providers configured for it. Gateway-side routing is separate from Java Chat's `LLM_PRIMARY_PROVIDER` ordering. `OPENAI_BASE_URL` remains the chat base URL; embeddings keep their existing explicit provider selection and use `OPENAI_EMBEDDING_BASE_URL` or `REMOTE_EMBEDDING_SERVER_URL` rather than the chat gateway URL.
 
 ### Provider notes
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,7 +16,7 @@ Streaming uses the OpenAI Java SDK (`OpenAIStreamingService`) and supports:
 - **GitHub Models** via `GITHUB_TOKEN`
 - **OpenAI** via `OPENAI_API_KEY`
 
-If both keys are present, the service prefers OpenAI for streaming. There is no automatic cross-provider fallback; if the preferred provider fails or is rate-limited, the error is surfaced to the client rather than silently switching providers.
+Provider order is controlled by `LLM_PRIMARY_PROVIDER` (default `github_models`). When both keys are present, eligible failures can fail over to the configured secondary provider before the first streamed token; failures that are not eligible for failover are surfaced to the client.
 
 Common variables:
 
@@ -25,10 +25,23 @@ Common variables:
 - `GITHUB_MODELS_CHAT_MODEL` (default `openai/gpt-5`)
 - `OPENAI_API_KEY` (OpenAI auth)
 - `OPENAI_BASE_URL` (default `https://api.openai.com/v1`)
-- `OPENAI_MODEL` (default `gpt-5.2`)
+- `OPENAI_MODEL` (application fallback default `gpt-5.2`; shared-gateway alias `gemma-4-26b-a4b`)
 - `OPENAI_REASONING_EFFORT` (optional, GPT‑5 family)
 - `OPENAI_STREAMING_REQUEST_TIMEOUT_SECONDS` (default `600`)
 - `OPENAI_STREAMING_READ_TIMEOUT_SECONDS` (default `75`)
+
+### Researchly shared gateway
+
+Configure chat through the shared gateway with:
+
+```dotenv
+LLM_PRIMARY_PROVIDER=openai
+OPENAI_API_KEY=lgw-...
+OPENAI_BASE_URL=https://api.llm-gateway.iocloudhost.net/v1
+OPENAI_MODEL=gemma-4-26b-a4b
+```
+
+`gemma-4-26b-a4b` is a gateway alias and may fail over across upstream providers configured for that alias. This gateway-side routing is separate from Java Chat's `LLM_PRIMARY_PROVIDER` ordering. `OPENAI_BASE_URL` remains the chat base URL; embeddings keep their existing explicit provider selection and use `OPENAI_EMBEDDING_BASE_URL` or `REMOTE_EMBEDDING_SERVER_URL` rather than the chat gateway URL.
 
 ### Provider notes
 

--- a/src/main/java/com/williamcallahan/javachat/service/EmbeddingClient.java
+++ b/src/main/java/com/williamcallahan/javachat/service/EmbeddingClient.java
@@ -20,6 +20,13 @@ public interface EmbeddingClient {
     List<float[]> embed(List<String> texts, LlmGatewayTier requestTier);
 
     /**
+     * Returns the provider model identifier used for embedding requests.
+     *
+     * @return configured embedding model identifier
+     */
+    String modelName();
+
+    /**
      * Produces a dense embedding vector for a single text.
      *
      * @param text input text

--- a/src/main/java/com/williamcallahan/javachat/service/EmbeddingModelKeepAlive.java
+++ b/src/main/java/com/williamcallahan/javachat/service/EmbeddingModelKeepAlive.java
@@ -1,24 +1,29 @@
 package com.williamcallahan.javachat.service;
 
+import java.util.Objects;
+import java.util.function.LongSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 /**
- * Keeps the configured embedding model resident by probing the provider on a fixed cadence.
+ * Probes the configured embedding provider on a fixed cadence and reports its lifecycle state.
  *
  * <p>OpenAI-compatible embedding providers scale to zero when idle: serverless cloud hosts
  * (Novita) spin the model down between bursts, and self-hosted servers (LM Studio, Ollama)
  * unload after an idle TTL. The first request after either pays the full model spin-up on
  * the user's critical path — observed in production at 53.5s on a live chat turn and
  * reproduced at 23.7s cold versus 1.0s warm against the same provider. A probe cadence
- * below common scale-down windows keeps the model resident so user requests never pay the
- * cold start. Probe failures are logged as a cold-start risk and never affect request
- * handling.</p>
+ * below common scale-down windows can reduce how often user requests pay that startup cost.
+ * Probe latency alone cannot prove a remote model reload, so slow successful probes are
+ * classified separately from failures and exposed through application health.</p>
  */
 @Component
-public class EmbeddingModelKeepAlive {
+public class EmbeddingModelKeepAlive implements HealthIndicator {
     private static final Logger log = LoggerFactory.getLogger(EmbeddingModelKeepAlive.class);
 
     /** Probe cadence below the 5-minute idle-unload default of common model servers. */
@@ -27,18 +32,31 @@ public class EmbeddingModelKeepAlive {
     /** Delay before the first probe so the provider warms up right after startup. */
     private static final long STARTUP_WARMUP_DELAY_MILLIS = 5_000L;
 
-    /** Probe latency above this means the model was cold and a reload just happened. */
-    private static final long COLD_MODEL_WARN_THRESHOLD_MILLIS = 5_000L;
+    /** Probe latency above this marks a slow provider response without inferring its remote cause. */
+    private static final long SLOW_PROBE_THRESHOLD_MILLIS = 5_000L;
+
+    /** Rechecks an unavailable provider before container health exhausts its retry budget. */
+    private static final long UNAVAILABLE_RECOVERY_INTERVAL_MILLIS = 30_000L;
 
     private static final long NANOS_PER_MILLISECOND = 1_000_000L;
 
     private final EmbeddingClient embeddingClient;
+    private final String modelName;
+    private final LongSupplier nanoTime;
+    private volatile EmbeddingProbeSnapshot latestProbe = EmbeddingProbeSnapshot.initializing();
 
     /**
      * Creates the keep-alive prober for the active embedding provider.
      */
+    @Autowired
     public EmbeddingModelKeepAlive(EmbeddingClient embeddingClient) {
-        this.embeddingClient = embeddingClient;
+        this(embeddingClient, System::nanoTime);
+    }
+
+    EmbeddingModelKeepAlive(EmbeddingClient embeddingClient, LongSupplier nanoTime) {
+        this.embeddingClient = Objects.requireNonNull(embeddingClient, "embeddingClient");
+        this.modelName = Objects.requireNonNull(embeddingClient.modelName(), "embeddingClient.modelName");
+        this.nanoTime = Objects.requireNonNull(nanoTime, "nanoTime");
     }
 
     /**
@@ -52,21 +70,142 @@ public class EmbeddingModelKeepAlive {
     // start would push the next probe past the provider's idle-unload TTL.
     @Scheduled(initialDelay = STARTUP_WARMUP_DELAY_MILLIS, fixedRate = KEEP_ALIVE_INTERVAL_MILLIS)
     public void keepEmbeddingModelWarm() {
-        long probeStartNanos = System.nanoTime();
+        probeEmbeddingModel();
+    }
+
+    /** Retries only unavailable providers so health can recover promptly after a transient outage. */
+    @Scheduled(initialDelay = UNAVAILABLE_RECOVERY_INTERVAL_MILLIS, fixedDelay = UNAVAILABLE_RECOVERY_INTERVAL_MILLIS)
+    void retryUnavailableEmbeddingModel() {
+        if (latestProbe.lifecycle() == EmbeddingProbeLifecycle.UNAVAILABLE) {
+            probeEmbeddingModel();
+        }
+    }
+
+    private synchronized void probeEmbeddingModel() {
+        long probeStartNanos = nanoTime.getAsLong();
         try {
             embeddingClient.warmUp();
-        } catch (EmbeddingServiceUnavailableException exception) {
-            log.warn(
-                    "[EMBEDDING] Keep-alive probe failed; the next chat request may pay a model cold start", exception);
+        } catch (RuntimeException exception) {
+            recordFailure(elapsedMillis(probeStartNanos), exception);
+            if (exception instanceof EmbeddingServiceUnavailableException) {
+                return;
+            }
+            throw exception;
+        }
+        recordSuccess(elapsedMillis(probeStartNanos));
+    }
+
+    /**
+     * Projects the latest completed embedding probe into the application health endpoint.
+     *
+     * @return DOWN until a probe succeeds and after the latest probe fails; UP otherwise
+     */
+    @Override
+    public Health health() {
+        EmbeddingProbeSnapshot probeSnapshot = latestProbe;
+        Health.Builder health = probeSnapshot.ready() ? Health.up() : Health.down();
+        return health.withDetail("model", modelName)
+                .withDetail("lifecycle", probeSnapshot.lifecycle())
+                .withDetail("lastProbeDurationMs", probeSnapshot.durationMillis())
+                .withDetail("consecutiveSlowProbes", probeSnapshot.consecutiveSlowProbes())
+                .withDetail("consecutiveFailures", probeSnapshot.consecutiveFailures())
+                .build();
+    }
+
+    private long elapsedMillis(long probeStartNanos) {
+        return (nanoTime.getAsLong() - probeStartNanos) / NANOS_PER_MILLISECOND;
+    }
+
+    private void recordSuccess(long probeDurationMillis) {
+        String logSafeModelName = modelName.replace("\r", "\\r").replace("\n", "\\n");
+        EmbeddingProbeSnapshot previousProbe = latestProbe;
+        int previousSlowProbeCount = previousProbe.consecutiveSlowProbes();
+        int previousFailureCount = previousProbe.consecutiveFailures();
+
+        if (probeDurationMillis > SLOW_PROBE_THRESHOLD_MILLIS) {
+            int consecutiveSlowProbeCount =
+                    previousProbe.lifecycle() == EmbeddingProbeLifecycle.SLOW ? previousSlowProbeCount + 1 : 1;
+            latestProbe = new EmbeddingProbeSnapshot(
+                    EmbeddingProbeLifecycle.SLOW, probeDurationMillis, consecutiveSlowProbeCount, 0);
+            if (previousFailureCount > 0) {
+                log.atInfo().log(() -> "event=embedding_model_probe_recovered outcome=success model="
+                        + logSafeModelName + " durationMs=" + probeDurationMillis + " lifecycle="
+                        + EmbeddingProbeLifecycle.SLOW + " previousFailures=" + previousFailureCount);
+            } else if (consecutiveSlowProbeCount == 1) {
+                log.atInfo().log(() -> "event=embedding_model_probe_slow outcome=success model="
+                        + logSafeModelName + " durationMs=" + probeDurationMillis + " consecutiveSlowProbes="
+                        + consecutiveSlowProbeCount);
+            } else if (consecutiveSlowProbeCount == 2) {
+                log.atWarn()
+                        .log(() -> "event=embedding_model_probe_slow_loop outcome=success model="
+                                + logSafeModelName + " durationMs=" + probeDurationMillis + " consecutiveSlowProbes="
+                                + consecutiveSlowProbeCount);
+            } else {
+                log.atDebug().log(() -> "event=embedding_model_probe_slow outcome=success model="
+                        + logSafeModelName + " durationMs=" + probeDurationMillis + " consecutiveSlowProbes="
+                        + consecutiveSlowProbeCount);
+            }
             return;
         }
-        long probeDurationMillis = (System.nanoTime() - probeStartNanos) / NANOS_PER_MILLISECOND;
-        if (probeDurationMillis > COLD_MODEL_WARN_THRESHOLD_MILLIS) {
-            log.warn(
-                    "[EMBEDDING] Keep-alive probe took {}ms — embedding model was cold and has been reloaded",
-                    probeDurationMillis);
+
+        latestProbe = new EmbeddingProbeSnapshot(EmbeddingProbeLifecycle.READY, probeDurationMillis, 0, 0);
+        if (previousSlowProbeCount > 0 || previousFailureCount > 0) {
+            log.atInfo().log(() -> "event=embedding_model_probe_recovered outcome=success model="
+                    + logSafeModelName + " durationMs=" + probeDurationMillis + " previousSlowProbes="
+                    + previousSlowProbeCount + " previousFailures=" + previousFailureCount);
+        } else if (previousProbe.lifecycle() == EmbeddingProbeLifecycle.INITIALIZING) {
+            log.atInfo().log(() -> "event=embedding_model_probe_ready outcome=success model=" + logSafeModelName
+                    + " durationMs=" + probeDurationMillis);
         } else {
-            log.debug("[EMBEDDING] Keep-alive probe completed in {}ms", probeDurationMillis);
+            log.atDebug().log(() -> "event=embedding_model_probe_ready outcome=success model=" + logSafeModelName
+                    + " durationMs=" + probeDurationMillis);
+        }
+    }
+
+    private void recordFailure(long probeDurationMillis, RuntimeException exception) {
+        String logSafeModelName = modelName.replace("\r", "\\r").replace("\n", "\\n");
+        EmbeddingProbeSnapshot previousProbe = latestProbe;
+        int consecutiveFailureCount = previousProbe.lifecycle() == EmbeddingProbeLifecycle.UNAVAILABLE
+                ? previousProbe.consecutiveFailures() + 1
+                : 1;
+        latestProbe = new EmbeddingProbeSnapshot(
+                EmbeddingProbeLifecycle.UNAVAILABLE, probeDurationMillis, 0, consecutiveFailureCount);
+        if (consecutiveFailureCount == 1) {
+            log.atWarn()
+                    .setCause(exception)
+                    .log(() -> "event=embedding_model_probe_failed outcome=failure model=" + logSafeModelName
+                            + " durationMs=" + probeDurationMillis + " consecutiveFailures=" + consecutiveFailureCount);
+        } else if (consecutiveFailureCount == 2) {
+            log.atError()
+                    .setCause(exception)
+                    .log(() -> "event=embedding_model_probe_failure_loop outcome=failure model=" + logSafeModelName
+                            + " durationMs=" + probeDurationMillis + " consecutiveFailures=" + consecutiveFailureCount);
+        } else {
+            log.atDebug().log(() -> "event=embedding_model_probe_failed outcome=failure model="
+                    + logSafeModelName + " durationMs=" + probeDurationMillis + " consecutiveFailures="
+                    + consecutiveFailureCount);
+        }
+    }
+
+    /** Describes the latest provider probe outcome without inferring remote engine state. */
+    private enum EmbeddingProbeLifecycle {
+        INITIALIZING,
+        READY,
+        SLOW,
+        UNAVAILABLE
+    }
+
+    private record EmbeddingProbeSnapshot(
+            EmbeddingProbeLifecycle lifecycle,
+            long durationMillis,
+            int consecutiveSlowProbes,
+            int consecutiveFailures) {
+        private static EmbeddingProbeSnapshot initializing() {
+            return new EmbeddingProbeSnapshot(EmbeddingProbeLifecycle.INITIALIZING, 0, 0, 0);
+        }
+
+        private boolean ready() {
+            return lifecycle == EmbeddingProbeLifecycle.READY || lifecycle == EmbeddingProbeLifecycle.SLOW;
         }
     }
 }

--- a/src/main/java/com/williamcallahan/javachat/service/EmbeddingModelKeepAlive.java
+++ b/src/main/java/com/williamcallahan/javachat/service/EmbeddingModelKeepAlive.java
@@ -38,6 +38,9 @@ public class EmbeddingModelKeepAlive implements HealthIndicator {
     /** Rechecks an unavailable provider before container health exhausts its retry budget. */
     private static final long UNAVAILABLE_RECOVERY_INTERVAL_MILLIS = 30_000L;
 
+    /** Escalates only after a probe condition repeats on the next observation. */
+    private static final int REPEATED_PROBE_ALERT_COUNT = 2;
+
     private static final long NANOS_PER_MILLISECOND = 1_000_000L;
 
     private final EmbeddingClient embeddingClient;
@@ -135,7 +138,7 @@ public class EmbeddingModelKeepAlive implements HealthIndicator {
                 log.atInfo().log(() -> "event=embedding_model_probe_slow outcome=success model="
                         + logSafeModelName + " durationMs=" + probeDurationMillis + " consecutiveSlowProbes="
                         + consecutiveSlowProbeCount);
-            } else if (consecutiveSlowProbeCount == 2) {
+            } else if (consecutiveSlowProbeCount == REPEATED_PROBE_ALERT_COUNT) {
                 log.atWarn()
                         .log(() -> "event=embedding_model_probe_slow_loop outcome=success model="
                                 + logSafeModelName + " durationMs=" + probeDurationMillis + " consecutiveSlowProbes="
@@ -175,7 +178,7 @@ public class EmbeddingModelKeepAlive implements HealthIndicator {
                     .setCause(exception)
                     .log(() -> "event=embedding_model_probe_failed outcome=failure model=" + logSafeModelName
                             + " durationMs=" + probeDurationMillis + " consecutiveFailures=" + consecutiveFailureCount);
-        } else if (consecutiveFailureCount == 2) {
+        } else if (consecutiveFailureCount == REPEATED_PROBE_ALERT_COUNT) {
             log.atError()
                     .setCause(exception)
                     .log(() -> "event=embedding_model_probe_failure_loop outcome=failure model=" + logSafeModelName

--- a/src/main/java/com/williamcallahan/javachat/service/LocalEmbeddingClient.java
+++ b/src/main/java/com/williamcallahan/javachat/service/LocalEmbeddingClient.java
@@ -79,6 +79,11 @@ public final class LocalEmbeddingClient implements EmbeddingClient {
         fetchValidatedEmbeddings(List.of(EMBEDDING_WARM_UP_PROBE_TEXT));
     }
 
+    @Override
+    public String modelName() {
+        return modelName;
+    }
+
     private List<float[]> fetchValidatedEmbeddings(List<String> texts) {
         try {
             return callEmbeddingApi(texts);

--- a/src/main/java/com/williamcallahan/javachat/service/OpenAIStreamingService.java
+++ b/src/main/java/com/williamcallahan/javachat/service/OpenAIStreamingService.java
@@ -179,7 +179,7 @@ public class OpenAIStreamingService {
      * @return completion text from the first successful provider attempt
      */
     public Mono<String> complete(String prompt, double temperature) {
-        return complete(prompt, temperature, null);
+        return complete(prompt, temperature, null, false);
     }
 
     /**
@@ -194,10 +194,26 @@ public class OpenAIStreamingService {
         if (maximumOutputTokens <= 0) {
             return Mono.error(new IllegalArgumentException("maximumOutputTokens must be positive"));
         }
-        return complete(prompt, temperature, Integer.valueOf(maximumOutputTokens));
+        return complete(prompt, temperature, Integer.valueOf(maximumOutputTokens), false);
     }
 
-    private Mono<String> complete(String prompt, double temperature, Integer maximumOutputTokens) {
+    /**
+     * Sends a non-streaming completion request that requires a JSON object response.
+     *
+     * @param prompt completion prompt
+     * @param temperature response temperature
+     * @param maximumOutputTokens maximum output tokens needed by this caller
+     * @return completion text from the first provider honoring the JSON contract
+     */
+    public Mono<String> completeJsonObject(String prompt, double temperature, int maximumOutputTokens) {
+        if (maximumOutputTokens <= 0) {
+            return Mono.error(new IllegalArgumentException("maximumOutputTokens must be positive"));
+        }
+        return complete(prompt, temperature, Integer.valueOf(maximumOutputTokens), true);
+    }
+
+    private Mono<String> complete(
+            String prompt, double temperature, Integer maximumOutputTokens, boolean requireJsonObject) {
         return Mono.<String>defer(() -> {
                     List<OpenAiProviderCandidate> availableProviders =
                             providerRoutingService.selectAvailableProviderCandidates(clientPrimary, clientSecondary);
@@ -213,8 +229,8 @@ public class OpenAIStreamingService {
                         OpenAiProviderCandidate providerCandidate = availableProviders.get(providerIndex);
                         RateLimitService.ApiProvider activeProvider = providerCandidate.provider();
 
-                        ResponseCreateParams requestParameters =
-                                buildCompletionRequest(prompt, temperature, activeProvider, maximumOutputTokens);
+                        ResponseCreateParams requestParameters = buildCompletionRequest(
+                                prompt, temperature, activeProvider, maximumOutputTokens, requireJsonObject);
                         try {
                             log.info("[LLM] Complete started (providerId={})", activeProvider.ordinal());
                             RequestOptions requestOptions = RequestOptions.builder()
@@ -259,7 +275,12 @@ public class OpenAIStreamingService {
             String prompt,
             double temperature,
             RateLimitService.ApiProvider activeProvider,
-            Integer maximumOutputTokens) {
+            Integer maximumOutputTokens,
+            boolean requireJsonObject) {
+        if (requireJsonObject) {
+            return requestFactory.buildJsonCompletionRequest(
+                    prompt, temperature, activeProvider, maximumOutputTokens.intValue());
+        }
         if (maximumOutputTokens == null) {
             return requestFactory.buildCompletionRequest(prompt, temperature, activeProvider);
         }

--- a/src/main/java/com/williamcallahan/javachat/service/OpenAiCompatibleEmbeddingClient.java
+++ b/src/main/java/com/williamcallahan/javachat/service/OpenAiCompatibleEmbeddingClient.java
@@ -106,6 +106,11 @@ public class OpenAiCompatibleEmbeddingClient implements EmbeddingClient, AutoClo
         createEmbeddings(List.of(EMBEDDING_WARM_UP_PROBE_TEXT), LlmGatewayTier.BATCH);
     }
 
+    @Override
+    public String modelName() {
+        return modelName;
+    }
+
     private List<float[]> createEmbeddings(List<String> texts, LlmGatewayTier requestTier) {
         EmbeddingCreateParams.Builder embeddingRequestBuilder =
                 EmbeddingCreateParams.builder().model(modelName).inputOfArrayOfStrings(texts);

--- a/src/main/java/com/williamcallahan/javachat/service/OpenAiRequestFactory.java
+++ b/src/main/java/com/williamcallahan/javachat/service/OpenAiRequestFactory.java
@@ -2,8 +2,10 @@ package com.williamcallahan.javachat.service;
 
 import com.openai.models.Reasoning;
 import com.openai.models.ReasoningEffort;
+import com.openai.models.ResponseFormatJsonObject;
 import com.openai.models.ResponsesModel;
 import com.openai.models.responses.ResponseCreateParams;
+import com.openai.models.responses.ResponseTextConfig;
 import com.williamcallahan.javachat.application.prompt.PromptTruncator;
 import com.williamcallahan.javachat.domain.prompt.StructuredPrompt;
 import com.williamcallahan.javachat.support.AsciiTextNormalizer;
@@ -117,7 +119,7 @@ public class OpenAiRequestFactory {
      */
     public ResponseCreateParams buildCompletionRequest(
             String prompt, double temperature, RateLimitService.ApiProvider provider) {
-        return buildCompletionRequest(prompt, temperature, provider, null);
+        return buildCompletionRequest(prompt, temperature, provider, null, false);
     }
 
     /**
@@ -134,15 +136,36 @@ public class OpenAiRequestFactory {
         if (maximumOutputTokens <= 0) {
             throw new IllegalArgumentException("maximumOutputTokens must be positive");
         }
-        return buildCompletionRequest(prompt, temperature, provider, Integer.valueOf(maximumOutputTokens));
+        return buildCompletionRequest(prompt, temperature, provider, Integer.valueOf(maximumOutputTokens), false);
+    }
+
+    /**
+     * Builds completion request parameters that require a JSON object response.
+     *
+     * @param prompt completion prompt
+     * @param temperature response temperature
+     * @param provider provider chosen for this request attempt
+     * @param maximumOutputTokens maximum output tokens needed by this caller
+     * @return request payload with a declared JSON-object output contract
+     */
+    public ResponseCreateParams buildJsonCompletionRequest(
+            String prompt, double temperature, RateLimitService.ApiProvider provider, int maximumOutputTokens) {
+        if (maximumOutputTokens <= 0) {
+            throw new IllegalArgumentException("maximumOutputTokens must be positive");
+        }
+        return buildCompletionRequest(prompt, temperature, provider, Integer.valueOf(maximumOutputTokens), true);
     }
 
     private ResponseCreateParams buildCompletionRequest(
-            String prompt, double temperature, RateLimitService.ApiProvider provider, Integer maximumOutputTokens) {
+            String prompt,
+            double temperature,
+            RateLimitService.ApiProvider provider,
+            Integer maximumOutputTokens,
+            boolean requireJsonObject) {
         boolean useGitHubModels = provider == RateLimitService.ApiProvider.GITHUB_MODELS;
         String modelId = normalizedModelId(useGitHubModels);
         String truncatedPrompt = truncatePromptForCompletion(prompt, modelId, useGitHubModels);
-        return buildResponseParams(truncatedPrompt, temperature, modelId, maximumOutputTokens);
+        return buildResponseParams(truncatedPrompt, temperature, modelId, maximumOutputTokens, requireJsonObject);
     }
 
     private String truncatePromptForCompletion(String prompt, String modelId, boolean useGitHubModels) {
@@ -172,12 +195,27 @@ public class OpenAiRequestFactory {
 
     private ResponseCreateParams buildResponseParams(
             String prompt, double temperature, String normalizedModelId, Integer maximumOutputTokens) {
+        return buildResponseParams(prompt, temperature, normalizedModelId, maximumOutputTokens, false);
+    }
+
+    private ResponseCreateParams buildResponseParams(
+            String prompt,
+            double temperature,
+            String normalizedModelId,
+            Integer maximumOutputTokens,
+            boolean requireJsonObject) {
         boolean gpt5Family = isGpt5Family(normalizedModelId);
         boolean reasoningModel =
                 gpt5Family || canonicalModelName(normalizedModelId).startsWith("o");
 
         ResponseCreateParams.Builder builder =
                 ResponseCreateParams.builder().input(prompt).model(ResponsesModel.ofString(normalizedModelId));
+
+        if (requireJsonObject) {
+            builder.text(ResponseTextConfig.builder()
+                    .format(ResponseFormatJsonObject.builder().build())
+                    .build());
+        }
 
         if (maximumOutputTokens != null) {
             builder.maxOutputTokens(maximumOutputTokens.longValue());

--- a/src/main/java/com/williamcallahan/javachat/service/RerankerService.java
+++ b/src/main/java/com/williamcallahan/javachat/service/RerankerService.java
@@ -124,6 +124,12 @@ public class RerankerService {
         prompt.append("Consider Java-specific context, version relevance, and learning value.\n");
         prompt.append("Prefer official documentation over blogs or third-party sources.\n");
         prompt.append("Prefer stable release documentation over early-access or preview content.\n");
+        prompt.append("There are exactly ")
+                .append(documents.size())
+                .append(" documents. Valid indices are 0 through ")
+                .append(documents.size() - 1)
+                .append(".\n");
+        prompt.append("Include each valid index exactly once and do not return any other values.\n");
         prompt.append("Return only JSON: {\"order\":[indices...]} with 0-based indices.\n");
         prompt.append("Do not include markdown, prose, or explanations.\n\n");
         prompt.append("Query: ").append(query).append("\n\n");

--- a/src/main/java/com/williamcallahan/javachat/service/RerankerService.java
+++ b/src/main/java/com/williamcallahan/javachat/service/RerankerService.java
@@ -103,7 +103,7 @@ public class RerankerService {
 
         try {
             return openAIStreamingService
-                    .complete(prompt, 0.0, RERANKER_OUTPUT_TOKEN_BUDGET)
+                    .completeJsonObject(prompt, 0.0, RERANKER_OUTPUT_TOKEN_BUDGET)
                     .timeout(rerankerTimeout)
                     .doOnError(
                             timeoutOrApiError -> log.debug("Reranker LLM call timed out or failed", timeoutOrApiError))

--- a/src/main/java/com/williamcallahan/javachat/service/RerankerService.java
+++ b/src/main/java/com/williamcallahan/javachat/service/RerankerService.java
@@ -32,8 +32,8 @@ public class RerankerService {
     /** Maximum character length of document text included in the rerank prompt. */
     private static final int RERANK_PROMPT_TEXT_MAX_LENGTH = 500;
 
-    /** Output budget for the small JSON ordering the reranker requires. */
-    private static final int RERANKER_OUTPUT_TOKEN_BUDGET = 128;
+    /** Output budget including hidden reasoning before the small JSON ordering. */
+    private static final int RERANKER_OUTPUT_TOKEN_BUDGET = 512;
 
     private final OpenAIStreamingService openAIStreamingService;
     private final ObjectMapper mapper;

--- a/src/main/java/com/williamcallahan/javachat/web/CustomErrorController.java
+++ b/src/main/java/com/williamcallahan/javachat/web/CustomErrorController.java
@@ -26,6 +26,7 @@ import org.springframework.web.servlet.ModelAndView;
 public class CustomErrorController implements ErrorController {
 
     private static final Logger log = LoggerFactory.getLogger(CustomErrorController.class);
+    private static final int MAX_LOG_FIELD_LENGTH = 512;
     private static final String ERROR_PATH = "/error";
     private static final String ERROR_VIEW_ACCESS_DENIED = "forward:/errors/access-denied";
     private static final String ERROR_VIEW_AUTH_REQUIRED = "forward:/errors/authentication-required";
@@ -81,14 +82,9 @@ public class CustomErrorController implements ErrorController {
         String errorMessage = message != null ? message.toString() : "An unexpected error occurred";
         String uri = requestUri != null ? requestUri.toString() : request.getRequestURI();
 
-        // Log the error for monitoring without echoing request-derived strings
-        log.error("Error {} occurred while handling request", statusCode);
-        if (exception instanceof Exception exceptionInstance) {
-            log.error("Exception type: {}", exceptionInstance.getClass().getSimpleName());
-        }
-
         // Determine if this is an API request or a page request
         boolean isApiRequest = uri.equals("/api") || uri.startsWith("/api/");
+        logRequestFailure(request, statusCode, uri, isApiRequest, exception);
 
         if (isApiRequest) {
             // Return JSON error response for API requests
@@ -97,6 +93,52 @@ public class CustomErrorController implements ErrorController {
             // Return HTML error page for browser requests
             return handlePageError(statusCode, resolveUserFacingMessage(statusCode), uri, model);
         }
+    }
+
+    private void logRequestFailure(
+            HttpServletRequest request, int statusCode, String uri, boolean apiRequest, Object exception) {
+        String method = safeLogField(request.getMethod());
+        String canonicalUri = safeLogField(uri.split("[?#]", 2)[0]);
+        String serverHost = safeLogField(request.getServerName());
+        String userAgent = safeLogField(request.getHeader("User-Agent"));
+        String requestId = safeLogField(request.getRequestId());
+        String source = safeLogField(request.getAttribute(RequestDispatcher.ERROR_SERVLET_NAME));
+        String diagnostic = "Request failed status={} source={} method={} uri={} host={} userAgent={} requestId={}";
+
+        if (statusCode >= HttpStatus.INTERNAL_SERVER_ERROR.value()) {
+            if (exception instanceof Exception exceptionInstance) {
+                log.error(
+                        diagnostic,
+                        statusCode,
+                        source,
+                        method,
+                        canonicalUri,
+                        serverHost,
+                        userAgent,
+                        requestId,
+                        exceptionInstance);
+            } else {
+                log.error(diagnostic, statusCode, source, method, canonicalUri, serverHost, userAgent, requestId);
+            }
+        } else if (statusCode == HttpStatus.NOT_FOUND.value() && apiRequest) {
+            log.warn(diagnostic, statusCode, source, method, canonicalUri, serverHost, userAgent, requestId);
+        } else {
+            log.info(diagnostic, statusCode, source, method, canonicalUri, serverHost, userAgent, requestId);
+        }
+    }
+
+    private String safeLogField(Object requestField) {
+        if (requestField == null) {
+            return "unknown";
+        }
+        String logField = requestField.toString();
+        int boundedLength = Math.min(logField.length(), MAX_LOG_FIELD_LENGTH);
+        StringBuilder safeField = new StringBuilder(boundedLength);
+        for (int index = 0; index < boundedLength; index++) {
+            char character = logField.charAt(index);
+            safeField.append(Character.isISOControl(character) ? '?' : character);
+        }
+        return safeField.toString();
     }
 
     /**

--- a/src/test/java/com/williamcallahan/javachat/JavaChatApplicationTests.java
+++ b/src/test/java/com/williamcallahan/javachat/JavaChatApplicationTests.java
@@ -3,6 +3,7 @@ package com.williamcallahan.javachat;
 import com.williamcallahan.javachat.service.EmbeddingClient;
 import io.qdrant.client.QdrantClient;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -23,7 +24,7 @@ class JavaChatApplicationTests {
     @MockitoBean
     ChatModel chatModel;
 
-    @MockitoBean
+    @MockitoBean(answers = Answers.RETURNS_MOCKS)
     EmbeddingClient embeddingClient;
 
     @MockitoBean

--- a/src/test/java/com/williamcallahan/javachat/service/EmbeddingModelKeepAliveTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/EmbeddingModelKeepAliveTest.java
@@ -1,38 +1,147 @@
 package com.williamcallahan.javachat.service;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.util.ArrayDeque;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.actuate.health.Status;
 
 /**
- * Verifies the keep-alive probe contacts the embedding provider and treats provider
- * unavailability as a logged monitoring signal rather than a propagated failure.
+ * Verifies that embedding probes expose readiness and classify lifecycle events without warning storms.
  */
 class EmbeddingModelKeepAliveTest {
+    private final Logger lifecycleLogger = (Logger) LoggerFactory.getLogger(EmbeddingModelKeepAlive.class);
+    private final ListAppender<ILoggingEvent> lifecycleEvents = new ListAppender<>();
+    private boolean lifecycleLoggerAdditive;
 
-    @Test
-    void keepEmbeddingModelWarmProbesTheEmbeddingProvider() {
-        RecordingEmbeddingClient recordingEmbeddingClient = new RecordingEmbeddingClient();
+    @BeforeEach
+    void captureLifecycleEvents() {
+        lifecycleLoggerAdditive = lifecycleLogger.isAdditive();
+        lifecycleLogger.setAdditive(false);
+        lifecycleEvents.start();
+        lifecycleLogger.addAppender(lifecycleEvents);
+    }
 
-        new EmbeddingModelKeepAlive(recordingEmbeddingClient).keepEmbeddingModelWarm();
-
-        assertEquals(1, recordingEmbeddingClient.warmUpInvocationCount);
+    @AfterEach
+    void stopCapturingLifecycleEvents() {
+        lifecycleLogger.detachAppender(lifecycleEvents);
+        lifecycleLogger.setAdditive(lifecycleLoggerAdditive);
+        lifecycleEvents.stop();
     }
 
     @Test
-    void keepEmbeddingModelWarmDoesNotPropagateProviderUnavailability() {
-        EmbeddingModelKeepAlive keepAlive = new EmbeddingModelKeepAlive(new UnavailableEmbeddingClient());
+    void successfulProbeMakesEmbeddingHealthReady() {
+        SequencedEmbeddingClient embeddingClient = new SequencedEmbeddingClient(ProbeOutcome.SUCCESS);
+        EmbeddingModelKeepAlive keepAlive = new EmbeddingModelKeepAlive(embeddingClient, new SequencedNanoTime(100));
 
-        assertDoesNotThrow(keepAlive::keepEmbeddingModelWarm);
+        assertEquals(Status.DOWN, keepAlive.health().getStatus());
+
+        keepAlive.keepEmbeddingModelWarm();
+
+        assertEquals(1, embeddingClient.warmUpInvocationCount);
+        assertEquals(Status.UP, keepAlive.health().getStatus());
+        assertEquals("test-embedding-model", keepAlive.health().getDetails().get("model"));
+        assertEquals(1, eventCount(Level.INFO, "event=embedding_model_probe_ready"));
+
+        keepAlive.retryUnavailableEmbeddingModel();
+
+        assertEquals(1, embeddingClient.warmUpInvocationCount);
     }
 
-    /**
-     * Records scheduled warm-up calls without allowing pipeline embedding calls.
-     */
-    private static final class RecordingEmbeddingClient implements EmbeddingClient {
+    @Test
+    void repeatedSlowProbesWarnOnceAndRecoveryIsRecorded() {
+        SequencedEmbeddingClient embeddingClient = new SequencedEmbeddingClient(
+                ProbeOutcome.SUCCESS, ProbeOutcome.SUCCESS, ProbeOutcome.SUCCESS, ProbeOutcome.SUCCESS);
+        EmbeddingModelKeepAlive keepAlive =
+                new EmbeddingModelKeepAlive(embeddingClient, new SequencedNanoTime(6_001, 6_002, 6_003, 100));
+
+        keepAlive.keepEmbeddingModelWarm();
+        keepAlive.keepEmbeddingModelWarm();
+        keepAlive.keepEmbeddingModelWarm();
+        keepAlive.keepEmbeddingModelWarm();
+
+        assertEquals(Status.UP, keepAlive.health().getStatus());
+        assertEquals(1, eventCount(Level.INFO, "event=embedding_model_probe_slow"));
+        assertEquals(1, eventCount(Level.WARN, "event=embedding_model_probe_slow_loop"));
+        assertEquals(1, eventCount(Level.INFO, "event=embedding_model_probe_recovered"));
+        assertTrue(lifecycleEvents.list.stream()
+                .noneMatch(loggingEvent -> loggingEvent.getFormattedMessage().contains("cold and has been reloaded")));
+    }
+
+    @Test
+    void repeatedFailuresEscalateOnceAndRecoveryRestoresHealth() {
+        SequencedEmbeddingClient embeddingClient = new SequencedEmbeddingClient(
+                ProbeOutcome.UNAVAILABLE, ProbeOutcome.UNAVAILABLE, ProbeOutcome.UNAVAILABLE, ProbeOutcome.SUCCESS);
+        EmbeddingModelKeepAlive keepAlive =
+                new EmbeddingModelKeepAlive(embeddingClient, new SequencedNanoTime(10, 20, 30, 6_000));
+
+        keepAlive.keepEmbeddingModelWarm();
+        keepAlive.keepEmbeddingModelWarm();
+        keepAlive.keepEmbeddingModelWarm();
+
+        assertEquals(Status.DOWN, keepAlive.health().getStatus());
+        assertEquals(1, eventCount(Level.WARN, "event=embedding_model_probe_failed"));
+        assertEquals(1, eventCount(Level.ERROR, "event=embedding_model_probe_failure_loop"));
+
+        keepAlive.retryUnavailableEmbeddingModel();
+
+        assertEquals(Status.UP, keepAlive.health().getStatus());
+        assertEquals(1, eventCount(Level.INFO, "event=embedding_model_probe_recovered"));
+    }
+
+    @Test
+    void unexpectedProbeFailureMarksHealthDownAndPropagates() {
+        SequencedEmbeddingClient embeddingClient =
+                new SequencedEmbeddingClient(ProbeOutcome.SUCCESS, ProbeOutcome.UNEXPECTED);
+        EmbeddingModelKeepAlive keepAlive =
+                new EmbeddingModelKeepAlive(embeddingClient, new SequencedNanoTime(100, 10));
+
+        keepAlive.keepEmbeddingModelWarm();
+
+        assertEquals(Status.UP, keepAlive.health().getStatus());
+
+        assertThrows(IllegalStateException.class, keepAlive::keepEmbeddingModelWarm);
+
+        assertEquals(Status.DOWN, keepAlive.health().getStatus());
+        assertEquals(1, eventCount(Level.WARN, "event=embedding_model_probe_failed"));
+    }
+
+    private long eventCount(Level level, String eventName) {
+        return lifecycleEvents.list.stream()
+                .filter(loggingEvent -> loggingEvent.getLevel().equals(level))
+                .filter(loggingEvent -> loggingEvent.getFormattedMessage().contains(eventName))
+                .count();
+    }
+
+    /** Controls the provider outcome returned by a test probe. */
+    private enum ProbeOutcome {
+        SUCCESS,
+        UNAVAILABLE,
+        UNEXPECTED
+    }
+
+    /** Provides deterministic embedding outcomes without making network calls. */
+    private static final class SequencedEmbeddingClient implements EmbeddingClient {
+        private final Queue<ProbeOutcome> probeOutcome;
         private int warmUpInvocationCount;
+
+        private SequencedEmbeddingClient(ProbeOutcome... probeOutcome) {
+            this.probeOutcome = new ArrayDeque<>(Arrays.asList(probeOutcome));
+        }
 
         @Override
         public List<float[]> embed(List<String> texts, LlmGatewayTier requestTier) {
@@ -40,8 +149,18 @@ class EmbeddingModelKeepAliveTest {
         }
 
         @Override
+        public String modelName() {
+            return "test-embedding-model";
+        }
+
+        @Override
         public void warmUp() {
             warmUpInvocationCount++;
+            switch (probeOutcome.remove()) {
+                case SUCCESS -> {}
+                case UNAVAILABLE -> throw new EmbeddingServiceUnavailableException("provider offline for test");
+                case UNEXPECTED -> throw new IllegalStateException("unexpected provider defect");
+            }
         }
 
         @Override
@@ -50,23 +169,25 @@ class EmbeddingModelKeepAliveTest {
         }
     }
 
-    /**
-     * Simulates a provider that is unavailable during scheduled warm-up.
-     */
-    private static final class UnavailableEmbeddingClient implements EmbeddingClient {
-        @Override
-        public List<float[]> embed(List<String> texts, LlmGatewayTier requestTier) {
-            throw new EmbeddingServiceUnavailableException("provider offline for test");
+    /** Supplies deterministic monotonic timestamps for probe duration tests. */
+    private static final class SequencedNanoTime implements LongSupplier {
+        private static final long GAP_BETWEEN_PROBES_MILLIS = 1_000L;
+        private final Queue<Long> nanoTime;
+
+        private SequencedNanoTime(long... probeDurationMillis) {
+            nanoTime = new ArrayDeque<>();
+            long probeStartNanos = 0;
+            for (long probeDurationMillisValue : probeDurationMillis) {
+                nanoTime.add(probeStartNanos);
+                probeStartNanos += TimeUnit.MILLISECONDS.toNanos(probeDurationMillisValue);
+                nanoTime.add(probeStartNanos);
+                probeStartNanos += TimeUnit.MILLISECONDS.toNanos(GAP_BETWEEN_PROBES_MILLIS);
+            }
         }
 
         @Override
-        public void warmUp() {
-            throw new EmbeddingServiceUnavailableException("provider offline for test");
-        }
-
-        @Override
-        public int dimensions() {
-            return 1;
+        public long getAsLong() {
+            return nanoTime.remove();
         }
     }
 }

--- a/src/test/java/com/williamcallahan/javachat/service/OpenAiRequestFactoryTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/OpenAiRequestFactoryTest.java
@@ -61,6 +61,19 @@ class OpenAiRequestFactoryTest {
     }
 
     @Test
+    void buildJsonCompletionRequestDeclaresJsonObjectOutput() {
+        OpenAiRequestFactory requestFactory =
+                new OpenAiRequestFactory(new Chunker(), new PromptTruncator(), "gemma-4-26b-a4b", "openai/gpt-5", "");
+
+        ResponseCreateParams responseCreateParams = requestFactory.buildJsonCompletionRequest(
+                "Rank these documents", 0.0, RateLimitService.ApiProvider.OPENAI, 128);
+
+        assertTrue(
+                responseCreateParams.text().orElseThrow().format().orElseThrow().isJsonObject());
+        assertEquals(128L, responseCreateParams.maxOutputTokens().orElseThrow());
+    }
+
+    @Test
     void buildCompletionRequestKeepsPromptWithinSelectedOpenAiModelLimit() {
         OpenAiRequestFactory requestFactory =
                 new OpenAiRequestFactory(new Chunker(), new PromptTruncator(), "gpt-4o", "openai/gpt-5", "");

--- a/src/test/java/com/williamcallahan/javachat/service/RerankerServiceTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/RerankerServiceTest.java
@@ -2,6 +2,7 @@ package com.williamcallahan.javachat.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.eq;
@@ -48,9 +49,12 @@ class RerankerServiceTest {
 
         List<Document> rankedDocuments = rerankerService.rerank("query", sourceDocuments, 2);
 
+        ArgumentCaptor<String> promptCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<Integer> outputBudgetCaptor = ArgumentCaptor.forClass(Integer.class);
-        verify(streamingService).completeJsonObject(anyString(), eq(0.0), outputBudgetCaptor.capture());
+        verify(streamingService).completeJsonObject(promptCaptor.capture(), eq(0.0), outputBudgetCaptor.capture());
         verify(streamingService, never()).complete(anyString(), eq(0.0));
+        assertTrue(promptCaptor.getValue().contains("Valid indices are 0 through 1."));
+        assertTrue(promptCaptor.getValue().contains("Include each valid index exactly once"));
         assertEquals(512, outputBudgetCaptor.getValue());
         assertEquals(sourceDocuments.get(1), rankedDocuments.get(0));
     }

--- a/src/test/java/com/williamcallahan/javachat/service/RerankerServiceTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/RerankerServiceTest.java
@@ -39,7 +39,8 @@ class RerankerServiceTest {
     void rerankUsesBoundedCompletionBudget() {
         OpenAIStreamingService streamingService = mock(OpenAIStreamingService.class);
         when(streamingService.isAvailable()).thenReturn(true);
-        when(streamingService.complete(anyString(), eq(0.0), anyInt())).thenReturn(Mono.just("{\"order\":[1,0]}"));
+        when(streamingService.completeJsonObject(anyString(), eq(0.0), anyInt()))
+                .thenReturn(Mono.just("{\"order\":[1,0]}"));
 
         RerankerService rerankerService =
                 new RerankerService(streamingService, new ObjectMapper(), new AppProperties());
@@ -48,7 +49,7 @@ class RerankerServiceTest {
         List<Document> rankedDocuments = rerankerService.rerank("query", sourceDocuments, 2);
 
         ArgumentCaptor<Integer> outputBudgetCaptor = ArgumentCaptor.forClass(Integer.class);
-        verify(streamingService).complete(anyString(), eq(0.0), outputBudgetCaptor.capture());
+        verify(streamingService).completeJsonObject(anyString(), eq(0.0), outputBudgetCaptor.capture());
         verify(streamingService, never()).complete(anyString(), eq(0.0));
         assertEquals(128, outputBudgetCaptor.getValue());
         assertEquals(sourceDocuments.get(1), rankedDocuments.get(0));

--- a/src/test/java/com/williamcallahan/javachat/service/RerankerServiceTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/RerankerServiceTest.java
@@ -51,7 +51,7 @@ class RerankerServiceTest {
         ArgumentCaptor<Integer> outputBudgetCaptor = ArgumentCaptor.forClass(Integer.class);
         verify(streamingService).completeJsonObject(anyString(), eq(0.0), outputBudgetCaptor.capture());
         verify(streamingService, never()).complete(anyString(), eq(0.0));
-        assertEquals(128, outputBudgetCaptor.getValue());
+        assertEquals(512, outputBudgetCaptor.getValue());
         assertEquals(sourceDocuments.get(1), rankedDocuments.get(0));
     }
 }

--- a/src/test/java/com/williamcallahan/javachat/web/ChatSseIntegrationTest.java
+++ b/src/test/java/com/williamcallahan/javachat/web/ChatSseIntegrationTest.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -30,7 +31,7 @@ class ChatSseIntegrationTest {
     @Autowired
     WebTestClient webTestClient;
 
-    @MockitoBean
+    @MockitoBean(answers = Answers.RETURNS_MOCKS)
     EmbeddingClient embeddingClient;
 
     @MockitoBean

--- a/src/test/java/com/williamcallahan/javachat/web/CustomErrorControllerTest.java
+++ b/src/test/java/com/williamcallahan/javachat/web/CustomErrorControllerTest.java
@@ -1,0 +1,117 @@
+package com.williamcallahan.javachat.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.williamcallahan.javachat.domain.errors.ApiErrorResponse;
+import jakarta.servlet.RequestDispatcher;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/** Verifies error diagnostics retain request attribution without exposing query data. */
+@WebMvcTest(controllers = CustomErrorController.class)
+@Import(com.williamcallahan.javachat.config.AppProperties.class)
+@WithMockUser
+class CustomErrorControllerTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @MockitoBean
+    ExceptionResponseBuilder exceptionBuilder;
+
+    private final Logger controllerLogger = (Logger) LoggerFactory.getLogger(CustomErrorController.class);
+    private final ListAppender<ILoggingEvent> logAppender = new ListAppender<>();
+
+    @BeforeEach
+    void captureControllerLogs() {
+        logAppender.start();
+        controllerLogger.addAppender(logAppender);
+    }
+
+    @AfterEach
+    void stopCapturingControllerLogs() {
+        controllerLogger.detachAppender(logAppender);
+        logAppender.stop();
+        logAppender.list.clear();
+    }
+
+    @Test
+    void logs_non_api_not_found_at_info_with_safe_request_metadata() throws Exception {
+        mvc.perform(errorRequest(HttpStatus.NOT_FOUND, "/missing.js?token=secret")
+                        .header("User-Agent", "browser")
+                        .requestAttr(RequestDispatcher.ERROR_SERVLET_NAME, "default\r\nServlet"))
+                .andExpect(status().isNotFound());
+
+        ILoggingEvent event = onlyLogEvent();
+        assertEquals(Level.INFO, event.getLevel());
+        assertTrue(event.getFormattedMessage().contains("status=404 source=default??Servlet method=GET"));
+        assertTrue(event.getFormattedMessage().contains("uri=/missing.js host=localhost"));
+        assertTrue(event.getFormattedMessage().contains("userAgent=browser requestId="));
+        assertFalse(event.getFormattedMessage().contains("secret"));
+        assertNull(event.getThrowableProxy());
+    }
+
+    @Test
+    void logs_unknown_api_path_at_warn() throws Exception {
+        when(exceptionBuilder.buildErrorResponse(HttpStatus.NOT_FOUND, "Missing"))
+                .thenReturn(ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiErrorResponse.error("Missing")));
+
+        mvc.perform(errorRequest(HttpStatus.NOT_FOUND, "/api/unknown")
+                        .requestAttr(RequestDispatcher.ERROR_SERVLET_NAME, "dispatcherServlet"))
+                .andExpect(status().isNotFound());
+
+        ILoggingEvent event = onlyLogEvent();
+        assertEquals(Level.WARN, event.getLevel());
+        assertTrue(event.getFormattedMessage().contains("status=404 source=dispatcherServlet method=GET"));
+        assertTrue(event.getFormattedMessage().contains("uri=/api/unknown host=localhost"));
+    }
+
+    @Test
+    void logs_server_error_at_error_with_exception() throws Exception {
+        IllegalStateException failure = new IllegalStateException("dependency failed");
+
+        mvc.perform(errorRequest(HttpStatus.INTERNAL_SERVER_ERROR, "/chat")
+                        .requestAttr(RequestDispatcher.ERROR_EXCEPTION, failure)
+                        .requestAttr(RequestDispatcher.ERROR_SERVLET_NAME, "dispatcherServlet"))
+                .andExpect(status().isInternalServerError());
+
+        ILoggingEvent event = onlyLogEvent();
+        assertEquals(Level.ERROR, event.getLevel());
+        assertEquals(failure.getClass().getName(), event.getThrowableProxy().getClassName());
+    }
+
+    private org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder errorRequest(
+            HttpStatus status, String uri) {
+        return get("/error")
+                .requestAttr(RequestDispatcher.ERROR_STATUS_CODE, status.value())
+                .requestAttr(RequestDispatcher.ERROR_MESSAGE, status == HttpStatus.NOT_FOUND ? "Missing" : "Failure")
+                .requestAttr(RequestDispatcher.ERROR_REQUEST_URI, uri);
+    }
+
+    private ILoggingEvent onlyLogEvent() {
+        List<ILoggingEvent> events = logAppender.list;
+        assertEquals(1, events.size());
+        return events.getFirst();
+    }
+}

--- a/src/test/java/com/williamcallahan/javachat/web/GuidedSseIntegrationTest.java
+++ b/src/test/java/com/williamcallahan/javachat/web/GuidedSseIntegrationTest.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -30,7 +31,7 @@ class GuidedSseIntegrationTest {
     @Autowired
     WebTestClient webTestClient;
 
-    @MockitoBean
+    @MockitoBean(answers = Answers.RETURNS_MOCKS)
     EmbeddingClient embeddingClient;
 
     @MockitoBean


### PR DESCRIPTION
## Summary

Java Chat dev routes user-facing chat through the shared gateway's regular Gemma alias while preserving its separate Qwen embedding provider path. The branch also hardens reranking output, embedding-provider health and recovery, request-failure attribution, and enabled live-test startup.

## Changes

- **Shared Gemma routing**: Gateway setups explicitly select the OpenAI-compatible provider and use the regular `gemma-4-26b-a4b` alias, which may fail over across configured gateway providers (`.env.example`, `docs/configuration.md`).
- **Independent embeddings**: Chat gateway settings do not change the explicit Qwen embedding provider, model, or base URL (`EmbeddingClient`, `LocalEmbeddingClient`, `OpenAiCompatibleEmbeddingClient`).
- **Bounded structured reranking**: Reranker completions require a JSON object, receive enough output budget for hidden reasoning, and constrain document indices to the supplied candidates (`OpenAiRequestFactory`, `OpenAIStreamingService`, `RerankerService`).
- **Observable embedding recovery**: Probes report initializing, ready, slow, and unavailable states through Actuator health, with prompt retries after provider outages (`EmbeddingModelKeepAlive`).
- **Attributed request failures**: API and page failures log bounded, sanitized request metadata with severity appropriate to the failure (`CustomErrorController`).
- **Constructible live-test contexts**: Chat and guided SSE integration contexts satisfy the embedding model-name contract before Spring creates the keep-alive bean (`ChatSseIntegrationTest`, `GuidedSseIntegrationTest`).

## Verification

- Repository pre-push build, 261-test suite, and lint gates passed.
- PR head is pushed to `origin/dev`.
- 17 files changed across 11 focused commits.
- Live Java Chat dev prompt completed and rendered three Oracle JDK source links without browser errors.
- Live gateway checks passed for alias discovery, strict structured output, strict tool calling, and request correlation.

## Deployment notes

Pushing `dev` triggers the Java Chat dev deployment. User-facing chat uses `gemma-4-26b-a4b` through the shared gateway; embeddings remain on their existing explicit provider and model configuration.

Related investigation: aventurevc/back-end#1118
