### PR TITLE
fix(runtime): reliable Gemma routing, streaming recovery, embeddings, and ingestion

### DIFF
--- a/docs/github-repository-ingestion.md
+++ b/docs/github-repository-ingestion.md
@@ -11,26 +11,14 @@ Java Chat supports GitHub source-code ingestion into dedicated hybrid Qdrant col
 
 ## Canonical repository identity
 
-Every repository is identified by canonical `owner/repository` (lowercase).
+The canonical owner for repository identity and collection-name validation is
+[`scripts/lib/github_identity.sh`](../scripts/lib/github_identity.sh), specifically
+`require_canonical_collection_name`.
 
-Derived values:
-
-- `repoKey`: `owner/repository`
-- `repoUrl`: `https://github.com/owner/repository`
-- canonical collection name:
-  - default: `github-owner-repository` (when owner/repo use only `[a-z0-9-]`)
-  - collision-safe encoded form with hash suffix for punctuation variants (for example underscores/dots)
-
-The ingestion pipeline stores this identity in payload metadata:
-
-- `repoKey`
-- `repoUrl`
-- `repoOwner`
-- `repoName`
-- `repoBranch`
-- `commitHash`
-
-`docSet` for GitHub source files is `github/owner/repository`.
+Every ingestion entrypoint asks that owner to validate the repository before processing. The result
+is one collection for each GitHub repository: local-clone, URL, and batch-sync ingestion reject a
+collection name that does not match the source repository. Ingested content retains the repository
+metadata required for incremental synchronization.
 
 ## Commands
 
@@ -83,9 +71,10 @@ SYNC_EXISTING=1 make process-github-repo
 Batch sync flow:
 
 1. Discover all Qdrant collections prefixed with `github-`.
-2. Read `repoUrl`/`repoKey` and `commitHash` payload metadata from each collection.
-3. Resolve remote HEAD commit (`git ls-remote <repoUrl> HEAD`).
-4. Reingest only collections where remote HEAD differs from stored `commitHash`.
+2. Read the source repository and indexed revision from each collection's payload metadata.
+3. Verify collection identity through `require_canonical_collection_name`.
+4. Resolve the source repository's remote HEAD commit.
+5. Reingest only collections whose source has changed.
 
 ## Incremental update behavior
 
@@ -135,10 +124,11 @@ Then the file is chunked and upserted again.
 
 ## Collection and payload indexes
 
-GitHub collections are created (if missing) with hybrid vector schema copied from reference collection (`java-docs` by default), then payload indexes are ensured for:
-
-- core fields: `url`, `hash`, `chunkIndex`, `docSet`, `docPath`, `sourceName`, `sourceKind`, `docVersion`, `docType`
-- GitHub fields: `filePath`, `language`, `repoUrl`, `repoOwner`, `repoName`, `repoKey`, `repoBranch`, `commitHash`, `license`, `repoDescription`
+The canonical GitHub payload-index inventory is owned by
+[`scripts/lib/github_identity.sh`](../scripts/lib/github_identity.sh), specifically
+`ensure_github_payload_indexes`. The pipeline creates a missing collection from the reference
+schema and asks that owner to ensure the canonical indexes before ingestion. This keeps GitHub
+collections consistently queryable while centralizing future index changes.
 
 ## Environment variables
 

--- a/frontend/src/lib/services/markdown.test.ts
+++ b/frontend/src/lib/services/markdown.test.ts
@@ -45,6 +45,43 @@ describe("parseMarkdown", () => {
     expect(renderedHtml).not.toContain("<p>}</p>");
   });
 
