### PR TITLE
fix(web): make request failures externally attributable

### DIFF
--- a/src/main/java/com/williamcallahan/javachat/web/CustomErrorController.java
+++ b/src/main/java/com/williamcallahan/javachat/web/CustomErrorController.java
@@ -4,6 +4,7 @@ import com.williamcallahan.javachat.domain.errors.ApiResponse;
 import jakarta.annotation.security.PermitAll;
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.web.servlet.error.ErrorController;
@@ -27,6 +28,7 @@ public class CustomErrorController implements ErrorController {
 
     private static final Logger log = LoggerFactory.getLogger(CustomErrorController.class);
     private static final int MAX_LOG_FIELD_LENGTH = 512;
+    private static final String REQUEST_ID_HEADER = "X-Request-ID";
     private static final String ERROR_PATH = "/error";
     private static final String ERROR_VIEW_ACCESS_DENIED = "forward:/errors/access-denied";
     private static final String ERROR_VIEW_AUTH_REQUIRED = "forward:/errors/authentication-required";
@@ -71,7 +73,7 @@ public class CustomErrorController implements ErrorController {
                 RequestMethod.HEAD,
                 RequestMethod.OPTIONS
             })
-    public Object handleError(HttpServletRequest request, Model model) {
+    public Object handleError(HttpServletRequest request, HttpServletResponse servletResponse, Model model) {
         // Get error details from request attributes
         Object status = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
         Object message = request.getAttribute(RequestDispatcher.ERROR_MESSAGE);
@@ -81,10 +83,12 @@ public class CustomErrorController implements ErrorController {
         int statusCode = status != null ? (Integer) status : 500;
         String errorMessage = message != null ? message.toString() : "An unexpected error occurred";
         String uri = requestUri != null ? requestUri.toString() : request.getRequestURI();
+        String requestId = request.getRequestId();
+        servletResponse.setHeader(REQUEST_ID_HEADER, requestId);
 
         // Determine if this is an API request or a page request
         boolean isApiRequest = uri.equals("/api") || uri.startsWith("/api/");
-        logRequestFailure(request, statusCode, uri, isApiRequest, exception);
+        logRequestFailure(request, statusCode, uri, isApiRequest, requestId, exception);
 
         if (isApiRequest) {
             // Return JSON error response for API requests
@@ -96,12 +100,17 @@ public class CustomErrorController implements ErrorController {
     }
 
     private void logRequestFailure(
-            HttpServletRequest request, int statusCode, String uri, boolean apiRequest, Object exception) {
+            HttpServletRequest request,
+            int statusCode,
+            String uri,
+            boolean apiRequest,
+            String requestId,
+            Object exception) {
         String method = safeLogField(request.getMethod());
         String canonicalUri = safeLogField(uri.split("[?#]", 2)[0]);
         String serverHost = safeLogField(request.getServerName());
         String userAgent = safeLogField(request.getHeader("User-Agent"));
-        String requestId = safeLogField(request.getRequestId());
+        String safeRequestId = safeLogField(requestId);
         String source = safeLogField(request.getAttribute(RequestDispatcher.ERROR_SERVLET_NAME));
         String diagnostic = "Request failed status={} source={} method={} uri={} host={} userAgent={} requestId={}";
 
@@ -115,15 +124,15 @@ public class CustomErrorController implements ErrorController {
                         canonicalUri,
                         serverHost,
                         userAgent,
-                        requestId,
+                        safeRequestId,
                         exceptionInstance);
             } else {
-                log.error(diagnostic, statusCode, source, method, canonicalUri, serverHost, userAgent, requestId);
+                log.error(diagnostic, statusCode, source, method, canonicalUri, serverHost, userAgent, safeRequestId);
             }
         } else if (statusCode == HttpStatus.NOT_FOUND.value() && apiRequest) {
-            log.warn(diagnostic, statusCode, source, method, canonicalUri, serverHost, userAgent, requestId);
+            log.warn(diagnostic, statusCode, source, method, canonicalUri, serverHost, userAgent, safeRequestId);
         } else {
-            log.info(diagnostic, statusCode, source, method, canonicalUri, serverHost, userAgent, requestId);
+            log.info(diagnostic, statusCode, source, method, canonicalUri, serverHost, userAgent, safeRequestId);
         }
     }
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <!-- Console appender with color coding -->
+    <!-- Plain console output keeps container log levels machine-detectable. -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %highlight(%-5level) %cyan(%logger{36}) - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/src/test/java/com/williamcallahan/javachat/web/CustomErrorControllerTest.java
+++ b/src/test/java/com/williamcallahan/javachat/web/CustomErrorControllerTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -12,7 +11,6 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
-import com.williamcallahan.javachat.domain.errors.ApiErrorResponse;
 import jakarta.servlet.RequestDispatcher;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
@@ -23,22 +21,23 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.ui.ExtendedModelMap;
 
 /** Verifies error diagnostics retain request attribution without exposing query data. */
 @WebMvcTest(controllers = CustomErrorController.class)
-@Import(com.williamcallahan.javachat.config.AppProperties.class)
+@Import({com.williamcallahan.javachat.config.AppProperties.class, ExceptionResponseBuilder.class})
 @WithMockUser
 class CustomErrorControllerTest {
 
     @Autowired
     MockMvc mvc;
 
-    @MockitoBean
-    ExceptionResponseBuilder exceptionBuilder;
+    @Autowired
+    CustomErrorController controller;
 
     private final Logger controllerLogger = (Logger) LoggerFactory.getLogger(CustomErrorController.class);
     private final ListAppender<ILoggingEvent> logAppender = new ListAppender<>();
@@ -74,9 +73,6 @@ class CustomErrorControllerTest {
 
     @Test
     void logs_unknown_api_path_at_warn() throws Exception {
-        when(exceptionBuilder.buildErrorResponse(HttpStatus.NOT_FOUND, "Missing"))
-                .thenReturn(ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiErrorResponse.error("Missing")));
-
         mvc.perform(errorRequest(HttpStatus.NOT_FOUND, "/api/unknown")
                         .requestAttr(RequestDispatcher.ERROR_SERVLET_NAME, "dispatcherServlet"))
                 .andExpect(status().isNotFound());
@@ -99,6 +95,54 @@ class CustomErrorControllerTest {
         ILoggingEvent event = onlyLogEvent();
         assertEquals(Level.ERROR, event.getLevel());
         assertEquals(failure.getClass().getName(), event.getThrowableProxy().getClassName());
+    }
+
+    @Test
+    void logs_server_error_without_exception_at_error() throws Exception {
+        mvc.perform(errorRequest(HttpStatus.INTERNAL_SERVER_ERROR, "/chat"))
+                .andExpect(status().isInternalServerError());
+
+        ILoggingEvent event = onlyLogEvent();
+        assertEquals(Level.ERROR, event.getLevel());
+        assertNull(event.getThrowableProxy());
+    }
+
+    @Test
+    void returns_the_same_non_empty_servlet_request_id_that_it_logs() {
+        String expectedRequestId = "servlet-request-123";
+        MockHttpServletRequest servletRequest = new MockHttpServletRequest() {
+            @Override
+            public String getRequestId() {
+                return expectedRequestId;
+            }
+        };
+        servletRequest.setMethod("PATCH");
+        servletRequest.setServerName("localhost");
+        servletRequest.addHeader("User-Agent", "browser");
+        servletRequest.setAttribute(RequestDispatcher.ERROR_STATUS_CODE, HttpStatus.NOT_FOUND.value());
+        servletRequest.setAttribute(RequestDispatcher.ERROR_MESSAGE, "Missing");
+        servletRequest.setAttribute(RequestDispatcher.ERROR_REQUEST_URI, "/api/unknown");
+        servletRequest.setAttribute(RequestDispatcher.ERROR_SERVLET_NAME, "dispatcherServlet");
+        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+
+        controller.handleError(servletRequest, servletResponse, new ExtendedModelMap());
+
+        assertEquals(expectedRequestId, servletResponse.getHeader("X-Request-ID"));
+        String message = onlyLogEvent().getFormattedMessage();
+        assertTrue(message.contains("method=PATCH uri=/api/unknown"));
+        assertTrue(message.contains("requestId=" + expectedRequestId));
+    }
+
+    @Test
+    void bounds_long_fields_and_marks_missing_fields_unknown() throws Exception {
+        String longUserAgent = "a".repeat(600);
+        mvc.perform(errorRequest(HttpStatus.NOT_FOUND, "/api/unknown").header("User-Agent", longUserAgent))
+                .andExpect(status().isNotFound());
+
+        String message = onlyLogEvent().getFormattedMessage();
+        assertTrue(message.contains("source=unknown"));
+        assertTrue(message.contains("userAgent=" + "a".repeat(512) + " requestId="));
+        assertFalse(message.contains("a".repeat(513)));
     }
 
     private org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder errorRequest(


### PR DESCRIPTION
## Summary

Java Chat now returns the same container-generated request ID recorded in error-dispatch logs, and container console output keeps severity machine-readable without ANSI escapes.

## Changes

- return `X-Request-ID` on HTML and API error dispatches
- preserve bounded, query-free request attribution and existing response behavior
- emit plain console severity for centralized log detection
- cover exact response/log correlation, field bounds, and exception-free server errors

## Verification

- targeted `CustomErrorControllerTest`: 6 passed
- Spotless Java check passed
- full pre-push build, 285-test suite, and lint gates passed
- development browser/API probes retained 404 behavior
- Loki recorded `java-chat-dev` with matching request IDs and detected WARN/INFO levels

Related to WilliamAGH/java-chat#66 and aventurevc/back-end#1118.