+  it("removes a stray close before the next valid enrichment marker", () => {
+    const markdown = "The explanation is complete. } {{example: Use try-with-resources.}}";
+    const renderedHtml = parseMarkdown(markdown);
+
+    expect(renderedHtml).toContain("The explanation is complete.");
+    expect(renderedHtml).toContain('data-enrichment-type="example"');
+    expect(renderedHtml).not.toContain("complete. }");
+    expect(renderedHtml).not.toContain("} {{example:");
+  });
+
+  it("preserves prose from a truncated final enrichment without leaking its marker", () => {
+    const markdown =
+      "Close the resource.\n\n{{warning: This also applies when an exception is thrown.";
+    const renderedHtml = parseMarkdown(markdown);
+
+    expect(renderedHtml).toContain("Close the resource.");
+    expect(renderedHtml).toContain("This also applies when an exception is thrown.");
+    expect(renderedHtml).not.toContain("{{");
+  });
+
+  it("recovers a valid nested marker from an unbalanced outer marker", () => {
+    const markdown = "{{hint: Start with the invariant. {{warning: Never ignore exceptions.}}";
+    const renderedHtml = parseMarkdown(markdown);
+
+    expect(renderedHtml).toContain("Start with the invariant.");
+    expect(renderedHtml).toContain('data-enrichment-type="warning"');
+    expect(renderedHtml).not.toContain("{{");
+  });
+
+  it("preserves marker-like text and ordinary braces inside fenced code", () => {
+    const markdown = '```java\nString template = "{{warning: literal";\nif (ready) { run(); }\n```';
+    const renderedHtml = parseMarkdown(markdown);
+
+    expect(renderedHtml).toContain("{{warning: literal");
+    expect(renderedHtml).toContain("if (ready) { run(); }");
+  });
+
   it("normalizes attached fenced code blocks with trailing prose", () => {
     const markdown = "Here's an example:```java\nint x = 10 % 3;\n```The result is 1.";
     const renderedHtml = parseMarkdown(markdown);

--- a/frontend/src/lib/services/markdown.ts
+++ b/frontend/src/lib/services/markdown.ts
@@ -33,7 +33,10 @@ interface EnrichmentToken extends Tokens.Generic {
   raw: string;
   kind: string;
   content: string;
+  resolved: boolean;
 }
+
+type EnrichmentOpening = { kind: string; length: number };
 
 /** Pattern matching code fence delimiters (3+ backticks or tildes at line start). */
 const FENCE_PATTERN = /^[ \t]*(`{3,}|~{3,})/;
@@ -206,6 +209,34 @@ function hasBalancedCodeFences(content: string): boolean {
 /** Enrichment close marker. */
 const ENRICHMENT_CLOSE = "}}";
 
+function readEnrichmentOpening(src: string, index: number): EnrichmentOpening | null {
+  for (const kind of Object.keys(ENRICHMENT_KINDS)) {
+    const opening = `{{${kind}:`;
+    if (src.startsWith(opening, index)) {
+      return { kind, length: opening.length };
+    }
+  }
+  return null;
+}
+
+function findEnrichmentStart(src: string): number {
+  let openingIndex = -1;
+  for (const kind of Object.keys(ENRICHMENT_KINDS)) {
+    const candidateIndex = src.indexOf(`{{${kind}:`);
+    if (candidateIndex >= 0 && (openingIndex < 0 || candidateIndex < openingIndex)) {
+      openingIndex = candidateIndex;
+    }
+  }
+
+  let precedingIndex = openingIndex - 1;
+  while (precedingIndex >= 0 && " \t\r\n".includes(src[precedingIndex])) {
+    precedingIndex--;
+  }
+  return src[precedingIndex] === "}" && src[precedingIndex - 1] !== "}"
+    ? precedingIndex
+    : openingIndex;
+}
+
 /**
  * Resolves the close marker position for a run of closing braces.
  * For runs like "}}}", this picks the final "}}" so a trailing content "}" is preserved.
@@ -221,10 +252,7 @@ function resolveCloseIndexFromBraceRun(src: string, runStart: number): number {
   return runStart + (runLength - ENRICHMENT_CLOSE.length);
 }
 
-/**
- * Finds the closing }} for an enrichment marker, skipping }} inside code fences.
- * Scans character-by-character, tracking fence state at line boundaries.
- */
+/** Finds the closing }} while rejecting unresolved nesting and fenced-code braces. */
 function findEnrichmentClose(src: string, startIndex: number): number {
   let inFence = false;
   let fenceChar = "";
@@ -250,7 +278,10 @@ function findEnrichmentClose(src: string, startIndex: number): number {
       }
     }
 
-    // Check for closing marker only outside fences
+    if (!inFence && readEnrichmentOpening(src, cursor)) {
+      return -1;
+    }
+
     if (!inFence && src[cursor] === "}") {
       const closeIndex = resolveCloseIndexFromBraceRun(src, cursor);
       if (closeIndex >= 0) {
@@ -271,38 +302,49 @@ function createEnrichmentExtension(): TokenizerExtension & RendererExtension {
     name: "enrichment",
     level: "block",
     start(src: string) {
-      return src.indexOf("{{");
+      return findEnrichmentStart(src);
     },
     tokenizer(src: string): EnrichmentToken | undefined {
-      // Match opening {{kind: pattern
-      const openingRule = /^\{\{(hint|warning|background|example|reminder):/;
-      const openingMatch = openingRule.exec(src);
-      if (!openingMatch) {
+      if (src[0] === "}") {
+        return { type: "enrichment", raw: "}", kind: "", content: "", resolved: false };
+      }
+
+      const opening = readEnrichmentOpening(src, 0);
+      if (!opening) {
         return undefined;
       }
 
-      const kind = openingMatch[1].toLowerCase();
-      const contentStart = openingMatch[0].length;
+      const contentStart = opening.length;
 
-      // Find closing }} that's not inside a code fence
       const closeIndex = findEnrichmentClose(src, contentStart);
       if (closeIndex === -1) {
-        return undefined;
+        return {
+          type: "enrichment",
+          raw: src.slice(0, contentStart),
+          kind: opening.kind,
+          content: "",
+          resolved: false,
+        };
       }
 
       const content = src.slice(contentStart, closeIndex);
-      const raw = src.slice(0, closeIndex + 2);
+      const raw = src.slice(0, closeIndex + ENRICHMENT_CLOSE.length);
 
       return {
         type: "enrichment",
         raw,
-        kind,
+        kind: opening.kind,
         content: content.trim(),
+        resolved: true,
       };
     },
     renderer(token: Tokens.Generic): string {
       if (token.type !== "enrichment") {
         return token.raw;
+      }
+
+      if (token.resolved !== true) {
+        return "";
       }
 
       const kind = typeof token.kind === "string" ? token.kind : "";

--- a/scripts/lib/common_qdrant.sh
+++ b/scripts/lib/common_qdrant.sh
@@ -179,6 +179,36 @@ locate_app_jar() {
     echo "$jar_path"
 }
 
+# Copies a runnable JAR into a private directory and removes write access so a
+# later build cannot change the archive used by a running JVM.
+#
+# Arguments:
+#   $1 - source JAR path
+#   $2 - empty staging directory owned by the caller
+stage_app_jar() {
+    local source_jar_path="$1"
+    local staging_directory="$2"
+    local staged_jar_path="$staging_directory/application.jar"
+
+    if [ ! -f "$source_jar_path" ]; then
+        echo -e "${RED}Runnable jar does not exist: $source_jar_path${NC}" >&2
+        return 1
+    fi
+    if [ ! -d "$staging_directory" ]; then
+        echo -e "${RED}JAR staging directory does not exist: $staging_directory${NC}" >&2
+        return 1
+    fi
+
+    cp "$source_jar_path" "$staged_jar_path"
+    if ! jar tf "$staged_jar_path" >/dev/null; then
+        echo -e "${RED}Staged runnable jar is not a valid archive: $staged_jar_path${NC}" >&2
+        return 1
+    fi
+    chmod 0444 "$staged_jar_path"
+    chmod 0555 "$staging_directory"
+    echo "$staged_jar_path"
+}
+
 # Manages PID file lifecycle: kills any existing process, registers cleanup trap.
 # Sets APP_PID to empty initially; the caller must set it after launching the Java process.
 #

--- a/scripts/lib/github_identity.sh
+++ b/scripts/lib/github_identity.sh
@@ -112,7 +112,23 @@ extract_repository_identity() {
         exit 1
     fi
 
-    CANONICAL_COLLECTION_NAME="github-${encoded_owner_segment}-${encoded_name_segment}"
+    local repository_boundary="-"
+    if [[ ! "$REPOSITORY_OWNER" =~ ^[a-z0-9]+$ ]]; then
+        repository_boundary="_"
+    fi
+    CANONICAL_COLLECTION_NAME="github-${encoded_owner_segment}${repository_boundary}${encoded_name_segment}"
+}
+
+# Rejects collection names that do not match their repository's canonical identity.
+require_canonical_collection_name() {
+    local collection_name="$1"
+    local repository_url="$2"
+
+    extract_repository_identity "$repository_url"
+    if [ "$collection_name" != "$CANONICAL_COLLECTION_NAME" ]; then
+        echo -e "${RED}Collection '$collection_name' does not match canonical name '$CANONICAL_COLLECTION_NAME'.${NC}" >&2
+        return 1
+    fi
 }
 
 # ── Cache management ─────────────────────────────────────────────────

--- a/scripts/process_github_repo.sh
+++ b/scripts/process_github_repo.sh
@@ -172,12 +172,7 @@ run_single_ingestion() {
     local app_jar="$4"
 
     resolve_repository_metadata_from_path "$repository_path"
-    if [ "$collection_name" != "$CANONICAL_COLLECTION_NAME" ]; then
-        echo -e "${RED}Error: Collection naming mismatch for $REPOSITORY_URL${NC}"
-        echo -e "${RED}Expected canonical collection: $CANONICAL_COLLECTION_NAME${NC}"
-        echo -e "${RED}Received collection: $collection_name${NC}"
-        exit 1
-    fi
+    require_canonical_collection_name "$collection_name" "$REPOSITORY_URL"
 
     print_ingestion_banner "$repository_path" "$collection_name"
     ensure_collection_exists "$collection_name" "$qdrant_base_url"
@@ -235,6 +230,8 @@ sync_single_collection() {
         return
     fi
 
+    require_canonical_collection_name "$collection_name" "$stored_repository_url"
+
     local remote_commit
     remote_commit="$(remote_head_commit "$stored_repository_url")"
     if [ -z "$remote_commit" ]; then
@@ -252,12 +249,6 @@ sync_single_collection() {
     echo -e "${CYAN}Syncing updated repository for $collection_name: $stored_repository_url${NC}"
     local cached_repository_path
     cached_repository_path="$(ensure_repository_cache_clone "$stored_repository_url" "")"
-
-    extract_repository_identity "$stored_repository_url"
-    if [ "$collection_name" != "$CANONICAL_COLLECTION_NAME" ]; then
-        echo -e "${RED}Collection '$collection_name' does not match canonical name '$CANONICAL_COLLECTION_NAME'${NC}"
-        exit 1
-    fi
 
     local previous_repo_url="$REPO_URL"
     REPO_URL="$stored_repository_url"
@@ -325,7 +316,14 @@ else
 fi
 
 build_application "$LOG_FILE"
-APP_JAR="$(locate_app_jar)"
+SOURCE_APP_JAR="$(locate_app_jar)"
+STAGED_APP_JAR_DIRECTORY="$(mktemp -d "${TMPDIR:-/tmp}/java-chat-github-ingestion.XXXXXX")"
+cleanup_staged_app_jar() {
+    chmod u+w "$STAGED_APP_JAR_DIRECTORY" "$STAGED_APP_JAR_DIRECTORY/application.jar" 2>/dev/null || true
+    rm -rf "$STAGED_APP_JAR_DIRECTORY"
+}
+trap cleanup_staged_app_jar EXIT
+APP_JAR="$(stage_app_jar "$SOURCE_APP_JAR" "$STAGED_APP_JAR_DIRECTORY")"
 QDRANT_BASE_URL="$(qdrant_rest_base_url)"
 
 if [ "$SYNC_EXISTING" = "1" ]; then

--- a/src/main/java/com/williamcallahan/javachat/cli/GitHubRepoProcessor.java
+++ b/src/main/java/com/williamcallahan/javachat/cli/GitHubRepoProcessor.java
@@ -286,10 +286,7 @@ public class GitHubRepoProcessor {
         GitHubRepositoryIdentity repositoryIdentity =
                 repositoryIdentityResolver.resolve(owner, repositoryName, repositoryUrl);
 
-        String collectionName = envOrEmpty(ENV_GITHUB_COLLECTION_NAME);
-        if (collectionName.isBlank()) {
-            collectionName = repositoryIdentity.canonicalCollectionName();
-        }
+        String collectionName = requireEnv(ENV_GITHUB_COLLECTION_NAME);
 
         return new GitHubRepoMetadata(
                 repoPath,

--- a/src/main/java/com/williamcallahan/javachat/domain/ingestion/GitHubRepositoryIdentity.java
+++ b/src/main/java/com/williamcallahan/javachat/domain/ingestion/GitHubRepositoryIdentity.java
@@ -1,8 +1,5 @@
 package com.williamcallahan.javachat.domain.ingestion;
 
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Locale;
 import java.util.Objects;
 
@@ -10,17 +7,13 @@ import java.util.Objects;
  * Represents the canonical identity of a GitHub repository.
  *
  * <p>The canonical identity is owner and repository name normalized to lowercase.
- * It is used to derive stable keys, URLs, and collection names so local-path and
- * URL-based ingestion converge on the same repository identity.</p>
+ * It is used to derive stable keys and URLs so local-path and URL-based ingestion
+ * converge on the same repository identity.</p>
  *
  * @param owner repository owner or organization name
  * @param repository repository name
  */
 public record GitHubRepositoryIdentity(String owner, String repository) {
-    private static final String SEGMENT_ALLOWED_PATTERN = "[a-z0-9-]+";
-    private static final String HASH_PREFIX = "-h";
-    private static final int HASH_HEX_LENGTH = 8;
-
     /**
      * Validates and normalizes owner/repository tokens.
      */
@@ -54,13 +47,6 @@ public record GitHubRepositoryIdentity(String owner, String repository) {
         return "https://github.com/" + canonicalRepoKey();
     }
 
-    /**
-     * Returns the canonical Qdrant collection name for this repository.
-     */
-    public String canonicalCollectionName() {
-        return "github-" + encodeCollectionSegment(owner) + "-" + encodeCollectionSegment(repository);
-    }
-
     private static String normalizeToken(String rawToken, String tokenName) {
         Objects.requireNonNull(rawToken, tokenName);
         String normalizedToken = rawToken.trim().toLowerCase(Locale.ROOT);
@@ -71,37 +57,5 @@ public record GitHubRepositoryIdentity(String owner, String repository) {
             throw new IllegalArgumentException(tokenName + " contains unsupported characters: " + rawToken);
         }
         return normalizedToken;
-    }
-
-    private static String encodeCollectionSegment(String rawSegment) {
-        String sanitizedSegment = sanitizeCollectionSegment(rawSegment);
-        if (rawSegment.matches(SEGMENT_ALLOWED_PATTERN) && rawSegment.equals(sanitizedSegment)) {
-            return sanitizedSegment;
-        }
-        String hashSuffix = shortHashHex(rawSegment);
-        return sanitizedSegment + HASH_PREFIX + hashSuffix;
-    }
-
-    private static String sanitizeCollectionSegment(String rawSegment) {
-        String normalizedSegment = rawSegment.replaceAll("[^a-z0-9-]", "-").replaceAll("-{2,}", "-");
-        String trimmedSegment = normalizedSegment.replaceAll("^-+", "").replaceAll("-+$", "");
-        if (trimmedSegment.isBlank()) {
-            throw new IllegalArgumentException("Collection segment cannot be blank: " + rawSegment);
-        }
-        return trimmedSegment;
-    }
-
-    private static String shortHashHex(String rawSegment) {
-        try {
-            MessageDigest sha256Digest = MessageDigest.getInstance("SHA-256");
-            byte[] digestBytes = sha256Digest.digest(rawSegment.getBytes(StandardCharsets.UTF_8));
-            StringBuilder hexBuilder = new StringBuilder(HASH_HEX_LENGTH * 2);
-            for (byte digestByte : digestBytes) {
-                hexBuilder.append(String.format("%02x", digestByte));
-            }
-            return hexBuilder.substring(0, HASH_HEX_LENGTH);
-        } catch (NoSuchAlgorithmException algorithmException) {
-            throw new IllegalStateException("SHA-256 digest algorithm unavailable", algorithmException);
-        }
     }
 }

--- a/src/main/java/com/williamcallahan/javachat/service/EmbeddingModelKeepAlive.java
+++ b/src/main/java/com/williamcallahan/javachat/service/EmbeddingModelKeepAlive.java
@@ -88,6 +88,9 @@ public class EmbeddingModelKeepAlive implements HealthIndicator {
         long probeStartNanos = nanoTime.getAsLong();
         try {
             embeddingClient.warmUp();
+        } catch (OpenAiCompatibleEmbeddingClient.EmbeddingProbeDeferredException exception) {
+            recordDeferred(elapsedMillis(probeStartNanos));
+            return;
         } catch (RuntimeException exception) {
             recordFailure(elapsedMillis(probeStartNanos), exception);
             if (exception instanceof EmbeddingServiceUnavailableException) {
@@ -96,6 +99,12 @@ public class EmbeddingModelKeepAlive implements HealthIndicator {
             throw exception;
         }
         recordSuccess(elapsedMillis(probeStartNanos));
+    }
+
+    private void recordDeferred(long probeDurationMillis) {
+        String logSafeModelName = modelName.replace("\r", "\\r").replace("\n", "\\n");
+        log.atDebug().log(() -> "event=embedding_model_probe_deferred outcome=deferred model=" + logSafeModelName
+                + " durationMs=" + probeDurationMillis + " reason=foreground_embedding_active");
     }
 
     /**

--- a/src/main/java/com/williamcallahan/javachat/service/HybridVectorService.java
+++ b/src/main/java/com/williamcallahan/javachat/service/HybridVectorService.java
@@ -296,9 +296,11 @@ public class HybridVectorService {
             points.add(point);
         }
 
-        var upsertFuture = qdrantClient.upsertAsync(Objects.requireNonNull(collectionName), points);
         RetrySupport.executeWithRetry(
-                () -> QdrantFutureAwaiter.awaitFuture(upsertFuture, UPSERT_TIMEOUT_SECONDS), "Qdrant hybrid upsert");
+                () -> QdrantFutureAwaiter.awaitFuture(
+                        qdrantClient.upsertAsync(Objects.requireNonNull(collectionName), points),
+                        UPSERT_TIMEOUT_SECONDS),
+                "Qdrant hybrid upsert");
 
         log.info("[QDRANT] Upserted {} hybrid points", points.size());
     }
@@ -313,10 +315,12 @@ public class HybridVectorService {
                 .addMust(matchKeyword(URL_PAYLOAD_FIELD, url))
                 .build();
 
-        var deleteFuture =
-                qdrantClient.deleteAsync(Objects.requireNonNull(collectionName), Objects.requireNonNull(filter));
         RetrySupport.executeWithRetry(
-                () -> QdrantFutureAwaiter.awaitFuture(deleteFuture, DELETE_TIMEOUT_SECONDS), "Qdrant delete by URL");
+                () -> QdrantFutureAwaiter.awaitFuture(
+                        qdrantClient.deleteAsync(
+                                Objects.requireNonNull(collectionName), Objects.requireNonNull(filter)),
+                        DELETE_TIMEOUT_SECONDS),
+                "Qdrant delete by URL");
 
         log.debug("[QDRANT] Deleted points by URL filter");
     }
@@ -331,10 +335,12 @@ public class HybridVectorService {
                 .addMust(matchKeyword(URL_PAYLOAD_FIELD, url))
                 .build();
 
-        var countFuture =
-                qdrantClient.countAsync(Objects.requireNonNull(collectionName), Objects.requireNonNull(filter), true);
         Long count = RetrySupport.executeWithRetry(
-                () -> QdrantFutureAwaiter.awaitFuture(countFuture, COUNT_TIMEOUT_SECONDS), "Qdrant count by URL");
+                () -> QdrantFutureAwaiter.awaitFuture(
+                        qdrantClient.countAsync(
+                                Objects.requireNonNull(collectionName), Objects.requireNonNull(filter), true),
+                        COUNT_TIMEOUT_SECONDS),
+                "Qdrant count by URL");
         return count == null ? 0 : count;
     }
 }

--- a/src/main/java/com/williamcallahan/javachat/service/OpenAIStreamingService.java
+++ b/src/main/java/com/williamcallahan/javachat/service/OpenAIStreamingService.java
@@ -41,7 +41,7 @@ import reactor.core.scheduler.Schedulers;
 public class OpenAIStreamingService {
     private static final Logger log = LoggerFactory.getLogger(OpenAIStreamingService.class);
 
-    private static final int COMPLETE_REQUEST_TIMEOUT_SECONDS = 30;
+    private static final Duration DEFAULT_COMPLETE_REQUEST_TIMEOUT = Duration.ofSeconds(30);
     private static final String STREAM_STATUS_CODE_PROVIDER_FALLBACK =
             SseConstants.STATUS_CODE_STREAM_PROVIDER_FALLBACK;
     private static final String STREAM_STAGE_STREAM = SseConstants.STATUS_STAGE_STREAM;
@@ -179,7 +179,7 @@ public class OpenAIStreamingService {
      * @return completion text from the first successful provider attempt
      */
     public Mono<String> complete(String prompt, double temperature) {
-        return complete(prompt, temperature, null, false);
+        return complete(prompt, temperature, CompletionConfiguration.withDefaultTimeout());
     }
 
     /**
@@ -194,7 +194,10 @@ public class OpenAIStreamingService {
         if (maximumOutputTokens <= 0) {
             return Mono.error(new IllegalArgumentException("maximumOutputTokens must be positive"));
         }
-        return complete(prompt, temperature, Integer.valueOf(maximumOutputTokens), false);
+        return complete(
+                prompt,
+                temperature,
+                CompletionConfiguration.withOutputBudget(maximumOutputTokens, DEFAULT_COMPLETE_REQUEST_TIMEOUT));
     }
 
     /**
@@ -206,14 +209,30 @@ public class OpenAIStreamingService {
      * @return completion text from the first provider honoring the JSON contract
      */
     public Mono<String> completeJsonObject(String prompt, double temperature, int maximumOutputTokens) {
+        return completeJsonObject(prompt, temperature, maximumOutputTokens, DEFAULT_COMPLETE_REQUEST_TIMEOUT);
+    }
+
+    /**
+     * Sends a non-streaming completion request that requires a JSON object response within a caller-owned timeout.
+     *
+     * @param prompt completion prompt
+     * @param temperature response temperature
+     * @param maximumOutputTokens maximum output tokens needed by this caller
+     * @param requestTimeout whole-request timeout owned by this caller
+     * @return completion text from the first provider honoring the JSON contract
+     */
+    public Mono<String> completeJsonObject(
+            String prompt, double temperature, int maximumOutputTokens, Duration requestTimeout) {
         if (maximumOutputTokens <= 0) {
             return Mono.error(new IllegalArgumentException("maximumOutputTokens must be positive"));
         }
-        return complete(prompt, temperature, Integer.valueOf(maximumOutputTokens), true);
+        if (requestTimeout == null || requestTimeout.isZero() || requestTimeout.isNegative()) {
+            return Mono.error(new IllegalArgumentException("requestTimeout must be positive"));
+        }
+        return complete(prompt, temperature, CompletionConfiguration.jsonObject(maximumOutputTokens, requestTimeout));
     }
 
-    private Mono<String> complete(
-            String prompt, double temperature, Integer maximumOutputTokens, boolean requireJsonObject) {
+    private Mono<String> complete(String prompt, double temperature, CompletionConfiguration configuration) {
         return Mono.<String>defer(() -> {
                     List<OpenAiProviderCandidate> availableProviders =
                             providerRoutingService.selectAvailableProviderCandidates(clientPrimary, clientSecondary);
@@ -229,12 +248,12 @@ public class OpenAIStreamingService {
                         OpenAiProviderCandidate providerCandidate = availableProviders.get(providerIndex);
                         RateLimitService.ApiProvider activeProvider = providerCandidate.provider();
 
-                        ResponseCreateParams requestParameters = buildCompletionRequest(
-                                prompt, temperature, activeProvider, maximumOutputTokens, requireJsonObject);
+                        ResponseCreateParams requestParameters =
+                                buildCompletionRequest(prompt, temperature, activeProvider, configuration);
                         try {
                             log.info("[LLM] Complete started (providerId={})", activeProvider.ordinal());
                             RequestOptions requestOptions = RequestOptions.builder()
-                                    .timeout(completeTimeout())
+                                    .timeout(completeTimeout(configuration.requestTimeout()))
                                     .build();
                             Response completion =
                                     providerCandidate.client().responses().create(requestParameters, requestOptions);
@@ -275,16 +294,19 @@ public class OpenAIStreamingService {
             String prompt,
             double temperature,
             RateLimitService.ApiProvider activeProvider,
-            Integer maximumOutputTokens,
-            boolean requireJsonObject) {
-        if (requireJsonObject) {
+            CompletionConfiguration configuration) {
+        if (configuration.requireJsonObject()) {
             return requestFactory.buildJsonCompletionRequest(
-                    prompt, temperature, activeProvider, maximumOutputTokens.intValue());
+                    prompt,
+                    temperature,
+                    activeProvider,
+                    configuration.maximumOutputTokens().intValue());
         }
-        if (maximumOutputTokens == null) {
+        if (configuration.maximumOutputTokens() == null) {
             return requestFactory.buildCompletionRequest(prompt, temperature, activeProvider);
         }
-        return requestFactory.buildCompletionRequest(prompt, temperature, activeProvider, maximumOutputTokens);
+        return requestFactory.buildCompletionRequest(
+                prompt, temperature, activeProvider, configuration.maximumOutputTokens());
     }
 
     /**
@@ -378,10 +400,24 @@ public class OpenAIStreamingService {
                 .build();
     }
 
-    private Timeout completeTimeout() {
-        return Timeout.builder()
-                .request(Duration.ofSeconds(COMPLETE_REQUEST_TIMEOUT_SECONDS))
-                .build();
+    private Timeout completeTimeout(Duration requestTimeout) {
+        return Timeout.builder().request(requestTimeout).build();
+    }
+
+    private record CompletionConfiguration(
+            Integer maximumOutputTokens, boolean requireJsonObject, Duration requestTimeout) {
+
+        private static CompletionConfiguration withDefaultTimeout() {
+            return new CompletionConfiguration(null, false, DEFAULT_COMPLETE_REQUEST_TIMEOUT);
+        }
+
+        private static CompletionConfiguration withOutputBudget(int maximumOutputTokens, Duration requestTimeout) {
+            return new CompletionConfiguration(maximumOutputTokens, false, requestTimeout);
+        }
+
+        private static CompletionConfiguration jsonObject(int maximumOutputTokens, Duration requestTimeout) {
+            return new CompletionConfiguration(maximumOutputTokens, true, requestTimeout);
+        }
     }
 
     private OpenAIClient createClient(String apiKey, String baseUrl) {
@@ -389,8 +425,8 @@ public class OpenAIStreamingService {
                 .apiKey(apiKey)
                 .baseUrl(OpenAiSdkUrlNormalizer.normalize(baseUrl))
                 .putHeader(LlmGatewayTier.REQUEST_TIER_HEADER, resolvedLlmGatewayTier())
-                // Disable SDK-level retries: Reactor timeout and onErrorResume handle failures.
-                // Retries cause InterruptedException when Reactor cancels a sleeping retry.
+                // Caller-owned request timeouts and provider routing own failure handling.
+                // SDK retry sleeps interfere with reactive cancellation.
                 .maxRetries(0)
                 .build();
     }

--- a/src/main/java/com/williamcallahan/javachat/service/OpenAIStreamingService.java
+++ b/src/main/java/com/williamcallahan/javachat/service/OpenAIStreamingService.java
@@ -139,7 +139,7 @@ public class OpenAIStreamingService {
     }
 
     /**
-     * Streams a response using a structured prompt with provider failover before first token.
+     * Streams a response using a structured prompt with bounded retries before first text.
      *
      * @param structuredPrompt typed prompt segments
      * @param temperature response temperature
@@ -162,8 +162,8 @@ public class OpenAIStreamingService {
                     Sinks.Many<StreamingNotice> noticeSink =
                             Sinks.many().multicast().onBackpressureBuffer();
                     StreamingAttemptContext attemptContext =
-                            new StreamingAttemptContext(availableProviders, 0, noticeSink);
-                    Flux<String> contentFlux = executeStreamingWithProviderFallback(
+                            StreamingAttemptContext.first(availableProviders, noticeSink);
+                    Flux<String> contentFlux = executeStreamingWithPreTextRetry(
                                     structuredPrompt, temperature, attemptContext)
                             .doFinally(ignoredSignal -> noticeSink.tryEmitComplete());
                     return Mono.just(new StreamingResult(contentFlux, initialProvider.provider(), noticeSink.asFlux()));
@@ -319,7 +319,7 @@ public class OpenAIStreamingService {
         return providerRoutingService.isRecoverableStreamingFailure(throwable);
     }
 
-    private Flux<String> executeStreamingWithProviderFallback(
+    private Flux<String> executeStreamingWithPreTextRetry(
             StructuredPrompt structuredPrompt, double temperature, StreamingAttemptContext attemptContext) {
         OpenAiProviderCandidate providerCandidate = attemptContext.currentProvider();
         RateLimitService.ApiProvider activeProvider = providerCandidate.provider();
@@ -338,18 +338,18 @@ public class OpenAIStreamingService {
                         providerCandidate.client(), preparedStreamingRequest.responseParams(), activeProvider)
                 .doOnNext(ignoredChunk -> emittedTextChunk.set(true))
                 .onErrorResume(streamingFailure -> {
-                    if (!attemptContext.hasNextProvider()
+                    if (!attemptContext.hasNextAttempt()
                             || emittedTextChunk.get()
                             || !providerRoutingService.isStreamingFallbackEligible(streamingFailure)) {
                         return Flux.error(streamingFailure);
                     }
 
-                    StreamingAttemptContext nextAttempt = attemptContext.withNextProvider();
-                    OpenAiProviderCandidate fallbackProvider = nextAttempt.currentProvider();
+                    StreamingAttemptContext nextAttempt = attemptContext.withNextAttempt();
+                    OpenAiProviderCandidate retryProvider = nextAttempt.currentProvider();
                     log.warn(
-                            "[LLM] Falling back to providerId={} before first chunk "
+                            "[LLM] Retrying with providerId={} before first chunk "
                                     + "(failedProviderId={}, attempt={}/{}, exceptionType={})",
-                            fallbackProvider.provider().ordinal(),
+                            retryProvider.provider().ordinal(),
                             activeProvider.ordinal(),
                             nextAttempt.currentAttempt(),
                             nextAttempt.maxAttempts(),
@@ -358,19 +358,18 @@ public class OpenAIStreamingService {
                     emitStreamingNotice(
                             attemptContext.noticeSink(),
                             StreamingNotice.builder(
-                                            "Retrying stream with alternate provider",
-                                            STREAM_STATUS_CODE_PROVIDER_FALLBACK)
+                                            "Retrying stream with provider", STREAM_STATUS_CODE_PROVIDER_FALLBACK)
                                     .diagnosticContext("The API returned an invalid or transient streaming response. "
                                             + "Retrying before any response text was emitted.")
                                     .retryable(true)
                                     .origin(new StreamingNoticeOrigin(
-                                            fallbackProvider.provider().getName(),
+                                            retryProvider.provider().getName(),
                                             STREAM_STAGE_STREAM,
                                             nextAttempt.currentAttempt(),
                                             nextAttempt.maxAttempts()))
                                     .build());
 
-                    return executeStreamingWithProviderFallback(structuredPrompt, temperature, nextAttempt);
+                    return executeStreamingWithPreTextRetry(structuredPrompt, temperature, nextAttempt);
                 });
     }
 

--- a/src/main/java/com/williamcallahan/javachat/service/OpenAiCompatibleEmbeddingClient.java
+++ b/src/main/java/com/williamcallahan/javachat/service/OpenAiCompatibleEmbeddingClient.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,22 +30,13 @@ public class OpenAiCompatibleEmbeddingClient implements EmbeddingClient, AutoClo
     private static final int CONNECT_TIMEOUT_SECONDS = 10;
     private static final int READ_TIMEOUT_SECONDS = 60;
     private static final int MAX_ERROR_SNIPPET = 512;
-    private static final int MAX_EMBED_ATTEMPTS = 4;
-    private static final long INITIAL_RETRY_BACKOFF_MILLIS = 1_000L;
-    private static final long MAX_RETRY_BACKOFF_MILLIS = 8_000L;
-
-    private static final int HTTP_BAD_REQUEST = 400;
-    private static final int HTTP_REQUEST_TIMEOUT = 408;
-    private static final int HTTP_CONFLICT = 409;
-    private static final int HTTP_TOO_EARLY = 425;
-    private static final int HTTP_TOO_MANY_REQUESTS = 429;
-    private static final int HTTP_INTERNAL_SERVER_ERROR = 500;
 
     private final OpenAIClient liveEmbeddingClient;
     private final OpenAIClient batchEmbeddingClient;
     private final String modelName;
     private final int dimensionsHint;
     private final boolean closeBatchEmbeddingClient;
+    private final AtomicInteger activeForegroundEmbeddingCount = new AtomicInteger();
 
     /**
      * Creates an OpenAI-compatible embedding client backed by a remote REST API endpoint.
@@ -98,11 +90,29 @@ public class OpenAiCompatibleEmbeddingClient implements EmbeddingClient, AutoClo
         if (texts == null || texts.isEmpty()) {
             return List.of();
         }
-        return createEmbeddings(texts, requestTier);
+        activeForegroundEmbeddingCount.incrementAndGet();
+        try {
+            return createEmbeddings(texts, requestTier);
+        } finally {
+            activeForegroundEmbeddingCount.decrementAndGet();
+        }
     }
 
+    /**
+     * Issues a probe only when no foreground embedding was active at admission time.
+     *
+     * <p>The OpenAI Java SDK's blocking embedding API does not expose a cancellation handle.
+     * Therefore a foreground request that arrives after this check cannot preempt an already
+     * admitted probe. Batch clients perform one attempt, which bounds that unavoidable race
+     * without delaying a foreground request behind an application-level lock.</p>
+     *
+     * @throws EmbeddingProbeDeferredException when foreground embedding work is already active
+     */
     @Override
     public void warmUp() {
+        if (activeForegroundEmbeddingCount.get() > 0) {
+            throw new EmbeddingProbeDeferredException();
+        }
         createEmbeddings(List.of(EMBEDDING_WARM_UP_PROBE_TEXT), LlmGatewayTier.BATCH);
     }
 
@@ -120,103 +130,54 @@ public class OpenAiCompatibleEmbeddingClient implements EmbeddingClient, AutoClo
         EmbeddingCreateParams embeddingRequest = embeddingRequestBuilder.build();
         RequestOptions requestOptions =
                 RequestOptions.builder().timeout(embeddingTimeout()).build();
-        return executeWithRetry(clientFor(requestTier), embeddingRequest, requestOptions, texts.size());
+        return execute(clientFor(requestTier), embeddingRequest, requestOptions, texts.size());
     }
 
-    private List<float[]> executeWithRetry(
+    private List<float[]> execute(
             OpenAIClient requestClient,
             EmbeddingCreateParams embeddingRequest,
             RequestOptions requestOptions,
             int expectedCount) {
-        long retryBackoffMillis = INITIAL_RETRY_BACKOFF_MILLIS;
-        for (int attemptNumber = 1; attemptNumber <= MAX_EMBED_ATTEMPTS; attemptNumber++) {
-            try {
-                CreateEmbeddingResponse embeddingResponse =
-                        requestClient.embeddings().create(embeddingRequest, requestOptions);
-                return parseResponse(embeddingResponse, expectedCount);
-            } catch (OpenAIServiceException exception) {
-                retryBackoffMillis = handleServiceError(exception, attemptNumber, retryBackoffMillis);
-            } catch (OpenAIRetryableException exception) {
-                retryBackoffMillis = handleRetryableError(exception, attemptNumber, retryBackoffMillis);
-            } catch (EmbeddingServiceUnavailableException exception) {
-                retryBackoffMillis = handleValidationError(exception, attemptNumber, retryBackoffMillis);
-            } catch (RuntimeException exception) {
-                throw wrapFatalError(exception, attemptNumber);
-            }
+        try {
+            CreateEmbeddingResponse embeddingResponse =
+                    requestClient.embeddings().create(embeddingRequest, requestOptions);
+            return parseResponse(embeddingResponse, expectedCount);
+        } catch (OpenAIServiceException exception) {
+            throw wrapServiceError(exception);
+        } catch (OpenAIRetryableException exception) {
+            throw wrapRetryableError(exception);
+        } catch (EmbeddingServiceUnavailableException exception) {
+            throw exception;
+        } catch (RuntimeException exception) {
+            throw wrapFatalError(exception);
         }
-        throw new EmbeddingServiceUnavailableException("Remote embedding call failed after retries");
     }
 
-    private long handleServiceError(OpenAIServiceException exception, int attemptNumber, long retryBackoffMillis) {
+    private EmbeddingServiceUnavailableException wrapServiceError(OpenAIServiceException exception) {
         int statusCode = exception.statusCode();
         String details = sanitizeMessage(exception.getMessage());
-        if (shouldRetryServiceError(statusCode, details) && attemptNumber < MAX_EMBED_ATTEMPTS) {
-            log.warn(
-                    "[EMBEDDING] Remote provider transient HTTP {} on attempt {}/{}; retrying in {}ms",
-                    statusCode,
-                    attemptNumber,
-                    MAX_EMBED_ATTEMPTS,
-                    retryBackoffMillis,
-                    exception);
-            sleepBeforeRetry(retryBackoffMillis);
-            return Math.min(retryBackoffMillis * 2L, MAX_RETRY_BACKOFF_MILLIS);
-        }
         String failureMessage = details.isBlank()
-                ? "Remote embedding provider returned HTTP " + statusCode + " after " + attemptNumber + " attempt(s)"
-                : "Remote embedding provider returned HTTP " + statusCode + " after " + attemptNumber + " attempt(s): "
-                        + details;
-        throw new EmbeddingServiceUnavailableException(failureMessage, exception);
+                ? "Remote embedding provider returned HTTP " + statusCode
+                : "Remote embedding provider returned HTTP " + statusCode + ": " + details;
+        return new EmbeddingServiceUnavailableException(failureMessage, exception);
     }
 
-    private long handleRetryableError(OpenAIRetryableException exception, int attemptNumber, long retryBackoffMillis) {
+    private EmbeddingServiceUnavailableException wrapRetryableError(OpenAIRetryableException exception) {
         String details = sanitizeMessage(exception.getMessage());
-        if (attemptNumber < MAX_EMBED_ATTEMPTS) {
-            log.warn(
-                    "[EMBEDDING] Retryable OpenAI SDK failure on attempt {}/{}; retrying in {}ms ({})",
-                    attemptNumber,
-                    MAX_EMBED_ATTEMPTS,
-                    retryBackoffMillis,
-                    details.isBlank() ? "no details" : details,
-                    exception);
-            sleepBeforeRetry(retryBackoffMillis);
-            return Math.min(retryBackoffMillis * 2L, MAX_RETRY_BACKOFF_MILLIS);
-        }
-        String failureMessage = details.isBlank()
-                ? "Remote embedding request failed after " + attemptNumber + " attempt(s)"
-                : "Remote embedding request failed after " + attemptNumber + " attempt(s): " + details;
-        throw new EmbeddingServiceUnavailableException(failureMessage, exception);
+        String failureMessage =
+                details.isBlank() ? "Remote embedding request failed" : "Remote embedding request failed: " + details;
+        return new EmbeddingServiceUnavailableException(failureMessage, exception);
     }
 
-    private long handleValidationError(
-            EmbeddingServiceUnavailableException exception, int attemptNumber, long retryBackoffMillis) {
-        String details = sanitizeMessage(exception.getMessage());
-        if (shouldRetryResponseValidationError(details) && attemptNumber < MAX_EMBED_ATTEMPTS) {
-            log.warn(
-                    "[EMBEDDING] Remote response validation failed on attempt {}/{}; retrying in {}ms ({})",
-                    attemptNumber,
-                    MAX_EMBED_ATTEMPTS,
-                    retryBackoffMillis,
-                    details.isBlank() ? "no details" : details,
-                    exception);
-            sleepBeforeRetry(retryBackoffMillis);
-            return Math.min(retryBackoffMillis * 2L, MAX_RETRY_BACKOFF_MILLIS);
-        }
-        String failureMessage = details.isBlank()
-                ? "Remote embedding response validation failed after " + attemptNumber + " attempt(s)"
-                : "Remote embedding response validation failed after " + attemptNumber + " attempt(s): " + details;
-        throw new EmbeddingServiceUnavailableException(failureMessage, exception);
-    }
-
-    private EmbeddingServiceUnavailableException wrapFatalError(RuntimeException exception, int attemptNumber) {
+    private EmbeddingServiceUnavailableException wrapFatalError(RuntimeException exception) {
         String details = sanitizeMessage(exception.getMessage());
         log.warn(
                 "[EMBEDDING] Remote embedding call failed (exception type: {}, details: {})",
                 exception.getClass().getSimpleName(),
                 details.isBlank() ? "none" : details,
                 exception);
-        String failureMessage = details.isBlank()
-                ? "Remote embedding call failed after " + attemptNumber + " attempt(s)"
-                : "Remote embedding call failed after " + attemptNumber + " attempt(s): " + details;
+        String failureMessage =
+                details.isBlank() ? "Remote embedding call failed" : "Remote embedding call failed: " + details;
         return new EmbeddingServiceUnavailableException(failureMessage, exception);
     }
 
@@ -228,45 +189,6 @@ public class OpenAiCompatibleEmbeddingClient implements EmbeddingClient, AutoClo
                 .request(requestTimeout)
                 .read(requestTimeout)
                 .build();
-    }
-
-    private static boolean shouldRetryServiceError(int statusCode, String details) {
-        if (statusCode == HTTP_TOO_MANY_REQUESTS
-                || statusCode >= HTTP_INTERNAL_SERVER_ERROR
-                || statusCode == HTTP_REQUEST_TIMEOUT
-                || statusCode == HTTP_CONFLICT
-                || statusCode == HTTP_TOO_EARLY) {
-            return true;
-        }
-        // Some providers intermittently return HTTP 400 with null/empty payloads for transient gateway failures.
-        if (statusCode != HTTP_BAD_REQUEST) {
-            return false;
-        }
-        String normalizedDetails = details == null ? "" : details.trim().toLowerCase(Locale.ROOT);
-        return normalizedDetails.isBlank() || "null".equals(normalizedDetails) || "400: null".equals(normalizedDetails);
-    }
-
-    private static boolean shouldRetryResponseValidationError(String validationFailureMessage) {
-        String normalizedMessage = validationFailureMessage == null
-                ? ""
-                : validationFailureMessage.trim().toLowerCase(Locale.ROOT);
-        if (normalizedMessage.isBlank()) {
-            return true;
-        }
-        return normalizedMessage.contains("response was null")
-                || normalizedMessage.contains("missing embedding entries")
-                || normalizedMessage.contains("missing embedding for index")
-                || normalizedMessage.contains("contained null entry")
-                || normalizedMessage.contains("null embedding value at index");
-    }
-
-    private static void sleepBeforeRetry(long retryBackoffMillis) {
-        try {
-            Thread.sleep(retryBackoffMillis);
-        } catch (InterruptedException interruptedException) {
-            Thread.currentThread().interrupt();
-            throw new IllegalStateException("Embedding retry interrupted", interruptedException);
-        }
     }
 
     private List<float[]> parseResponse(CreateEmbeddingResponse response, int expectedCount) {
@@ -419,11 +341,14 @@ public class OpenAiCompatibleEmbeddingClient implements EmbeddingClient, AutoClo
     }
 
     private static OpenAIClient createTieredClient(String apiKey, String baseUrl, LlmGatewayTier requestTier) {
-        return OpenAIOkHttpClient.builder()
+        OpenAIOkHttpClient.Builder clientBuilder = OpenAIOkHttpClient.builder()
                 .apiKey(apiKey)
                 .baseUrl(baseUrl)
-                .putHeader(LlmGatewayTier.REQUEST_TIER_HEADER, requestTier.requestHeader())
-                .build();
+                .putHeader(LlmGatewayTier.REQUEST_TIER_HEADER, requestTier.requestHeader());
+        if (requestTier == LlmGatewayTier.BATCH) {
+            clientBuilder.maxRetries(0);
+        }
+        return clientBuilder.build();
     }
 
     private OpenAIClient clientFor(LlmGatewayTier requestTier) {
@@ -436,6 +361,15 @@ public class OpenAiCompatibleEmbeddingClient implements EmbeddingClient, AutoClo
     private static void validateDimensions(int dimensionsHint) {
         if (dimensionsHint <= 0) {
             throw new IllegalArgumentException("Embedding dimensions must be positive");
+        }
+    }
+
+    /** Signals that a background probe yielded admission to active foreground embedding work. */
+    static final class EmbeddingProbeDeferredException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
+        EmbeddingProbeDeferredException() {
+            super("Embedding probe deferred while foreground embedding work is active");
         }
     }
 }

--- a/src/main/java/com/williamcallahan/javachat/service/ProviderCircuitState.java
+++ b/src/main/java/com/williamcallahan/javachat/service/ProviderCircuitState.java
@@ -10,9 +10,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 final class ProviderCircuitState {
     private final int maxBackoffMultiplier;
 
-    private volatile boolean circuitOpen = false;
-    private volatile Instant nextRetryTime;
-    private volatile int backoffMultiplier = 1;
+    private boolean circuitOpen = false;
+    private Instant nextRetryTime = Instant.EPOCH;
+    private int backoffMultiplier = 1;
     private final AtomicInteger requestsToday = new AtomicInteger(0);
     private volatile Instant dayReset = Instant.now().plus(Duration.ofDays(1));
 
@@ -29,7 +29,7 @@ final class ProviderCircuitState {
     /**
      * Returns whether the provider is currently eligible for requests.
      */
-    boolean isAvailable() {
+    synchronized boolean isAvailable() {
         if (circuitOpen && Instant.now().isBefore(nextRetryTime)) {
             return false;
         }
@@ -43,7 +43,7 @@ final class ProviderCircuitState {
     /**
      * Marks one successful request and closes the circuit if it was open.
      */
-    void recordSuccess() {
+    synchronized void recordSuccess() {
         backoffMultiplier = 1;
         circuitOpen = false;
         requestsToday.incrementAndGet();
@@ -52,14 +52,16 @@ final class ProviderCircuitState {
     /**
      * Marks a rate limit and computes next retry using explicit delay or bounded exponential backoff.
      */
-    void recordRateLimit(long retryAfterSeconds) {
-        circuitOpen = true;
+    synchronized void recordRateLimit(long retryAfterSeconds) {
+        Instant retryTime;
         if (retryAfterSeconds > 0) {
-            nextRetryTime = Instant.now().plusSeconds(retryAfterSeconds);
-            return;
+            retryTime = Instant.now().plusSeconds(retryAfterSeconds);
+        } else {
+            backoffMultiplier = Math.min(backoffMultiplier * 2, maxBackoffMultiplier);
+            retryTime = Instant.now().plusSeconds(backoffMultiplier);
         }
-        backoffMultiplier = Math.min(backoffMultiplier * 2, maxBackoffMultiplier);
-        nextRetryTime = Instant.now().plusSeconds(backoffMultiplier);
+        nextRetryTime = retryTime;
+        circuitOpen = true;
     }
 
     /**

--- a/src/main/java/com/williamcallahan/javachat/service/RateLimitHeaderParser.java
+++ b/src/main/java/com/williamcallahan/javachat/service/RateLimitHeaderParser.java
@@ -143,7 +143,7 @@ final class RateLimitHeaderParser {
             return epochResetInstant;
         }
 
-        long candidateSeconds = minPositive(
+        long candidateSeconds = maxPositive(
                 firstHeaderValue(headers, "x-ratelimit-reset-requests")
                         .map(this::parseDurationSeconds)
                         .orElse(0L),
@@ -151,12 +151,6 @@ final class RateLimitHeaderParser {
                         .map(this::parseDurationSeconds)
                         .orElse(0L),
                 firstHeaderValue(headers, "x-ratelimit-reset")
-                        .map(this::parseDurationSeconds)
-                        .orElse(0L),
-                firstHeaderValue(headers, "X-RateLimit-Reset-Requests")
-                        .map(this::parseDurationSeconds)
-                        .orElse(0L),
-                firstHeaderValue(headers, "X-RateLimit-Reset-Tokens")
                         .map(this::parseDurationSeconds)
                         .orElse(0L));
         if (candidateSeconds > 0) {
@@ -221,17 +215,14 @@ final class RateLimitHeaderParser {
         return Optional.ofNullable(headerValues.get(0));
     }
 
-    private long minPositive(long... candidates) {
-        long min = 0;
+    private long maxPositive(long... candidates) {
+        long maximumPositiveCandidate = 0;
         for (long candidate : candidates) {
-            if (candidate <= 0) {
-                continue;
-            }
-            if (min == 0 || candidate < min) {
-                min = candidate;
+            if (candidate > maximumPositiveCandidate) {
+                maximumPositiveCandidate = candidate;
             }
         }
-        return min;
+        return maximumPositiveCandidate;
     }
 
     private boolean isDigits(String candidate) {

--- a/src/main/java/com/williamcallahan/javachat/service/RateLimitState.java
+++ b/src/main/java/com/williamcallahan/javachat/service/RateLimitState.java
@@ -21,7 +21,7 @@ import org.springframework.stereotype.Component;
 
 /**
  * Persistent rate limit state manager that survives application restarts.
- * Tracks actual rate limit windows and implements intelligent backoff.
+ * Tracks provider-declared rate limit windows and request outcomes.
  */
 @Component
 public class RateLimitState {
@@ -76,7 +76,7 @@ public class RateLimitState {
     }
 
     /**
-     * Record a rate limit hit with proper backoff calculation
+     * Records a rate limit hit using the provider-declared reset time.
      */
     public void recordRateLimit(String provider, Instant resetTime, String rateLimitWindow) {
         ProviderState state = providerStates.computeIfAbsent(provider, providerKey -> new ProviderState());
@@ -90,26 +90,9 @@ public class RateLimitState {
         }
 
         state.rateLimitedUntil = resetTime;
-        int failures = state.consecutiveFailures.incrementAndGet();
+        state.consecutiveFailures.incrementAndGet();
         state.totalFailures.incrementAndGet();
         state.lastFailure = Instant.now();
-
-        // Implement exponential backoff for repeated failures
-        if (failures > 1) {
-            Duration additionalBackoff = Duration.ofHours((long) Math.pow(2, failures - 1));
-            Duration maxBackoff = Duration.ofDays(7); // Never back off more than a week
-
-            if (additionalBackoff.compareTo(maxBackoff) > 0) {
-                additionalBackoff = maxBackoff;
-            }
-
-            state.rateLimitedUntil = state.rateLimitedUntil.plus(additionalBackoff);
-            log.warn(
-                    "[{}] Consecutive failures (count={}). Extended backoff until {}",
-                    sanitizeLogValue(provider),
-                    failures,
-                    state.rateLimitedUntil);
-        }
 
         safeSaveState();
         log.info("[{}] Rate limited until {}", sanitizeLogValue(provider), state.rateLimitedUntil);

--- a/src/main/java/com/williamcallahan/javachat/service/RerankerService.java
+++ b/src/main/java/com/williamcallahan/javachat/service/RerankerService.java
@@ -33,7 +33,7 @@ public class RerankerService {
     private static final int RERANK_PROMPT_TEXT_MAX_LENGTH = 500;
 
     /** Output budget including hidden reasoning before the small JSON ordering. */
-    private static final int RERANKER_OUTPUT_TOKEN_BUDGET = 512;
+    private static final int RERANKER_OUTPUT_TOKEN_BUDGET = 4_000;
 
     private final OpenAIStreamingService openAIStreamingService;
     private final ObjectMapper mapper;
@@ -103,8 +103,7 @@ public class RerankerService {
 
         try {
             return openAIStreamingService
-                    .completeJsonObject(prompt, 0.0, RERANKER_OUTPUT_TOKEN_BUDGET)
-                    .timeout(rerankerTimeout)
+                    .completeJsonObject(prompt, 0.0, RERANKER_OUTPUT_TOKEN_BUDGET, rerankerTimeout)
                     .doOnError(
                             timeoutOrApiError -> log.debug("Reranker LLM call timed out or failed", timeoutOrApiError))
                     .blockOptional();

--- a/src/main/java/com/williamcallahan/javachat/service/StreamingAttemptContext.java
+++ b/src/main/java/com/williamcallahan/javachat/service/StreamingAttemptContext.java
@@ -5,32 +5,56 @@ import java.util.Objects;
 import reactor.core.publisher.Sinks;
 
 /**
- * Tracks provider iteration state during streaming with pre-first-token fallback.
+ * Tracks bounded provider attempts during streaming before response text is emitted.
  */
 record StreamingAttemptContext(
-        List<OpenAiProviderCandidate> availableProviders, int providerIndex, Sinks.Many<StreamingNotice> noticeSink) {
+        List<OpenAiProviderCandidate> availableProviders, int attemptIndex, Sinks.Many<StreamingNotice> noticeSink) {
+    private static final int SINGLE_PROVIDER_MAX_ATTEMPTS = 2;
+
     StreamingAttemptContext {
         Objects.requireNonNull(availableProviders, "availableProviders");
         Objects.requireNonNull(noticeSink, "noticeSink");
+        if (availableProviders.isEmpty()) {
+            throw new IllegalArgumentException("availableProviders cannot be empty");
+        }
+
+        int maxAttempts = maximumAttemptsFor(availableProviders);
+        if (attemptIndex < 0 || attemptIndex >= maxAttempts) {
+            throw new IllegalArgumentException("attemptIndex is outside the bounded attempt range");
+        }
+    }
+
+    static StreamingAttemptContext first(
+            List<OpenAiProviderCandidate> availableProviders, Sinks.Many<StreamingNotice> noticeSink) {
+        return new StreamingAttemptContext(availableProviders, 0, noticeSink);
     }
 
     OpenAiProviderCandidate currentProvider() {
+        int providerIndex = Math.min(attemptIndex, availableProviders.size() - 1);
         return availableProviders.get(providerIndex);
     }
 
     int currentAttempt() {
-        return providerIndex + 1;
+        return attemptIndex + 1;
     }
 
     int maxAttempts() {
-        return availableProviders.size();
+        return maximumAttemptsFor(availableProviders);
     }
 
-    boolean hasNextProvider() {
-        return providerIndex + 1 < availableProviders.size();
+    boolean hasNextAttempt() {
+        return currentAttempt() < maxAttempts();
     }
 
-    StreamingAttemptContext withNextProvider() {
-        return new StreamingAttemptContext(availableProviders, providerIndex + 1, noticeSink);
+    StreamingAttemptContext withNextAttempt() {
+        if (!hasNextAttempt()) {
+            throw new IllegalStateException("streaming attempts are exhausted");
+        }
+
+        return new StreamingAttemptContext(availableProviders, attemptIndex + 1, noticeSink);
+    }
+
+    private static int maximumAttemptsFor(List<OpenAiProviderCandidate> availableProviders) {
+        return availableProviders.size() == 1 ? SINGLE_PROVIDER_MAX_ATTEMPTS : availableProviders.size();
     }
 }

--- a/src/main/java/com/williamcallahan/javachat/service/ingestion/SourceCodeFileIngestionProcessor.java
+++ b/src/main/java/com/williamcallahan/javachat/service/ingestion/SourceCodeFileIngestionProcessor.java
@@ -126,8 +126,9 @@ public class SourceCodeFileIngestionProcessor {
                 .orElse(null);
 
         boolean unchangedByFingerprint = isUnchangedByFingerprint(previousFileRecord, fileContext, fileContent);
-        if (unchangedByFingerprint
-                && hasSufficientStoredPointCoverage(previousFileRecord, collectionName, fileContext)) {
+        boolean hasSufficientPointCoverage = unchangedByFingerprint
+                && hasSufficientStoredPointCoverage(previousFileRecord, collectionName, fileContext);
+        if (hasSufficientPointCoverage) {
             log.debug("Skipping unchanged file (already ingested): {}", fileContext.relativePath());
             return new SourceFileProcessingResult(LocalDocsFileOutcome.skippedFile(), fileUrl);
         }
@@ -137,7 +138,7 @@ public class SourceCodeFileIngestionProcessor {
                     fileContext.relativePath());
         }
 
-        boolean requiresFullReindex = previousFileRecord != null && !unchangedByFingerprint;
+        boolean requiresFullReindex = previousFileRecord != null;
         if (requiresFullReindex) {
             try {
                 ingestedFilePruneService.pruneCollectionFileStrict(

--- a/src/main/java/com/williamcallahan/javachat/web/BaseController.java
+++ b/src/main/java/com/williamcallahan/javachat/web/BaseController.java
@@ -22,13 +22,13 @@ public abstract class BaseController {
     /**
      * Handles service exceptions with standardized error responses.
      *
-     * @param e The exception that occurred
+     * @param serviceException exception raised while performing the operation
      * @param operation Description of the operation that failed
      * @return Standardized error response
      */
-    protected ResponseEntity<ApiResponse> handleServiceException(Exception e, String operation) {
+    protected ResponseEntity<ApiResponse> handleServiceException(Exception serviceException, String operation) {
         return exceptionBuilder.buildErrorResponse(
-                HttpStatus.INTERNAL_SERVER_ERROR, "Failed to " + operation + ": " + e.getMessage(), e);
+                HttpStatus.INTERNAL_SERVER_ERROR, "Failed to " + operation, serviceException);
     }
 
     /**

--- a/src/main/java/com/williamcallahan/javachat/web/CustomErrorController.java
+++ b/src/main/java/com/williamcallahan/javachat/web/CustomErrorController.java
@@ -75,27 +75,30 @@ public class CustomErrorController implements ErrorController {
             })
     public Object handleError(HttpServletRequest request, HttpServletResponse servletResponse, Model model) {
         // Get error details from request attributes
-        Object status = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
-        Object message = request.getAttribute(RequestDispatcher.ERROR_MESSAGE);
-        Object exception = request.getAttribute(RequestDispatcher.ERROR_EXCEPTION);
-        Object requestUri = request.getAttribute(RequestDispatcher.ERROR_REQUEST_URI);
+        Object errorStatusCodeAttribute = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
+        Object errorExceptionAttribute = request.getAttribute(RequestDispatcher.ERROR_EXCEPTION);
+        Object errorRequestUriAttribute = request.getAttribute(RequestDispatcher.ERROR_REQUEST_URI);
 
-        int statusCode = status != null ? (Integer) status : 500;
-        String errorMessage = message != null ? message.toString() : "An unexpected error occurred";
-        String uri = requestUri != null ? requestUri.toString() : request.getRequestURI();
+        int statusCode = errorStatusCodeAttribute instanceof Integer errorStatusCode
+                ? errorStatusCode
+                : HttpStatus.INTERNAL_SERVER_ERROR.value();
+        String requestUri =
+                errorRequestUriAttribute != null ? errorRequestUriAttribute.toString() : request.getRequestURI();
         String requestId = request.getRequestId();
         servletResponse.setHeader(REQUEST_ID_HEADER, requestId);
 
         // Determine if this is an API request or a page request
-        boolean isApiRequest = uri.equals("/api") || uri.startsWith("/api/");
-        logRequestFailure(request, statusCode, uri, isApiRequest, requestId, exception);
+        boolean isApiRequest = requestUri.equals("/api") || requestUri.startsWith("/api/");
+        logRequestFailure(request, statusCode, requestUri, isApiRequest, requestId, errorExceptionAttribute);
 
         if (isApiRequest) {
             // Return JSON error response for API requests
-            return handleApiError(statusCode, errorMessage, (Exception) exception);
+            Exception requestException =
+                    errorExceptionAttribute instanceof Exception exceptionInstance ? exceptionInstance : null;
+            return handleApiError(statusCode, requestException);
         } else {
             // Return HTML error page for browser requests
-            return handlePageError(statusCode, resolveUserFacingMessage(statusCode), uri, model);
+            return handlePageError(statusCode, resolveUserFacingMessage(statusCode), requestUri, model);
         }
     }
 
@@ -153,30 +156,28 @@ public class CustomErrorController implements ErrorController {
     /**
      * Handles API error responses with JSON format.
      */
-    private ResponseEntity<ApiResponse> handleApiError(int statusCode, String message, Exception exception) {
-        HttpStatus httpStatus = HttpStatus.resolve(statusCode);
-        if (httpStatus == null) {
-            httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
-        }
+    private ResponseEntity<ApiResponse> handleApiError(int statusCode, Exception requestException) {
+        HttpStatus httpStatus = resolveHttpStatus(statusCode);
+        String userFacingMessage = httpStatus.getReasonPhrase();
 
-        if (exception != null) {
-            return exceptionBuilder.buildErrorResponse(httpStatus, message, exception);
+        if (requestException != null) {
+            return exceptionBuilder.buildErrorResponse(httpStatus, userFacingMessage, requestException);
         } else {
-            return exceptionBuilder.buildErrorResponse(httpStatus, message);
+            return exceptionBuilder.buildErrorResponse(httpStatus, userFacingMessage);
         }
     }
 
     /**
      * Handles page error responses with HTML error pages.
      */
-    private ModelAndView handlePageError(int statusCode, String message, String uri, Model model) {
+    private ModelAndView handlePageError(int statusCode, String userFacingMessage, String requestUri, Model model) {
         ModelAndView modelAndView = new ModelAndView();
 
         // Add error details to model for potential template use
         model.addAttribute("status", statusCode);
         model.addAttribute("error", HttpStatus.resolve(statusCode));
-        model.addAttribute("message", message);
-        model.addAttribute("path", uri);
+        model.addAttribute("message", userFacingMessage);
+        model.addAttribute("path", requestUri);
         model.addAttribute("timestamp", System.currentTimeMillis());
 
         HttpStatus resolvedStatus = HttpStatus.resolve(statusCode);
@@ -193,11 +194,19 @@ public class CustomErrorController implements ErrorController {
     }
 
     private String resolveUserFacingMessage(int statusCode) {
-        HttpStatus status = HttpStatus.resolve(statusCode);
-        if (status != null) {
-            return status.getReasonPhrase();
+        HttpStatus resolvedStatus = HttpStatus.resolve(statusCode);
+        if (resolvedStatus != null) {
+            return resolvedStatus.getReasonPhrase();
         }
         return "Unexpected error";
+    }
+
+    private HttpStatus resolveHttpStatus(int statusCode) {
+        HttpStatus resolvedStatus = HttpStatus.resolve(statusCode);
+        if (resolvedStatus != null) {
+            return resolvedStatus;
+        }
+        return HttpStatus.INTERNAL_SERVER_ERROR;
     }
 
     private String resolveErrorViewName(HttpStatus status) {

--- a/src/main/java/com/williamcallahan/javachat/web/ExceptionResponseBuilder.java
+++ b/src/main/java/com/williamcallahan/javachat/web/ExceptionResponseBuilder.java
@@ -5,8 +5,6 @@ import com.williamcallahan.javachat.domain.errors.ApiErrorResponse;
 import com.williamcallahan.javachat.domain.errors.ApiResponse;
 import com.williamcallahan.javachat.domain.errors.ApiSuccessResponse;
 import java.util.Objects;
-import java.util.Optional;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
@@ -56,90 +54,29 @@ public class ExceptionResponseBuilder {
     }
 
     /**
-     * Builds a detailed error description suitable for API responses or UI diagnostics.
+     * Builds a client-safe error description without downstream messages, headers, or bodies.
      *
      * @param exception the exception to describe
-     * @return detailed description including class name, message, and protocol-specific details
+     * @return exception type and numeric HTTP status when available
      * @throws NullPointerException when exception is null
      */
     public String describeException(Exception exception) {
         Objects.requireNonNull(exception, EXCEPTION_REQUIRED_MESSAGE);
-        StringBuilder details = new StringBuilder();
-        details.append(exception.getClass().getSimpleName());
-        String message = exception.getMessage();
-        if (message != null && !message.isBlank()) {
-            details.append(": ").append(message);
-        }
+        StringBuilder details = new StringBuilder(exception.getClass().getSimpleName());
 
         if (exception instanceof RestClientResponseException restClientException) {
-            appendRestClientDetails(details, restClientException);
-        }
-        if (exception instanceof WebClientResponseException webClientException) {
-            appendWebClientDetails(details, webClientException);
-        }
-        if (exception instanceof OpenAIServiceException openAiException) {
-            appendOpenAiDetails(details, openAiException);
-        }
-        if (exception instanceof ResponseStatusException statusException) {
-            appendStatusExceptionDetails(details, statusException);
+            appendHttpStatus(details, restClientException.getStatusCode().value());
+        } else if (exception instanceof WebClientResponseException webClientException) {
+            appendHttpStatus(details, webClientException.getStatusCode().value());
+        } else if (exception instanceof OpenAIServiceException openAiException) {
+            appendHttpStatus(details, openAiException.statusCode());
+        } else if (exception instanceof ResponseStatusException statusException) {
+            appendHttpStatus(details, statusException.getStatusCode().value());
         }
         return details.toString();
     }
 
-    private void appendRestClientDetails(StringBuilder details, RestClientResponseException exception) {
-        details.append(" [httpStatus=").append(exception.getStatusCode().value());
-        String statusText = exception.getStatusText();
-        if (!statusText.isBlank()) {
-            details.append(" ").append(statusText);
-        }
-        String responseBody = exception.getResponseBodyAsString();
-        if (!responseBody.isBlank()) {
-            details.append(", body=").append(responseBody);
-        }
-        HttpHeaders headers =
-                Optional.ofNullable(exception.getResponseHeaders()).orElseGet(HttpHeaders::new);
-        if (!headers.isEmpty()) {
-            details.append(", headers=").append(headers);
-        }
-        details.append("]");
-    }
-
-    private void appendWebClientDetails(StringBuilder details, WebClientResponseException exception) {
-        details.append(" [httpStatus=").append(exception.getStatusCode().value());
-        String statusText = exception.getStatusText();
-        if (!statusText.isBlank()) {
-            details.append(" ").append(statusText);
-        }
-        String responseBody = exception.getResponseBodyAsString();
-        if (!responseBody.isBlank()) {
-            details.append(", body=").append(responseBody);
-        }
-        HttpHeaders headers = exception.getHeaders();
-        if (!headers.isEmpty()) {
-            details.append(", headers=").append(headers);
-        }
-        details.append("]");
-    }
-
-    private void appendOpenAiDetails(StringBuilder details, OpenAIServiceException exception) {
-        details.append(" [httpStatus=").append(exception.statusCode());
-        var headers = exception.headers();
-        if (!headers.isEmpty()) {
-            details.append(", headers=").append(headers);
-        }
-        String body = exception.body().toString();
-        if (!body.isBlank()) {
-            details.append(", body=").append(body);
-        }
-        exception.code().ifPresent(code -> details.append(", code=").append(code));
-        exception.param().ifPresent(param -> details.append(", param=").append(param));
-        exception.type().ifPresent(type -> details.append(", type=").append(type));
-        details.append("]");
-    }
-
-    private void appendStatusExceptionDetails(StringBuilder details, ResponseStatusException exception) {
-        details.append(" [httpStatus=")
-                .append(exception.getStatusCode().value())
-                .append("]");
+    private static void appendHttpStatus(StringBuilder details, int httpStatus) {
+        details.append(" [httpStatus=").append(httpStatus).append("]");
     }
 }

--- a/src/main/java/com/williamcallahan/javachat/web/IngestionController.java
+++ b/src/main/java/com/williamcallahan/javachat/web/IngestionController.java
@@ -63,18 +63,13 @@ public class IngestionController extends BaseController {
             log.error(
                     "IO error during ingestion (exception type: {})",
                     ioException.getClass().getSimpleName());
-            return buildIngestionError(
-                    HttpStatus.INTERNAL_SERVER_ERROR,
-                    "Failed to ingest documents: " + ioException.getMessage(),
-                    ioException);
+            return buildIngestionError(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to ingest documents", ioException);
         } catch (RuntimeException runtimeException) {
             log.error(
                     "Unexpected error during ingestion (exception type: {})",
                     runtimeException.getClass().getSimpleName());
             return buildIngestionError(
-                    HttpStatus.INTERNAL_SERVER_ERROR,
-                    "Failed to perform ingestion: " + runtimeException.getMessage(),
-                    runtimeException);
+                    HttpStatus.INTERNAL_SERVER_ERROR, "Failed to perform ingestion", runtimeException);
         }
     }
 
@@ -95,17 +90,13 @@ public class IngestionController extends BaseController {
                     "Local ingestion IO error (exception type: {})",
                     ioException.getClass().getSimpleName());
             return buildIngestionError(
-                    HttpStatus.INTERNAL_SERVER_ERROR,
-                    "Failed to perform local ingestion: " + ioException.getMessage(),
-                    ioException);
+                    HttpStatus.INTERNAL_SERVER_ERROR, "Failed to perform local ingestion", ioException);
         } catch (RuntimeException runtimeException) {
             log.error(
                     "Local ingestion error (exception type: {})",
                     runtimeException.getClass().getSimpleName());
             return buildIngestionError(
-                    HttpStatus.INTERNAL_SERVER_ERROR,
-                    "Failed to perform local ingestion: " + runtimeException.getMessage(),
-                    runtimeException);
+                    HttpStatus.INTERNAL_SERVER_ERROR, "Failed to perform local ingestion", runtimeException);
         }
     }
 
@@ -121,7 +112,7 @@ public class IngestionController extends BaseController {
     private ResponseEntity<IngestionErrorResponse> buildIngestionValidationError(
             IllegalArgumentException validationException) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(IngestionErrorResponse.error(validationException.getMessage()));
+                .body(IngestionErrorResponse.error("Invalid ingestion request"));
     }
 
     private ResponseEntity<IngestionErrorResponse> buildIngestionError(

--- a/src/main/java/com/williamcallahan/javachat/web/SseSupport.java
+++ b/src/main/java/com/williamcallahan/javachat/web/SseSupport.java
@@ -87,9 +87,9 @@ public class SseSupport {
                         BufferOverflowStrategy.DROP_OLDEST)
                 // Two subscribers consume this stream in controllers:
                 // 1) text event emission, 2) heartbeat termination signal.
-                // autoConnect(2) prevents a race where one subscriber could miss the first chunks.
+                // refCount(2) preserves their rendezvous and disconnects upstream when both cancel.
                 .publish()
-                .autoConnect(2);
+                .refCount(2);
     }
 
     /**

--- a/src/test/java/com/williamcallahan/javachat/domain/ingestion/GitHubCollectionNamingScriptTest.java
+++ b/src/test/java/com/williamcallahan/javachat/domain/ingestion/GitHubCollectionNamingScriptTest.java
@@ -1,0 +1,108 @@
+package com.williamcallahan.javachat.domain.ingestion;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the shell pipeline that owns canonical GitHub collection naming.
+ */
+class GitHubCollectionNamingScriptTest {
+
+    @Test
+    void separatesHyphenatedOwnerAndRepositoryBoundaries() throws IOException, InterruptedException {
+        String hyphenatedOwnerCollection = resolveCanonicalCollectionName("https://github.com/a-b/c");
+        String hyphenatedRepositoryCollection = resolveCanonicalCollectionName("https://github.com/a/b-c");
+
+        assertEquals("github-a-b_c", hyphenatedOwnerCollection);
+        assertEquals("github-a-b-c", hyphenatedRepositoryCollection);
+        assertNotEquals(hyphenatedOwnerCollection, hyphenatedRepositoryCollection);
+    }
+
+    @Test
+    void preservesExistingCollectionNamesForSimpleOwners() throws IOException, InterruptedException {
+        assertEquals(
+                "github-williamagh-apple-maps-java",
+                resolveCanonicalCollectionName("https://github.com/williamagh/apple-maps-java"));
+        assertEquals("github-williamagh-tui4j", resolveCanonicalCollectionName("https://github.com/williamagh/tui4j"));
+    }
+
+    @Test
+    void keepsPunctuationVariantsDistinct() throws IOException, InterruptedException {
+        String underscoreRepositoryCollection = resolveCanonicalCollectionName("https://github.com/openai/java_chat");
+        String hyphenRepositoryCollection = resolveCanonicalCollectionName("https://github.com/openai/java-chat");
+
+        assertNotEquals(underscoreRepositoryCollection, hyphenRepositoryCollection);
+    }
+
+    @Test
+    void normalizesRepositoryIdentityCase() throws IOException, InterruptedException {
+        assertEquals(
+                resolveCanonicalCollectionName("https://github.com/OpenAI/Java-Chat"),
+                resolveCanonicalCollectionName("https://github.com/openai/java-chat"));
+    }
+
+    @Test
+    void acceptsExistingCanonicalCollectionDuringBatchSync() throws IOException, InterruptedException {
+        ShellInvocation shellInvocation =
+                validateCollectionName("github-williamagh-tui4j", "https://github.com/williamagh/tui4j");
+
+        assertEquals(0, shellInvocation.exitCode(), shellInvocation.standardOutput());
+    }
+
+    @Test
+    void rejectsAmbiguousLegacyCollectionBeforeBatchSync() throws IOException, InterruptedException {
+        ShellInvocation shellInvocation = validateCollectionName("github-a-b-c", "https://github.com/a-b/c");
+
+        assertNotEquals(0, shellInvocation.exitCode(), shellInvocation.standardOutput());
+        assertTrue(shellInvocation.standardOutput().contains("canonical name 'github-a-b_c'"));
+    }
+
+    private String resolveCanonicalCollectionName(String repositoryUrl) throws IOException, InterruptedException {
+        Path identityScriptPath =
+                Path.of("scripts", "lib", "github_identity.sh").toAbsolutePath();
+        ProcessBuilder shellCommand = new ProcessBuilder(
+                "bash",
+                "-c",
+                "RED=''; NC=''; source \"$GITHUB_IDENTITY_SCRIPT\"; "
+                        + "extract_repository_identity \"$GITHUB_REPOSITORY_URL\"; "
+                        + "printf '%s' \"$CANONICAL_COLLECTION_NAME\"");
+        shellCommand.environment().put("GITHUB_IDENTITY_SCRIPT", identityScriptPath.toString());
+        shellCommand.environment().put("GITHUB_REPOSITORY_URL", repositoryUrl);
+        shellCommand.redirectErrorStream(true);
+
+        Process shellProcess = shellCommand.start();
+        String scriptStandardOutput = new String(shellProcess.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        int scriptExitCode = shellProcess.waitFor();
+
+        assertEquals(0, scriptExitCode, scriptStandardOutput);
+        return scriptStandardOutput.trim();
+    }
+
+    private ShellInvocation validateCollectionName(String collectionName, String repositoryUrl)
+            throws IOException, InterruptedException {
+        Path identityScriptPath =
+                Path.of("scripts", "lib", "github_identity.sh").toAbsolutePath();
+        ProcessBuilder shellCommand = new ProcessBuilder(
+                "bash",
+                "-c",
+                "RED=''; NC=''; source \"$GITHUB_IDENTITY_SCRIPT\"; "
+                        + "require_canonical_collection_name \"$GITHUB_COLLECTION_NAME\" \"$GITHUB_REPOSITORY_URL\"");
+        shellCommand.environment().put("GITHUB_IDENTITY_SCRIPT", identityScriptPath.toString());
+        shellCommand.environment().put("GITHUB_COLLECTION_NAME", collectionName);
+        shellCommand.environment().put("GITHUB_REPOSITORY_URL", repositoryUrl);
+        shellCommand.redirectErrorStream(true);
+
+        Process shellProcess = shellCommand.start();
+        String scriptStandardOutput = new String(shellProcess.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        int scriptExitCode = shellProcess.waitFor();
+        return new ShellInvocation(scriptExitCode, scriptStandardOutput.trim());
+    }
+
+    private record ShellInvocation(int exitCode, String standardOutput) {}
+}

--- a/src/test/java/com/williamcallahan/javachat/domain/ingestion/GitHubRepositoryIdentityTest.java
+++ b/src/test/java/com/williamcallahan/javachat/domain/ingestion/GitHubRepositoryIdentityTest.java
@@ -1,9 +1,7 @@
 package com.williamcallahan.javachat.domain.ingestion;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -13,23 +11,13 @@ import org.junit.jupiter.api.Test;
 class GitHubRepositoryIdentityTest {
 
     @Test
-    void createsCanonicalKeyUrlAndCollectionName() {
+    void createsCanonicalKeyAndUrl() {
         GitHubRepositoryIdentity repositoryIdentity = GitHubRepositoryIdentity.of("OpenAI", "Java_Chat");
 
         assertEquals("openai", repositoryIdentity.owner());
         assertEquals("java_chat", repositoryIdentity.repository());
         assertEquals("openai/java_chat", repositoryIdentity.canonicalRepoKey());
         assertEquals("https://github.com/openai/java_chat", repositoryIdentity.canonicalRepoUrl());
-        assertTrue(repositoryIdentity.canonicalCollectionName().startsWith("github-openai-java-chat-h"));
-    }
-
-    @Test
-    void avoidsCollectionNameCollisionBetweenUnderscoreAndHyphenRepositoryNames() {
-        GitHubRepositoryIdentity underscoreIdentity = GitHubRepositoryIdentity.of("openai", "java_chat");
-        GitHubRepositoryIdentity hyphenIdentity = GitHubRepositoryIdentity.of("openai", "java-chat");
-
-        assertNotEquals(underscoreIdentity.canonicalCollectionName(), hyphenIdentity.canonicalCollectionName());
-        assertEquals("github-openai-java-chat", hyphenIdentity.canonicalCollectionName());
     }
 
     @Test

--- a/src/test/java/com/williamcallahan/javachat/service/EmbeddingModelKeepAliveTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/EmbeddingModelKeepAliveTest.java
@@ -63,6 +63,20 @@ class EmbeddingModelKeepAliveTest {
     }
 
     @Test
+    void deferredProbePreservesLastCompletedHealthObservation() {
+        SequencedEmbeddingClient embeddingClient =
+                new SequencedEmbeddingClient(ProbeOutcome.SUCCESS, ProbeOutcome.DEFERRED);
+        EmbeddingModelKeepAlive keepAlive = new EmbeddingModelKeepAlive(embeddingClient, new SequencedNanoTime(100, 5));
+
+        keepAlive.keepEmbeddingModelWarm();
+        keepAlive.keepEmbeddingModelWarm();
+
+        assertEquals(2, embeddingClient.warmUpInvocationCount);
+        assertEquals(Status.UP, keepAlive.health().getStatus());
+        assertEquals(100L, keepAlive.health().getDetails().get("lastProbeDurationMs"));
+    }
+
+    @Test
     void repeatedSlowProbesWarnOnceAndRecoveryIsRecorded() {
         SequencedEmbeddingClient embeddingClient = new SequencedEmbeddingClient(
                 ProbeOutcome.SUCCESS, ProbeOutcome.SUCCESS, ProbeOutcome.SUCCESS, ProbeOutcome.SUCCESS);
@@ -130,6 +144,7 @@ class EmbeddingModelKeepAliveTest {
     /** Controls the provider outcome returned by a test probe. */
     private enum ProbeOutcome {
         SUCCESS,
+        DEFERRED,
         UNAVAILABLE,
         UNEXPECTED
     }
@@ -158,6 +173,7 @@ class EmbeddingModelKeepAliveTest {
             warmUpInvocationCount++;
             switch (probeOutcome.remove()) {
                 case SUCCESS -> {}
+                case DEFERRED -> throw new OpenAiCompatibleEmbeddingClient.EmbeddingProbeDeferredException();
                 case UNAVAILABLE -> throw new EmbeddingServiceUnavailableException("provider offline for test");
                 case UNEXPECTED -> throw new IllegalStateException("unexpected provider defect");
             }

--- a/src/test/java/com/williamcallahan/javachat/service/HybridVectorServiceTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/HybridVectorServiceTest.java
@@ -1,0 +1,94 @@
+package com.williamcallahan.javachat.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.util.concurrent.Futures;
+import com.williamcallahan.javachat.application.search.LexicalSparseVectorEncoder;
+import com.williamcallahan.javachat.config.AppProperties;
+import io.grpc.Status;
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.grpc.Common.Filter;
+import io.qdrant.client.grpc.Points.UpdateResult;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.document.Document;
+
+/**
+ * Verifies each retried Qdrant write or count starts a fresh asynchronous operation.
+ */
+class HybridVectorServiceTest {
+
+    private static final String COLLECTION_NAME = "retry-test-collection";
+    private static final String DOCUMENT_ID = "123e4567-e89b-12d3-a456-426614174000";
+    private static final String DOCUMENT_TEXT = "Java records are immutable data carriers.";
+    private static final String DOCUMENT_URL = "https://docs.example.com/java/records";
+    private static final long RECOVERED_POINT_COUNT = 7L;
+
+    private QdrantClient qdrantClient;
+    private EmbeddingClient embeddingClient;
+    private LexicalSparseVectorEncoder sparseVectorEncoder;
+    private HybridVectorService hybridVectorService;
+
+    @BeforeEach
+    void setUp() {
+        qdrantClient = mock(QdrantClient.class);
+        embeddingClient = mock(EmbeddingClient.class);
+        sparseVectorEncoder = mock(LexicalSparseVectorEncoder.class);
+        hybridVectorService =
+                new HybridVectorService(qdrantClient, embeddingClient, sparseVectorEncoder, new AppProperties());
+    }
+
+    @Test
+    void upsertStartsFreshOperationAfterTransientFailure() {
+        when(embeddingClient.embed(List.of(DOCUMENT_TEXT), LlmGatewayTier.BATCH))
+                .thenReturn(List.of(new float[] {0.1f, 0.2f}));
+        when(sparseVectorEncoder.encode(DOCUMENT_TEXT))
+                .thenReturn(new LexicalSparseVectorEncoder.SparseVector(List.of(1L), List.of(1.0f)));
+        AtomicInteger operationStartCount = new AtomicInteger();
+        doAnswer(unusedInvocation -> operationStartCount.getAndIncrement() == 0
+                        ? Futures.immediateFailedFuture(Status.UNAVAILABLE.asRuntimeException())
+                        : Futures.immediateFuture(UpdateResult.getDefaultInstance()))
+                .when(qdrantClient)
+                .upsertAsync(eq(COLLECTION_NAME), anyList());
+
+        Document document = new Document(DOCUMENT_ID, DOCUMENT_TEXT, Map.of());
+
+        assertDoesNotThrow(() -> hybridVectorService.upsertToCollection(COLLECTION_NAME, List.of(document)));
+    }
+
+    @Test
+    void deleteStartsFreshOperationAfterTransientFailure() {
+        AtomicInteger operationStartCount = new AtomicInteger();
+        doAnswer(unusedInvocation -> operationStartCount.getAndIncrement() == 0
+                        ? Futures.immediateFailedFuture(Status.UNAVAILABLE.asRuntimeException())
+                        : Futures.immediateFuture(UpdateResult.getDefaultInstance()))
+                .when(qdrantClient)
+                .deleteAsync(eq(COLLECTION_NAME), any(Filter.class));
+
+        assertDoesNotThrow(() -> hybridVectorService.deleteByUrl(COLLECTION_NAME, DOCUMENT_URL));
+    }
+
+    @Test
+    void countStartsFreshOperationAfterTransientFailure() {
+        AtomicInteger operationStartCount = new AtomicInteger();
+        doAnswer(unusedInvocation -> operationStartCount.getAndIncrement() == 0
+                        ? Futures.immediateFailedFuture(Status.UNAVAILABLE.asRuntimeException())
+                        : Futures.immediateFuture(RECOVERED_POINT_COUNT))
+                .when(qdrantClient)
+                .countAsync(eq(COLLECTION_NAME), any(Filter.class), eq(true));
+
+        long pointCount = hybridVectorService.countPointsForUrl(COLLECTION_NAME, DOCUMENT_URL);
+
+        assertEquals(RECOVERED_POINT_COUNT, pointCount);
+    }
+}

--- a/src/test/java/com/williamcallahan/javachat/service/OpenAIStreamingServiceTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/OpenAIStreamingServiceTest.java
@@ -58,6 +58,28 @@ class OpenAIStreamingServiceTest {
     }
 
     @Test
+    void callerCancellationKeepsConfiguredPrimaryProviderEligible() {
+        RateLimitService rateLimitService = mock(RateLimitService.class);
+        when(rateLimitService.isProviderAvailable(RateLimitService.ApiProvider.OPENAI))
+                .thenReturn(true);
+        when(rateLimitService.isProviderAvailable(RateLimitService.ApiProvider.GITHUB_MODELS))
+                .thenReturn(true);
+        OpenAiProviderRoutingService routingService = new OpenAiProviderRoutingService(rateLimitService, 600, "openai");
+        OpenAIClient openAiClient = mock(OpenAIClient.class);
+        OpenAIClient githubModelsClient = mock(OpenAIClient.class);
+        InterruptedIOException interruptedRequest = new InterruptedIOException("request interrupted by caller timeout");
+        OpenAIIoException cancelledCompletion = new OpenAIIoException("Request failed", interruptedRequest);
+
+        routingService.recordProviderFailure(RateLimitService.ApiProvider.OPENAI, cancelledCompletion);
+
+        List<OpenAiProviderCandidate> availableProviders =
+                routingService.selectAvailableProviderCandidates(githubModelsClient, openAiClient);
+        assertEquals(2, availableProviders.size());
+        assertEquals(
+                RateLimitService.ApiProvider.OPENAI, availableProviders.get(0).provider());
+    }
+
+    @Test
     void shouldBackoffPrimaryTreats401AsBackoffEligible() {
         OpenAiProviderRoutingService routingService = createRoutingService();
         Headers headers = Headers.builder().build();

--- a/src/test/java/com/williamcallahan/javachat/service/OpenAiCompatibleEmbeddingClientTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/OpenAiCompatibleEmbeddingClientTest.java
@@ -15,7 +15,18 @@ import com.openai.core.RequestOptions;
 import com.openai.models.embeddings.CreateEmbeddingResponse;
 import com.openai.models.embeddings.EmbeddingCreateParams;
 import com.openai.services.blocking.EmbeddingService;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -98,7 +109,7 @@ class OpenAiCompatibleEmbeddingClientTest {
     }
 
     @Test
-    void retriesTransientResponseValidationFailuresAndRecovers() {
+    void doesNotRetryResponseValidationFailuresOutsideTheSdk() {
         OpenAIClient client = mock(OpenAIClient.class);
         EmbeddingService embeddingService = mock(EmbeddingService.class);
 
@@ -116,29 +127,14 @@ class OpenAiCompatibleEmbeddingClientTest {
                         .build()))
                 .build();
 
-        CreateEmbeddingResponse recoveredResponse = CreateEmbeddingResponse.builder()
-                .model("text-embedding-qwen3-embedding-8b")
-                .usage(CreateEmbeddingResponse.Usage.builder()
-                        .promptTokens(1L)
-                        .totalTokens(1L)
-                        .build())
-                .data(List.of(com.openai.models.embeddings.Embedding.builder()
-                        .index(0L)
-                        .embedding(List.of(0.7f, 0.8f))
-                        .build()))
-                .build();
-
-        when(embeddingService.create(any(), any(RequestOptions.class)))
-                .thenReturn(malformedResponse, recoveredResponse);
+        when(embeddingService.create(any(), any(RequestOptions.class))).thenReturn(malformedResponse);
 
         try (OpenAiCompatibleEmbeddingClient clientAdapter = OpenAiCompatibleEmbeddingClient.create(
                 client, "text-embedding-qwen3-embedding-8b", EXPECTED_EMBEDDING_DIMENSION)) {
-            List<float[]> vectors = clientAdapter.embed(List.of("single"), LlmGatewayTier.LIVE);
-
-            assertEquals(1, vectors.size());
-            assertEquals(0.7f, vectors.get(0)[0]);
-            assertEquals(0.8f, vectors.get(0)[1]);
-            verify(embeddingService, times(2)).create(any(), any(RequestOptions.class));
+            assertThrows(
+                    EmbeddingServiceUnavailableException.class,
+                    () -> clientAdapter.embed(List.of("single"), LlmGatewayTier.LIVE));
+            verify(embeddingService).create(any(), any(RequestOptions.class));
         }
     }
 
@@ -236,5 +232,131 @@ class OpenAiCompatibleEmbeddingClientTest {
             clientAdapter.embed(List.of("batch document"), LlmGatewayTier.BATCH);
             verify(batchEmbeddingService).create(any(), any(RequestOptions.class));
         }
+    }
+
+    @Test
+    void defersProbeWhenForegroundEmbeddingIsAlreadyActive() throws Exception {
+        OpenAIClient liveClient = mock(OpenAIClient.class);
+        OpenAIClient batchClient = mock(OpenAIClient.class);
+        EmbeddingService liveEmbeddingService = mock(EmbeddingService.class);
+        EmbeddingService batchEmbeddingService = mock(EmbeddingService.class);
+        CountDownLatch foregroundStarted = new CountDownLatch(1);
+        CountDownLatch releaseForeground = new CountDownLatch(1);
+
+        when(liveClient.embeddings()).thenReturn(liveEmbeddingService);
+        when(batchClient.embeddings()).thenReturn(batchEmbeddingService);
+        when(liveEmbeddingService.create(any(), any(RequestOptions.class))).thenAnswer(invocation -> {
+            foregroundStarted.countDown();
+            assertTrue(releaseForeground.await(5, TimeUnit.SECONDS));
+            return successfulResponse();
+        });
+
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
+                OpenAiCompatibleEmbeddingClient clientAdapter = new OpenAiCompatibleEmbeddingClient(
+                        liveClient, batchClient, "text-embedding-qwen3-embedding-8b", EXPECTED_EMBEDDING_DIMENSION)) {
+            Future<List<float[]>> foregroundEmbedding =
+                    executor.submit(() -> clientAdapter.embed(List.of("live query"), LlmGatewayTier.LIVE));
+            try {
+                assertTrue(foregroundStarted.await(5, TimeUnit.SECONDS));
+
+                assertThrows(
+                        OpenAiCompatibleEmbeddingClient.EmbeddingProbeDeferredException.class, clientAdapter::warmUp);
+                verifyNoInteractions(batchEmbeddingService);
+            } finally {
+                releaseForeground.countDown();
+            }
+            assertEquals(1, foregroundEmbedding.get(5, TimeUnit.SECONDS).size());
+        }
+    }
+
+    @Test
+    void foregroundDoesNotWaitForProbeAdmittedBeforeItArrives() throws Exception {
+        OpenAIClient liveClient = mock(OpenAIClient.class);
+        OpenAIClient batchClient = mock(OpenAIClient.class);
+        EmbeddingService liveEmbeddingService = mock(EmbeddingService.class);
+        EmbeddingService batchEmbeddingService = mock(EmbeddingService.class);
+        CountDownLatch probeStarted = new CountDownLatch(1);
+        CountDownLatch releaseProbe = new CountDownLatch(1);
+
+        when(liveClient.embeddings()).thenReturn(liveEmbeddingService);
+        when(batchClient.embeddings()).thenReturn(batchEmbeddingService);
+        when(liveEmbeddingService.create(any(), any(RequestOptions.class))).thenReturn(successfulResponse());
+        when(batchEmbeddingService.create(any(), any(RequestOptions.class))).thenAnswer(invocation -> {
+            probeStarted.countDown();
+            assertTrue(releaseProbe.await(5, TimeUnit.SECONDS));
+            return successfulResponse();
+        });
+
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
+                OpenAiCompatibleEmbeddingClient clientAdapter = new OpenAiCompatibleEmbeddingClient(
+                        liveClient, batchClient, "text-embedding-qwen3-embedding-8b", EXPECTED_EMBEDDING_DIMENSION)) {
+            Future<?> admittedProbe = executor.submit(clientAdapter::warmUp);
+            try {
+                assertTrue(probeStarted.await(5, TimeUnit.SECONDS));
+
+                assertEquals(
+                        1,
+                        clientAdapter
+                                .embed(List.of("live query"), LlmGatewayTier.LIVE)
+                                .size());
+                verify(liveEmbeddingService).create(any(), any(RequestOptions.class));
+            } finally {
+                releaseProbe.countDown();
+            }
+            admittedProbe.get(5, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void usesSdkRetryBudgetForLiveAndSingleAttemptForBatch() throws IOException {
+        AtomicInteger requestCount = new AtomicInteger();
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/v1/embeddings", exchange -> {
+            requestCount.incrementAndGet();
+            respondWithRateLimit(exchange);
+        });
+        server.start();
+
+        try (OpenAiCompatibleEmbeddingClient clientAdapter = OpenAiCompatibleEmbeddingClient.create(
+                "http://127.0.0.1:" + server.getAddress().getPort() + "/v1",
+                "test-key",
+                "text-embedding-qwen3-embedding-8b",
+                EXPECTED_EMBEDDING_DIMENSION)) {
+            assertThrows(
+                    EmbeddingServiceUnavailableException.class,
+                    () -> clientAdapter.embed(List.of("batch document"), LlmGatewayTier.BATCH));
+            assertEquals(1, requestCount.get());
+
+            requestCount.set(0);
+            assertThrows(
+                    EmbeddingServiceUnavailableException.class,
+                    () -> clientAdapter.embed(List.of("live query"), LlmGatewayTier.LIVE));
+            assertEquals(3, requestCount.get());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    private static CreateEmbeddingResponse successfulResponse() {
+        return CreateEmbeddingResponse.builder()
+                .model("text-embedding-qwen3-embedding-8b")
+                .usage(CreateEmbeddingResponse.Usage.builder()
+                        .promptTokens(1L)
+                        .totalTokens(1L)
+                        .build())
+                .data(List.of(com.openai.models.embeddings.Embedding.builder()
+                        .index(0L)
+                        .embedding(List.of(0.4f, 0.6f))
+                        .build()))
+                .build();
+    }
+
+    private static void respondWithRateLimit(HttpExchange exchange) throws IOException {
+        byte[] responseBody = "{\"error\":{\"message\":\"rate limited\"}}".getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().add("Content-Type", "application/json");
+        exchange.getResponseHeaders().add("Retry-After", "0");
+        exchange.sendResponseHeaders(429, responseBody.length);
+        exchange.getResponseBody().write(responseBody);
+        exchange.close();
     }
 }

--- a/src/test/java/com/williamcallahan/javachat/service/ProviderCircuitStateTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/ProviderCircuitStateTest.java
@@ -1,0 +1,71 @@
+package com.williamcallahan.javachat.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies provider circuit availability transitions.
+ */
+class ProviderCircuitStateTest {
+    private static final int CONCURRENT_TRANSITION_ITERATIONS = 10_000;
+    private static final int CONCURRENT_TEST_TIMEOUT_SECONDS = 10;
+
+    @Test
+    void freshCircuitIsAvailable() {
+        ProviderCircuitState circuitState = new ProviderCircuitState(32);
+
+        assertTrue(circuitState.isAvailable());
+    }
+
+    @Test
+    void rateLimitPublishesRetryDeadlineBeforeOpeningCircuit() {
+        ProviderCircuitState circuitState = new ProviderCircuitState(32);
+
+        circuitState.recordRateLimit(60);
+
+        assertFalse(circuitState.isAvailable());
+    }
+
+    @Test
+    void concurrentCircuitOpeningAndAvailabilityChecksDoNotExposePartialState() throws Exception {
+        ExecutorService transitionExecutor = Executors.newFixedThreadPool(2);
+        AtomicReference<ProviderCircuitState> circuitStateReference = new AtomicReference<>();
+        AtomicInteger completedAvailabilityChecks = new AtomicInteger();
+        CyclicBarrier transitionBarrier = new CyclicBarrier(2);
+        try {
+            Future<?> rateLimitRecordingTask = transitionExecutor.submit(() -> {
+                for (int iteration = 0; iteration < CONCURRENT_TRANSITION_ITERATIONS; iteration++) {
+                    circuitStateReference.set(new ProviderCircuitState(32));
+                    transitionBarrier.await();
+                    circuitStateReference.get().recordRateLimit(60);
+                }
+                return null;
+            });
+            Future<?> availabilityCheckTask = transitionExecutor.submit(() -> {
+                for (int iteration = 0; iteration < CONCURRENT_TRANSITION_ITERATIONS; iteration++) {
+                    transitionBarrier.await();
+                    circuitStateReference.get().isAvailable();
+                    completedAvailabilityChecks.incrementAndGet();
+                }
+                return null;
+            });
+
+            rateLimitRecordingTask.get(CONCURRENT_TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            availabilityCheckTask.get(CONCURRENT_TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            assertEquals(CONCURRENT_TRANSITION_ITERATIONS, completedAvailabilityChecks.get());
+            assertFalse(circuitStateReference.get().isAvailable());
+        } finally {
+            transitionExecutor.shutdownNow();
+        }
+    }
+}

--- a/src/test/java/com/williamcallahan/javachat/service/RateLimitHeaderParserTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/RateLimitHeaderParserTest.java
@@ -3,8 +3,10 @@ package com.williamcallahan.javachat.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.openai.core.http.Headers;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -45,5 +47,20 @@ class RateLimitHeaderParserTest {
         Headers headers = Headers.builder().put("Retry-After", "15").build();
         RateLimitHeaderParser parser = new RateLimitHeaderParser();
         assertEquals(15L, parser.parseRetryAfterSeconds(headers));
+    }
+
+    @Test
+    void parseResetInstant_waitsForLatestPositiveRateLimitBucket() {
+        Headers headers = Headers.builder()
+                .put("x-ratelimit-reset-requests", "1s")
+                .put("x-ratelimit-reset-tokens", "60s")
+                .build();
+        RateLimitHeaderParser parser = new RateLimitHeaderParser();
+
+        Instant parsedResetTime = parser.parseResetInstant(headers).orElseThrow();
+        long remainingResetSeconds =
+                Duration.between(Instant.now(), parsedResetTime).getSeconds();
+
+        assertTrue(remainingResetSeconds >= 58, "Expected the 60-second token reset window");
     }
 }

--- a/src/test/java/com/williamcallahan/javachat/service/RateLimitStateTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/RateLimitStateTest.java
@@ -48,6 +48,18 @@ class RateLimitStateTest {
         assertEquals(1, providerState.getTotalFailures());
     }
 
+    @Test
+    void recordRateLimit_preservesProviderResetTimeAcrossRepeatedFailures() throws ReflectiveOperationException {
+        Instant providerResetTime = Instant.now().plus(Duration.ofMinutes(1));
+
+        rateLimitState.recordRateLimit(PROVIDER_NAME, providerResetTime, "1m");
+        rateLimitState.recordRateLimit(PROVIDER_NAME, providerResetTime, "1m");
+
+        RateLimitState.ProviderState providerState = providerState(PROVIDER_NAME);
+        assertEquals(providerResetTime, providerState.getRateLimitedUntil());
+        assertEquals(2, providerState.getConsecutiveFailures());
+    }
+
     private RateLimitState.ProviderState providerState(String providerName) throws ReflectiveOperationException {
         Field providerStatesField = RateLimitState.class.getDeclaredField("providerStates");
         providerStatesField.setAccessible(true);

--- a/src/test/java/com/williamcallahan/javachat/service/RerankerServiceTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/RerankerServiceTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.williamcallahan.javachat.config.AppProperties;
+import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -37,25 +38,28 @@ class RerankerServiceTest {
     }
 
     @Test
-    void rerankUsesBoundedCompletionBudget() {
+    void rerankUsesConfiguredCompletionBudgetAndTimeout() {
         OpenAIStreamingService streamingService = mock(OpenAIStreamingService.class);
         when(streamingService.isAvailable()).thenReturn(true);
-        when(streamingService.completeJsonObject(anyString(), eq(0.0), anyInt()))
+        Duration rerankerTimeout = Duration.ofSeconds(45);
+        when(streamingService.completeJsonObject(anyString(), eq(0.0), anyInt(), eq(rerankerTimeout)))
                 .thenReturn(Mono.just("{\"order\":[1,0]}"));
 
-        RerankerService rerankerService =
-                new RerankerService(streamingService, new ObjectMapper(), new AppProperties());
+        AppProperties appProperties = new AppProperties();
+        appProperties.getRag().setRerankerTimeout(rerankerTimeout);
+        RerankerService rerankerService = new RerankerService(streamingService, new ObjectMapper(), appProperties);
         List<Document> sourceDocuments = List.of(new Document("first"), new Document("second"));
 
         List<Document> rankedDocuments = rerankerService.rerank("query", sourceDocuments, 2);
 
         ArgumentCaptor<String> promptCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<Integer> outputBudgetCaptor = ArgumentCaptor.forClass(Integer.class);
-        verify(streamingService).completeJsonObject(promptCaptor.capture(), eq(0.0), outputBudgetCaptor.capture());
+        verify(streamingService)
+                .completeJsonObject(promptCaptor.capture(), eq(0.0), outputBudgetCaptor.capture(), eq(rerankerTimeout));
         verify(streamingService, never()).complete(anyString(), eq(0.0));
         assertTrue(promptCaptor.getValue().contains("Valid indices are 0 through 1."));
         assertTrue(promptCaptor.getValue().contains("Include each valid index exactly once"));
-        assertEquals(512, outputBudgetCaptor.getValue());
+        assertEquals(4_000, outputBudgetCaptor.getValue());
         assertEquals(sourceDocuments.get(1), rankedDocuments.get(0));
     }
 }

--- a/src/test/java/com/williamcallahan/javachat/service/StreamingAttemptContextTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/StreamingAttemptContextTest.java
@@ -1,0 +1,65 @@
+package com.williamcallahan.javachat.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import com.openai.client.OpenAIClient;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Sinks;
+
+/**
+ * Verifies bounded streaming attempts for single- and multi-provider routing.
+ */
+class StreamingAttemptContextTest {
+    private static final int EXPECTED_MAX_ATTEMPTS = 2;
+
+    @Test
+    void singleProviderGetsExactlyOneBoundedRetry() {
+        OpenAiProviderCandidate onlyProvider = provider(RateLimitService.ApiProvider.OPENAI);
+        StreamingAttemptContext firstAttempt = StreamingAttemptContext.first(List.of(onlyProvider), noticeSink());
+
+        assertAttempt(firstAttempt, onlyProvider, 1, true);
+
+        StreamingAttemptContext retryAttempt = firstAttempt.withNextAttempt();
+
+        assertAttempt(retryAttempt, onlyProvider, 2, false);
+        assertThrows(IllegalStateException.class, retryAttempt::withNextAttempt);
+    }
+
+    @Test
+    void multipleProvidersAreAttemptedExactlyOnceEach() {
+        OpenAiProviderCandidate primaryProvider = provider(RateLimitService.ApiProvider.OPENAI);
+        OpenAiProviderCandidate secondaryProvider = provider(RateLimitService.ApiProvider.GITHUB_MODELS);
+        StreamingAttemptContext firstAttempt =
+                StreamingAttemptContext.first(List.of(primaryProvider, secondaryProvider), noticeSink());
+
+        assertAttempt(firstAttempt, primaryProvider, 1, true);
+
+        StreamingAttemptContext secondAttempt = firstAttempt.withNextAttempt();
+
+        assertAttempt(secondAttempt, secondaryProvider, 2, false);
+        assertThrows(IllegalStateException.class, secondAttempt::withNextAttempt);
+    }
+
+    private static OpenAiProviderCandidate provider(RateLimitService.ApiProvider provider) {
+        return new OpenAiProviderCandidate(mock(OpenAIClient.class), provider);
+    }
+
+    private static Sinks.Many<StreamingNotice> noticeSink() {
+        return Sinks.many().multicast().onBackpressureBuffer();
+    }
+
+    private static void assertAttempt(
+            StreamingAttemptContext attemptContext,
+            OpenAiProviderCandidate expectedProvider,
+            int expectedAttempt,
+            boolean expectedHasNextAttempt) {
+        assertSame(expectedProvider, attemptContext.currentProvider());
+        assertEquals(expectedAttempt, attemptContext.currentAttempt());
+        assertEquals(EXPECTED_MAX_ATTEMPTS, attemptContext.maxAttempts());
+        assertEquals(expectedHasNextAttempt, attemptContext.hasNextAttempt());
+    }
+}

--- a/src/test/java/com/williamcallahan/javachat/service/ingestion/SourceCodeFileIngestionProcessorTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/ingestion/SourceCodeFileIngestionProcessorTest.java
@@ -34,6 +34,7 @@ import org.springframework.ai.document.Document;
  * Verifies incremental GitHub source ingestion behavior for changed and unchanged files.
  */
 class SourceCodeFileIngestionProcessorTest {
+    private static final String TARGET_COLLECTION_NAME = "target-collection";
 
     @Test
     void changedFilePrunesAndForcesReindex(@TempDir Path tempDirectory) throws IOException {
@@ -59,7 +60,7 @@ class SourceCodeFileIngestionProcessorTest {
         GitHubRepoMetadata repositoryMetadata = new GitHubRepoMetadata(
                 repositoryRoot.toString(),
                 GitHubRepositoryIdentity.of("openai", "java-chat"),
-                "github-openai-java-chat",
+                TARGET_COLLECTION_NAME,
                 "main",
                 "abcdef123456",
                 "MIT",
@@ -86,21 +87,85 @@ class SourceCodeFileIngestionProcessorTest {
 
         doNothing()
                 .when(hybridVectorService)
-                .upsertToCollection(eq("github-openai-java-chat"), eq(List.of(indexedDocument)));
+                .upsertToCollection(eq(TARGET_COLLECTION_NAME), eq(List.of(indexedDocument)));
         doNothing().when(localStoreService).markHashIngested("newhash");
         doNothing()
                 .when(localStoreService)
                 .markFileIngested(eq(sourceUrl), anyLong(), anyLong(), eq("new-fingerprint"), eq(List.of("newhash")));
 
-        SourceFileProcessingResult processingResult = ingestionProcessor.process(
-                repositoryRoot, sourceFilePath, repositoryMetadata, "github-openai-java-chat");
+        SourceFileProcessingResult processingResult =
+                ingestionProcessor.process(repositoryRoot, sourceFilePath, repositoryMetadata, TARGET_COLLECTION_NAME);
 
         assertTrue(processingResult.outcome().processed());
         assertEquals(sourceUrl, processingResult.fileUrl());
         verify(ingestedFilePruneService)
-                .pruneCollectionFileStrict("github-openai-java-chat", sourceUrl, previousFileRecord);
+                .pruneCollectionFileStrict(TARGET_COLLECTION_NAME, sourceUrl, previousFileRecord);
         verify(chunkProcessingService)
                 .processAndStoreChunksForce(anyString(), eq(sourceUrl), eq("Main.java"), anyString());
+        verify(chunkProcessingService, never())
+                .processAndStoreChunks(anyString(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void unchangedFileWithMissingPointCoverageForcesReindex(@TempDir Path tempDirectory) throws IOException {
+        ChunkProcessingService chunkProcessingService = Mockito.mock(ChunkProcessingService.class);
+        HybridVectorService hybridVectorService = Mockito.mock(HybridVectorService.class);
+        LocalStoreService localStoreService = Mockito.mock(LocalStoreService.class);
+        ProgressTracker progressTracker = Mockito.mock(ProgressTracker.class);
+        IngestedFilePruneService ingestedFilePruneService = Mockito.mock(IngestedFilePruneService.class);
+
+        SourceCodeFileIngestionProcessor ingestionProcessor = new SourceCodeFileIngestionProcessor(
+                chunkProcessingService,
+                hybridVectorService,
+                localStoreService,
+                progressTracker,
+                ingestedFilePruneService);
+
+        Path repositoryRoot = tempDirectory.resolve("repository");
+        Path sourceDirectory = repositoryRoot.resolve("src");
+        Files.createDirectories(sourceDirectory);
+        Path sourceFilePath = sourceDirectory.resolve("Main.java");
+        Files.writeString(sourceFilePath, "package demo; class Main {}", StandardCharsets.UTF_8);
+
+        GitHubRepoMetadata repositoryMetadata = new GitHubRepoMetadata(
+                repositoryRoot.toString(),
+                GitHubRepositoryIdentity.of("openai", "java-chat"),
+                TARGET_COLLECTION_NAME,
+                "main",
+                "abcdef123456",
+                "MIT",
+                "Example repository");
+
+        String sourceUrl = "https://github.com/openai/java-chat/blob/main/src/Main.java";
+        long fileSizeBytes = Files.size(sourceFilePath);
+        long lastModifiedMillis = Files.getLastModifiedTime(sourceFilePath).toMillis();
+        LocalStoreService.FileIngestionRecord previousFileRecord = new LocalStoreService.FileIngestionRecord(
+                fileSizeBytes, lastModifiedMillis, "same-fingerprint", List.of("existing-hash"));
+
+        when(localStoreService.computeFileContentFingerprint(sourceFilePath)).thenReturn("same-fingerprint");
+        when(localStoreService.readFileIngestionRecord(sourceUrl)).thenReturn(Optional.of(previousFileRecord));
+        when(hybridVectorService.countPointsForUrl(TARGET_COLLECTION_NAME, sourceUrl))
+                .thenReturn(0L);
+        when(progressTracker.formatPercent()).thenReturn("100%");
+
+        Document indexedDocument = new Document("point-1", "package demo; class Main {}", new HashMap<>());
+        indexedDocument.getMetadata().put("hash", "existing-hash");
+        ChunkProcessingService.ChunkProcessingOutcome chunkProcessingOutcome =
+                new ChunkProcessingService.ChunkProcessingOutcome(
+                        List.of(indexedDocument), List.of("existing-hash"), 1, 0);
+        when(chunkProcessingService.processAndStoreChunksForce(
+                        anyString(), eq(sourceUrl), eq("Main.java"), anyString()))
+                .thenReturn(chunkProcessingOutcome);
+
+        SourceFileProcessingResult processingResult =
+                ingestionProcessor.process(repositoryRoot, sourceFilePath, repositoryMetadata, TARGET_COLLECTION_NAME);
+
+        assertTrue(processingResult.outcome().processed());
+        verify(ingestedFilePruneService)
+                .pruneCollectionFileStrict(TARGET_COLLECTION_NAME, sourceUrl, previousFileRecord);
+        verify(chunkProcessingService)
+                .processAndStoreChunksForce(anyString(), eq(sourceUrl), eq("Main.java"), anyString());
+        verify(hybridVectorService).upsertToCollection(TARGET_COLLECTION_NAME, List.of(indexedDocument));
         verify(chunkProcessingService, never())
                 .processAndStoreChunks(anyString(), anyString(), anyString(), anyString());
     }
@@ -129,7 +194,7 @@ class SourceCodeFileIngestionProcessorTest {
         GitHubRepoMetadata repositoryMetadata = new GitHubRepoMetadata(
                 repositoryRoot.toString(),
                 GitHubRepositoryIdentity.of("openai", "java-chat"),
-                "github-openai-java-chat",
+                TARGET_COLLECTION_NAME,
                 "main",
                 "abcdef123456",
                 "MIT",
@@ -144,11 +209,11 @@ class SourceCodeFileIngestionProcessorTest {
 
         when(localStoreService.computeFileContentFingerprint(sourceFilePath)).thenReturn("same-fingerprint");
         when(localStoreService.readFileIngestionRecord(sourceUrl)).thenReturn(Optional.of(previousFileRecord));
-        when(hybridVectorService.countPointsForUrl("github-openai-java-chat", sourceUrl))
+        when(hybridVectorService.countPointsForUrl(TARGET_COLLECTION_NAME, sourceUrl))
                 .thenReturn(2L);
 
-        SourceFileProcessingResult processingResult = ingestionProcessor.process(
-                repositoryRoot, sourceFilePath, repositoryMetadata, "github-openai-java-chat");
+        SourceFileProcessingResult processingResult =
+                ingestionProcessor.process(repositoryRoot, sourceFilePath, repositoryMetadata, TARGET_COLLECTION_NAME);
 
         assertFalse(processingResult.outcome().processed());
         assertTrue(processingResult.outcome().failure().isEmpty());
@@ -185,7 +250,7 @@ class SourceCodeFileIngestionProcessorTest {
         GitHubRepoMetadata repositoryMetadata = new GitHubRepoMetadata(
                 repositoryRoot.toString(),
                 GitHubRepositoryIdentity.of("openai", "java-chat"),
-                "github-openai-java-chat",
+                TARGET_COLLECTION_NAME,
                 "main",
                 "abcdef123456",
                 "MIT",
@@ -200,11 +265,11 @@ class SourceCodeFileIngestionProcessorTest {
 
         when(localStoreService.computeFileContentFingerprint(sourceFilePath)).thenReturn("same-fingerprint");
         when(localStoreService.readFileIngestionRecord(sourceUrl)).thenReturn(Optional.of(previousFileRecord));
-        when(hybridVectorService.countPointsForUrl("github-openai-java-chat", sourceUrl))
+        when(hybridVectorService.countPointsForUrl(TARGET_COLLECTION_NAME, sourceUrl))
                 .thenReturn(1L);
 
-        SourceFileProcessingResult processingResult = ingestionProcessor.process(
-                repositoryRoot, sourceFilePath, repositoryMetadata, "github-openai-java-chat");
+        SourceFileProcessingResult processingResult =
+                ingestionProcessor.process(repositoryRoot, sourceFilePath, repositoryMetadata, TARGET_COLLECTION_NAME);
 
         assertFalse(processingResult.outcome().processed());
         assertTrue(processingResult.outcome().failure().isEmpty());
@@ -238,14 +303,14 @@ class SourceCodeFileIngestionProcessorTest {
         GitHubRepoMetadata repositoryMetadata = new GitHubRepoMetadata(
                 repositoryRoot.toString(),
                 GitHubRepositoryIdentity.of("owner", "repo"),
-                "github-owner-repo",
+                TARGET_COLLECTION_NAME,
                 "main",
                 "abc123",
                 "",
                 "");
 
         SourceFileProcessingResult processingResult =
-                ingestionProcessor.process(repositoryRoot, sourceFilePath, repositoryMetadata, "github-owner-repo");
+                ingestionProcessor.process(repositoryRoot, sourceFilePath, repositoryMetadata, TARGET_COLLECTION_NAME);
 
         assertFalse(processingResult.outcome().processed());
         assertTrue(processingResult.fileUrl().startsWith("https://github.com/owner/repo/blob/main/src/Empty.java"));

--- a/src/test/java/com/williamcallahan/javachat/web/CustomErrorControllerTest.java
+++ b/src/test/java/com/williamcallahan/javachat/web/CustomErrorControllerTest.java
@@ -1,10 +1,14 @@
 package com.williamcallahan.javachat.web;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import ch.qos.logback.classic.Level;
@@ -81,6 +85,29 @@ class CustomErrorControllerTest {
         assertEquals(Level.WARN, event.getLevel());
         assertTrue(event.getFormattedMessage().contains("status=404 source=dispatcherServlet method=GET"));
         assertTrue(event.getFormattedMessage().contains("uri=/api/unknown host=localhost"));
+    }
+
+    @Test
+    void does_not_expose_servlet_error_message_for_api_requests() throws Exception {
+        String servletSecret = "OPENAI_API_KEY=secret-value";
+
+        mvc.perform(errorRequest(HttpStatus.BAD_REQUEST, "/api/chat")
+                        .requestAttr(RequestDispatcher.ERROR_MESSAGE, servletSecret))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value("error"))
+                .andExpect(jsonPath("$.message").value(HttpStatus.BAD_REQUEST.getReasonPhrase()))
+                .andExpect(content().string(not(containsString(servletSecret))));
+    }
+
+    @Test
+    void returns_stable_api_error_when_servlet_throwable_is_not_an_exception() throws Exception {
+        AssertionError nonExceptionFailure = new AssertionError("fatal servlet failure");
+
+        mvc.perform(errorRequest(HttpStatus.INTERNAL_SERVER_ERROR, "/api/chat")
+                        .requestAttr(RequestDispatcher.ERROR_EXCEPTION, nonExceptionFailure))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.status").value("error"))
+                .andExpect(jsonPath("$.message").value(HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase()));
     }
 
     @Test

--- a/src/test/java/com/williamcallahan/javachat/web/ExceptionResponseBuilderTest.java
+++ b/src/test/java/com/williamcallahan/javachat/web/ExceptionResponseBuilderTest.java
@@ -1,58 +1,120 @@
 package com.williamcallahan.javachat.web;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
+import com.openai.core.http.Headers;
+import com.openai.errors.BadRequestException;
+import com.openai.models.ErrorObject;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
-/**
- * Verifies exception descriptions include HTTP details when available.
- */
+/** Verifies exception descriptions expose only client-safe diagnostics. */
 class ExceptionResponseBuilderTest {
-    private static final String TEST_HEADER_NAME = "X-Test";
-    private static final String TEST_HEADER_VALUE = "1";
-    private static final String HTTP_STATUS_TEXT_BAD_REQUEST = "Bad Request";
-    private static final String HTTP_STATUS_TEXT_BLANK = "";
-    private static final String RESPONSE_BODY_PROBLEM = "problem";
-    private static final String EXPECTED_HTTP_STATUS_TOKEN = "httpStatus=400";
-    private static final String EXPECTED_BODY_TOKEN = "body=problem";
-    private static final String EXPECTED_HEADERS_TOKEN = "headers=";
+    private static final String TEST_AUTHORIZATION_HEADER_VALUE = "Bearer authorization-secret";
+    private static final String TEST_COOKIE_HEADER_VALUE = "session=cookie-secret";
+    private static final String TEST_RESPONSE_BODY_SECRET = "response-body-secret";
+    private static final String TEST_PREPARED_EXCEPTION_MESSAGE = "400 Bad Request: " + TEST_RESPONSE_BODY_SECRET;
+    private static final String TEST_OPENAI_ERROR_CODE = "provider-error-code-secret";
+    private static final String TEST_OPENAI_ERROR_PARAMETER = "provider-parameter-secret";
+    private static final String TEST_OPENAI_ERROR_TYPE = "provider-error-type-secret";
+
+    private final ExceptionResponseBuilder exceptionResponseBuilder = new ExceptionResponseBuilder();
 
     @Test
-    void describeException_includesHttpStatusAndBody() {
-        HttpHeaders headers = new HttpHeaders();
-        headers.add(TEST_HEADER_NAME, TEST_HEADER_VALUE);
+    void shouldExposeOnlyTypeAndStatusForRestClientFailures() {
         HttpClientErrorException exception = HttpClientErrorException.create(
+                TEST_PREPARED_EXCEPTION_MESSAGE,
                 HttpStatus.BAD_REQUEST,
-                HTTP_STATUS_TEXT_BAD_REQUEST,
-                headers,
-                RESPONSE_BODY_PROBLEM.getBytes(StandardCharsets.UTF_8),
+                HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                sensitiveSpringHeaders(),
+                TEST_RESPONSE_BODY_SECRET.getBytes(StandardCharsets.UTF_8),
                 StandardCharsets.UTF_8);
 
-        ExceptionResponseBuilder builder = new ExceptionResponseBuilder();
-        String details = builder.describeException(exception);
+        String clientDiagnostic = exceptionResponseBuilder.describeException(exception);
 
-        assertTrue(details.contains(EXPECTED_HTTP_STATUS_TOKEN), details);
-        assertTrue(details.contains(EXPECTED_BODY_TOKEN), details);
-        assertTrue(details.contains(EXPECTED_HEADERS_TOKEN), details);
+        assertClientDiagnostic(
+                "BadRequest [httpStatus=400]",
+                clientDiagnostic,
+                TEST_PREPARED_EXCEPTION_MESSAGE,
+                HttpHeaders.AUTHORIZATION,
+                TEST_AUTHORIZATION_HEADER_VALUE,
+                HttpHeaders.COOKIE,
+                TEST_COOKIE_HEADER_VALUE,
+                TEST_RESPONSE_BODY_SECRET,
+                HttpStatus.BAD_REQUEST.getReasonPhrase());
     }
 
     @Test
-    void describeException_handlesBlankStatusTextWithoutThrowing() {
-        HttpHeaders headers = new HttpHeaders();
-        HttpClientErrorException exception = HttpClientErrorException.create(
-                HttpStatus.BAD_REQUEST,
-                HTTP_STATUS_TEXT_BLANK,
-                headers,
-                RESPONSE_BODY_PROBLEM.getBytes(StandardCharsets.UTF_8),
+    void shouldExposeOnlyTypeAndStatusForWebClientFailures() {
+        WebClientResponseException exception = WebClientResponseException.create(
+                HttpStatus.BAD_GATEWAY.value(),
+                HttpStatus.BAD_GATEWAY.getReasonPhrase(),
+                sensitiveSpringHeaders(),
+                TEST_RESPONSE_BODY_SECRET.getBytes(StandardCharsets.UTF_8),
                 StandardCharsets.UTF_8);
 
-        ExceptionResponseBuilder builder = new ExceptionResponseBuilder();
-        String details = assertDoesNotThrow(() -> builder.describeException(exception));
-        assertTrue(details.contains(EXPECTED_HTTP_STATUS_TOKEN), details);
+        String clientDiagnostic = exceptionResponseBuilder.describeException(exception);
+
+        assertClientDiagnostic(
+                "BadGateway [httpStatus=502]",
+                clientDiagnostic,
+                HttpHeaders.AUTHORIZATION,
+                TEST_AUTHORIZATION_HEADER_VALUE,
+                HttpHeaders.COOKIE,
+                TEST_COOKIE_HEADER_VALUE,
+                TEST_RESPONSE_BODY_SECRET,
+                HttpStatus.BAD_GATEWAY.getReasonPhrase());
+    }
+
+    @Test
+    void shouldExposeOnlyTypeAndStatusForOpenAiFailures() {
+        Headers providerHeaders = Headers.builder()
+                .put(HttpHeaders.AUTHORIZATION, TEST_AUTHORIZATION_HEADER_VALUE)
+                .put(HttpHeaders.COOKIE, TEST_COOKIE_HEADER_VALUE)
+                .build();
+        ErrorObject providerError = ErrorObject.builder()
+                .message(TEST_RESPONSE_BODY_SECRET)
+                .code(TEST_OPENAI_ERROR_CODE)
+                .param(TEST_OPENAI_ERROR_PARAMETER)
+                .type(TEST_OPENAI_ERROR_TYPE)
+                .build();
+        BadRequestException exception = BadRequestException.builder()
+                .headers(providerHeaders)
+                .error(providerError)
+                .build();
+
+        String clientDiagnostic = exceptionResponseBuilder.describeException(exception);
+
+        assertClientDiagnostic(
+                "BadRequestException [httpStatus=400]",
+                clientDiagnostic,
+                HttpHeaders.AUTHORIZATION,
+                TEST_AUTHORIZATION_HEADER_VALUE,
+                HttpHeaders.COOKIE,
+                TEST_COOKIE_HEADER_VALUE,
+                TEST_RESPONSE_BODY_SECRET,
+                TEST_OPENAI_ERROR_CODE,
+                TEST_OPENAI_ERROR_PARAMETER,
+                TEST_OPENAI_ERROR_TYPE);
+    }
+
+    private static HttpHeaders sensitiveSpringHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.AUTHORIZATION, TEST_AUTHORIZATION_HEADER_VALUE);
+        headers.add(HttpHeaders.COOKIE, TEST_COOKIE_HEADER_VALUE);
+        return headers;
+    }
+
+    private static void assertClientDiagnostic(
+            String expectedDiagnostic, String clientDiagnostic, String... prohibitedTokens) {
+        assertEquals(expectedDiagnostic, clientDiagnostic);
+        for (String prohibitedToken : prohibitedTokens) {
+            assertFalse(clientDiagnostic.contains(prohibitedToken), clientDiagnostic);
+        }
     }
 }

--- a/src/test/java/com/williamcallahan/javachat/web/IngestionControllerTest.java
+++ b/src/test/java/com/williamcallahan/javachat/web/IngestionControllerTest.java
@@ -1,0 +1,76 @@
+package com.williamcallahan.javachat.web;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.williamcallahan.javachat.config.AppProperties;
+import com.williamcallahan.javachat.service.DocsIngestionService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Verifies Spring MVC enforces ingestion request limits before invoking application services.
+ */
+@WebMvcTest(controllers = IngestionController.class)
+@Import({AppProperties.class, ExceptionResponseBuilder.class})
+@WithMockUser
+class IngestionControllerTest {
+    private static final String DOWNSTREAM_SECRET = "downstream-response-body-secret";
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    DocsIngestionService docsIngestionService;
+
+    @Test
+    void rejectsRemoteIngestionAboveConfiguredPageLimit() throws Exception {
+        mockMvc.perform(post("/api/ingest").with(csrf()).param("maxPages", Integer.toString(Integer.MAX_VALUE)))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(docsIngestionService);
+    }
+
+    @Test
+    void rejectsLocalIngestionAboveConfiguredFileLimit() throws Exception {
+        mockMvc.perform(post("/api/ingest/local").with(csrf()).param("maxFiles", Integer.toString(Integer.MAX_VALUE)))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(docsIngestionService);
+    }
+
+    @Test
+    void omitsDownstreamDetailsFromRemoteIngestionFailures() throws Exception {
+        doThrow(new IllegalStateException(DOWNSTREAM_SECRET))
+                .when(docsIngestionService)
+                .crawlAndIngest(anyInt());
+
+        mockMvc.perform(post("/api/ingest").with(csrf()))
+                .andExpect(status().isInternalServerError())
+                .andExpect(content().string(not(containsString(DOWNSTREAM_SECRET))));
+    }
+
+    @Test
+    void omitsFilesystemDetailsFromLocalIngestionFailures() throws Exception {
+        when(docsIngestionService.ingestLocalDirectory(anyString(), anyInt()))
+                .thenThrow(new IllegalArgumentException(DOWNSTREAM_SECRET));
+
+        mockMvc.perform(post("/api/ingest/local").with(csrf()))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string(not(containsString(DOWNSTREAM_SECRET))));
+    }
+}

--- a/src/test/java/com/williamcallahan/javachat/web/SseSupportTest.java
+++ b/src/test/java/com/williamcallahan/javachat/web/SseSupportTest.java
@@ -8,8 +8,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.codec.ServerSentEvent;
+import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
@@ -41,6 +43,28 @@ class SseSupportTest {
         assertEquals(expectedContent, firstSubscriberContent, "First subscriber should receive full stream content");
         assertEquals(expectedContent, secondSubscriberContent, "Second subscriber should receive full stream content");
         assertEquals(expectedContent, consumedContent, "Chunk consumer should observe full stream content");
+    }
+
+    @Test
+    void cancellingTextAndHeartbeatStreamCancelsUpstream() {
+        SseSupport sseSupport = new SseSupport(new ObjectMapper());
+        AtomicInteger upstreamSubscriptionCount = new AtomicInteger();
+        AtomicInteger upstreamCancellationCount = new AtomicInteger();
+        Flux<String> upstreamStream = Flux.<String>never()
+                .doOnSubscribe(ignoredSubscription -> upstreamSubscriptionCount.incrementAndGet())
+                .doOnCancel(upstreamCancellationCount::incrementAndGet);
+        Flux<String> preparedStream = sseSupport.prepareDataStream(upstreamStream, ignoredChunk -> {});
+        Flux<ServerSentEvent<String>> sseEventStream =
+                Flux.merge(preparedStream.map(sseSupport::textEvent), sseSupport.heartbeats(preparedStream));
+
+        Disposable clientSubscription = sseEventStream.subscribe();
+
+        assertEquals(1, upstreamSubscriptionCount.get(), "Text and heartbeat subscribers should share one upstream");
+        assertEquals(0, upstreamCancellationCount.get(), "Active client should keep the upstream connected");
+
+        clientSubscription.dispose();
+
+        assertEquals(1, upstreamCancellationCount.get(), "Client cancellation should cancel the shared upstream");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Stabilizes Java Chat on the regular Gemma gateway alias and hardens the adjacent retrieval, rendering, ingestion, and error paths exposed during live dogfood.

## Changes

- raises structured reranking to the gateway-required 4,000-token reasoning budget and threads the caller timeout into the SDK request
- retries a single shared gateway endpoint exactly once when a transient stream fails before any answer text
- suppresses malformed enrichment control markers while preserving valid cards, prose, code fences, and ordinary braces
- removes multiplied embedding retries, uses SDK Retry-After behavior, and keeps background probes out of active foreground work
- makes repository ingestion deterministic, repairs incomplete vector coverage, and recreates asynchronous Qdrant operations per retry
- publishes provider circuit transitions atomically and honors provider availability windows
- keeps downstream failure details out of public API responses and cancels upstream work after SSE disconnect

## Verification

- full pre-push gate passed: frontend production build, Svelte checks, JVM build, 293 tests, SpotBugs/PMD, and lint
- dev deployment completed on 6512b39
- live dev prompt completed in one HTTP stream with no retry, no control-marker leakage, and no browser/network errors

## Notes

The production generation model remains the regular gemma-4-26b-a4b alias. Structured reranking is capability-routed by the gateway to a compatible binding under that same alias.