### PR TITLE
fix(app): resolve production citation and guided-learning regressions

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -7,6 +7,7 @@
   import { refreshCsrfToken } from './lib/services/csrf'
   import {
     applicationViewForPath,
+    canonicalRecoveryPathForPath,
     canonicalPathForApplicationView,
     synchronizeDocumentMetadata,
     type ApplicationView,
@@ -15,6 +16,7 @@
   let currentView = $state<ApplicationView>(applicationViewForPath(globalThis.location.pathname))
 
   $effect(() => {
+    recoverUnimplementedLessonRoute()
     if (applicationViewForPath(globalThis.location.pathname) !== currentView) {
       const selectedViewPath = canonicalPathForApplicationView(currentView)
       globalThis.history.pushState({}, '', selectedViewPath)
@@ -27,8 +29,16 @@
   })
 
   function synchronizeViewWithBrowserHistory(): void {
+    recoverUnimplementedLessonRoute()
     currentView = applicationViewForPath(globalThis.location.pathname)
     synchronizeDocumentMetadata()
+  }
+
+  function recoverUnimplementedLessonRoute(): void {
+    const canonicalRecoveryPath = canonicalRecoveryPathForPath(globalThis.location.pathname)
+    if (canonicalRecoveryPath) {
+      globalThis.history.replaceState({}, '', canonicalRecoveryPath)
+    }
   }
 </script>
 

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -105,6 +105,20 @@ describe("App route synchronization", () => {
     expectCurrentRouteMetadata(LEARN_CANONICAL_PATH);
   });
 
+  it("recovers an unimplemented direct learn descendant to the canonical learn route", async () => {
+    globalThis.history.replaceState({}, "", "/learn/not-a-lesson/");
+    const App = (await import("./App.svelte")).default;
+    const application = render(App);
+
+    expect(await application.findByRole("heading", { name: "Learn Java" })).toBeInTheDocument();
+    expect(application.getByRole("tab", { name: "Learn" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(globalThis.location.pathname).toBe(LEARN_CANONICAL_PATH);
+    expectCurrentRouteMetadata(LEARN_CANONICAL_PATH);
+  });
+
   it("honors a direct chat alias", async () => {
     globalThis.history.replaceState({}, "", "/chat");
     const App = (await import("./App.svelte")).default;
@@ -163,5 +177,21 @@ describe("App route synchronization", () => {
       "true",
     );
     expectCurrentRouteMetadata(CHAT_CANONICAL_PATH);
+  });
+
+  it("recovers an unimplemented guided descendant on browser history navigation", async () => {
+    const App = (await import("./App.svelte")).default;
+    const application = render(App);
+
+    globalThis.history.replaceState({}, "", "/guided/not-a-lesson/");
+    globalThis.dispatchEvent(new PopStateEvent("popstate"));
+
+    expect(await application.findByRole("heading", { name: "Learn Java" })).toBeInTheDocument();
+    expect(application.getByRole("tab", { name: "Learn" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(globalThis.location.pathname).toBe(LEARN_CANONICAL_PATH);
+    expectCurrentRouteMetadata(LEARN_CANONICAL_PATH);
   });
 });

--- a/frontend/src/lib/components/ChatInput.svelte
+++ b/frontend/src/lib/components/ChatInput.svelte
@@ -16,47 +16,84 @@
   let { onSend, disabled = false, placeholder = DEFAULT_PLACEHOLDER }: Props = $props()
 
   let inputValue = $state('')
-  let inputEl: HTMLTextAreaElement | null = $state(null)
+  let messageInput: HTMLTextAreaElement | null = $state(null)
+  let chatInputForm: HTMLFormElement | null = $state(null)
+  let previouslyDisabled = false
+  let submissionAwaitsDisabledTransition = false
+  let submissionOwnsDisabledTransition = false
 
-  function handleSubmit() {
-    if (!inputValue.trim() || disabled) return
-    onSend(inputValue.trim())
+  $effect(() => {
+    const hasDisabledStateTransition = disabled !== previouslyDisabled
+
+    if (submissionAwaitsDisabledTransition && hasDisabledStateTransition && disabled) {
+      submissionOwnsDisabledTransition = true
+    }
+
+    if (submissionOwnsDisabledTransition && hasDisabledStateTransition && !disabled) {
+      if (canRestoreMessageInputFocus()) {
+        messageInput?.focus()
+      }
+      submissionAwaitsDisabledTransition = false
+      submissionOwnsDisabledTransition = false
+    }
+
+    previouslyDisabled = disabled
+  })
+
+  function canRestoreMessageInputFocus(): boolean {
+    const focusedElement = document.activeElement
+    return (
+      focusedElement === null ||
+      focusedElement === document.body ||
+      chatInputForm?.contains(focusedElement) === true
+    )
+  }
+
+  function submitMessage(): void {
+    const submittedMessage = inputValue.trim()
+    if (!submittedMessage || disabled) return
+
+    submissionAwaitsDisabledTransition = true
+    onSend(submittedMessage)
     inputValue = ''
-    // Reset height after clearing
-    if (inputEl) {
-      inputEl.style.height = 'auto'
+    if (messageInput) {
+      messageInput.style.height = 'auto'
     }
   }
 
-  function handleKeyDown(e: KeyboardEvent) {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault()
-      handleSubmit()
+  function handleFormSubmit(submitEvent: SubmitEvent): void {
+    submitEvent.preventDefault()
+    submitMessage()
+  }
+
+  function handleKeyDown(keyboardEvent: KeyboardEvent) {
+    if (keyboardEvent.key === 'Enter' && !keyboardEvent.shiftKey) {
+      keyboardEvent.preventDefault()
+      submitMessage()
     }
   }
 
   function autoResize() {
-    if (!inputEl) return
-    inputEl.style.height = 'auto'
-    inputEl.style.height = `${Math.min(inputEl.scrollHeight, 200)}px`
+    if (!messageInput) return
+    messageInput.style.height = 'auto'
+    messageInput.style.height = `${Math.min(messageInput.scrollHeight, 200)}px`
   }
 
-  // Global keyboard shortcut
   onMount(() => {
-    function handleGlobalKeyDown(e: KeyboardEvent) {
-      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
-        e.preventDefault()
-        inputEl?.focus()
-        inputEl?.select()
+    function handleGlobalKeyDown(keyboardEvent: KeyboardEvent) {
+      if ((keyboardEvent.metaKey || keyboardEvent.ctrlKey) && keyboardEvent.key === 'k') {
+        keyboardEvent.preventDefault()
+        messageInput?.focus()
+        messageInput?.select()
       }
-      if (e.key === 'Escape' && document.activeElement === inputEl) {
+      if (keyboardEvent.key === 'Escape' && document.activeElement === messageInput) {
         inputValue = ''
-        if (inputEl) inputEl.style.height = 'auto'
+        if (messageInput) messageInput.style.height = 'auto'
       }
     }
 
     document.addEventListener('keydown', handleGlobalKeyDown)
-    inputEl?.focus()
+    messageInput?.focus()
 
     return () => {
       document.removeEventListener('keydown', handleGlobalKeyDown)
@@ -66,9 +103,9 @@
 
 <div class="input-area">
   <div class="input-container">
-    <div class="input-wrapper">
+    <form bind:this={chatInputForm} class="input-wrapper" onsubmit={handleFormSubmit}>
       <textarea
-        bind:this={inputEl}
+        bind:this={messageInput}
         bind:value={inputValue}
         oninput={autoResize}
         onkeydown={handleKeyDown}
@@ -80,9 +117,8 @@
       ></textarea>
 
       <button
-        type="button"
+        type="submit"
         class="send-btn"
-        onclick={handleSubmit}
         disabled={disabled || !inputValue.trim()}
         aria-label="Send message"
       >
@@ -96,7 +132,7 @@
           </svg>
         {/if}
       </button>
-    </div>
+    </form>
 
     <p class="input-hint">
       <span class="hint-text">Press <kbd>Enter</kbd> to send, <kbd>Shift + Enter</kbd> for new line</span>

--- a/frontend/src/lib/components/ChatInput.svelte
+++ b/frontend/src/lib/components/ChatInput.svelte
@@ -66,7 +66,9 @@
     submitMessage()
   }
 
-  function handleKeyDown(keyboardEvent: KeyboardEvent) {
+  function handleKeyDown(keyboardEvent: KeyboardEvent): void {
+    if (keyboardEvent.isComposing) return
+
     if (keyboardEvent.key === 'Enter' && !keyboardEvent.shiftKey) {
       keyboardEvent.preventDefault()
       submitMessage()

--- a/frontend/src/lib/components/ChatView.test.ts
+++ b/frontend/src/lib/components/ChatView.test.ts
@@ -43,6 +43,28 @@ describe("ChatView streaming stability", () => {
     vi.unstubAllGlobals();
   });
 
+  it("does not submit while an IME composition is active", async () => {
+    const renderedChatView = await renderChatView();
+    const messageInput = renderedChatView.getByLabelText("Message input");
+    if (!(messageInput instanceof HTMLTextAreaElement)) {
+      throw new Error("Expected message input element to be a textarea");
+    }
+
+    await fireEvent.input(messageInput, { target: { value: "record" } });
+    const composingEnterEvent = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      isComposing: true,
+      key: "Enter",
+    });
+    await fireEvent(messageInput, composingEnterEvent);
+
+    expect(composingEnterEvent.defaultPrevented).toBe(false);
+    expect(streamChatMock).not.toHaveBeenCalled();
+    expect(renderedChatView.container.querySelector(".message.user")).toBeNull();
+    expect(messageInput).toHaveValue("record");
+  });
+
   it("keeps the assistant message DOM node stable when the stream completes", async () => {
     let completeStream: () => void = () => {
       throw new Error("Expected stream completion callback to be set");

--- a/frontend/src/lib/components/ChatView.test.ts
+++ b/frontend/src/lib/components/ChatView.test.ts
@@ -84,6 +84,101 @@ describe("ChatView streaming stability", () => {
     expect(container.querySelector(".message.assistant .cursor.visible")).toBeNull();
   });
 
+  it("restores input focus after a submitted stream completes with focus in the form", async () => {
+    let completeStream: () => void = () => {
+      throw new Error("Expected stream completion callback to be set");
+    };
+    streamChatMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          completeStream = resolve;
+        }),
+    );
+
+    const renderedChatView = await renderChatView();
+    const messageInput = renderedChatView.getByLabelText("Message input");
+    if (!(messageInput instanceof HTMLTextAreaElement)) {
+      throw new Error("Expected message input element to be a textarea");
+    }
+    messageInput.focus();
+
+    await sendChatMessage(renderedChatView, "Explain records");
+    await vi.waitFor(() => expect(messageInput).toBeDisabled());
+    expect(messageInput).toHaveFocus();
+
+    completeStream();
+
+    await vi.waitFor(() => {
+      expect(messageInput).toBeEnabled();
+      expect(messageInput).toHaveFocus();
+    });
+  });
+
+  it("restores input focus after a submitted stream completes with focus on the document body", async () => {
+    let completeStream: () => void = () => {
+      throw new Error("Expected stream completion callback to be set");
+    };
+    streamChatMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          completeStream = resolve;
+        }),
+    );
+
+    const renderedChatView = await renderChatView();
+    const messageInput = renderedChatView.getByLabelText("Message input");
+    if (!(messageInput instanceof HTMLTextAreaElement)) {
+      throw new Error("Expected message input element to be a textarea");
+    }
+
+    await sendChatMessage(renderedChatView, "Explain records");
+    await vi.waitFor(() => expect(messageInput).toBeDisabled());
+
+    const transientFocusControl = document.createElement("button");
+    renderedChatView.container.append(transientFocusControl);
+    transientFocusControl.focus();
+    transientFocusControl.remove();
+    expect(document.activeElement).toBe(document.body);
+
+    completeStream();
+
+    await vi.waitFor(() => {
+      expect(messageInput).toBeEnabled();
+      expect(messageInput).toHaveFocus();
+    });
+  });
+
+  it("preserves external focus after a submitted stream completes", async () => {
+    let completeStream: () => void = () => {
+      throw new Error("Expected stream completion callback to be set");
+    };
+    streamChatMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          completeStream = resolve;
+        }),
+    );
+
+    const renderedChatView = await renderChatView();
+    const messageInput = renderedChatView.getByLabelText("Message input");
+    if (!(messageInput instanceof HTMLTextAreaElement)) {
+      throw new Error("Expected message input element to be a textarea");
+    }
+
+    await sendChatMessage(renderedChatView, "Explain records");
+    await vi.waitFor(() => expect(messageInput).toBeDisabled());
+
+    const externalNavigationButton = document.createElement("button");
+    renderedChatView.container.append(externalNavigationButton);
+    externalNavigationButton.focus();
+    expect(externalNavigationButton).toHaveFocus();
+
+    completeStream();
+
+    await vi.waitFor(() => expect(messageInput).toBeEnabled());
+    expect(externalNavigationButton).toHaveFocus();
+  });
+
   it("keeps a citation warning visible after response text and stream completion", async () => {
     let completeStream: () => void = () => {
       throw new Error("Expected stream completion callback to be set");

--- a/frontend/src/lib/components/CitationPanel.svelte
+++ b/frontend/src/lib/components/CitationPanel.svelte
@@ -4,7 +4,8 @@
     getCitationType,
     getDisplaySource,
     buildFullUrl,
-    deduplicateCitations
+    deduplicateCitations,
+    citationUrlIdentity
   } from '../utils/url'
 
   interface Props {
@@ -52,14 +53,6 @@
   /** Deduplicated citations for display, with defensive validation. */
   let uniqueCitations = $derived(deduplicateCitations(citations))
 
-  /**
-   * Builds the full citation URL including anchor fragment.
-   * Delegates to shared utility for sanitization.
-   */
-  function buildCitationUrl(citation: Citation): string {
-    return buildFullUrl(citation.url, citation.anchor)
-  }
-
   function toggleExpand() {
     isExpanded = !isExpanded
   }
@@ -86,12 +79,12 @@
 
     {#if isExpanded}
       <ul id={citationListId} class="citation-list" role="list" bind:this={citationListElement}>
-        {#each uniqueCitations as citation (citation.url)}
+        {#each uniqueCitations as citation (citationUrlIdentity(citation.url, citation.anchor))}
           {@const citationType = getCitationType(citation.url)}
           {@const displaySource = getDisplaySource(citation.url)}
           <li class="citation-item" data-type={citationType}>
             <a
-              href={buildCitationUrl(citation)}
+              href={buildFullUrl(citation.url, citation.anchor)}
               target="_blank"
               rel="noopener noreferrer"
               class="citation-link"

--- a/frontend/src/lib/components/CitationPanel.test.ts
+++ b/frontend/src/lib/components/CitationPanel.test.ts
@@ -21,6 +21,39 @@ const LIVE_PDF_CITATION: Citation[] = [
   },
 ];
 
+const SHARED_PAGE_CITATIONS: Citation[] = [
+  {
+    url: "HTTPS://DOCS.example.com/String.html",
+    anchor: "Foo()",
+    title: "String Foo method",
+    snippet: "Returns the Foo member.",
+  },
+  {
+    url: "https://docs.example.com/string.html",
+    anchor: "foo()",
+    title: "String foo method",
+    snippet: "Returns the foo member.",
+  },
+  {
+    url: "https://docs.example.com/STRING.html",
+    anchor: "Foo()",
+    title: "Duplicate String Foo method",
+    snippet: "Duplicates the Foo method citation.",
+  },
+  {
+    url: "https://docs.example.com/string.html",
+    anchor: "%3Cinit%3E()",
+    title: "String constructor",
+    snippet: "Creates a new string.",
+  },
+  {
+    url: "https://docs.example.com/STRING.html",
+    anchor: "%3Cinit%3E()",
+    title: "Duplicate constructor citation",
+    snippet: "Duplicates the constructor citation.",
+  },
+];
+
 describe("CitationPanel", () => {
   // The prototype polyfill lives in src/test/setup.ts; spying here captures calls
   // from the panel revealing the expanded list inside its scroll container.
@@ -85,5 +118,29 @@ describe("CitationPanel", () => {
     });
     expect(citationLink).not.toHaveAccessibleName(/%20/);
     expect(citationLink).toHaveAttribute("href", "/pdfs/Think Java - 2nd Edition Book.pdf#page=42");
+  });
+
+  it("renders case-sensitive anchors separately while collapsing matching citation identities", async () => {
+    const { getByRole, queryByText } = render(CitationPanel, {
+      props: { citations: SHARED_PAGE_CITATIONS },
+    });
+
+    await fireEvent.click(getByRole("button", { name: /3 sources/i }));
+    await tick();
+
+    expect(getByRole("link", { name: /String Foo method/ })).toHaveAttribute(
+      "href",
+      "HTTPS://DOCS.example.com/String.html#Foo()",
+    );
+    expect(getByRole("link", { name: /String foo method/ })).toHaveAttribute(
+      "href",
+      "https://docs.example.com/string.html#foo()",
+    );
+    expect(getByRole("link", { name: /String constructor/ })).toHaveAttribute(
+      "href",
+      "https://docs.example.com/string.html#%3Cinit%3E()",
+    );
+    expect(queryByText("Duplicate String Foo method")).toBeNull();
+    expect(queryByText("Duplicate constructor citation")).toBeNull();
   });
 });

--- a/frontend/src/lib/components/LearnView.ownership.test.ts
+++ b/frontend/src/lib/components/LearnView.ownership.test.ts
@@ -160,11 +160,7 @@ describe("LearnView async request ownership", () => {
     const learnView = await renderSelectedLesson();
     const lessonContentPanel =
       learnView.container.querySelector<HTMLElement>(".lesson-content-panel");
-    if (!lessonContentPanel) {
-      throw new Error("Expected a scrollable lesson content panel");
-    }
-
-    expect(lessonContentPanel).toHaveClass("lesson-content-panel");
+    expect(lessonContentPanel).toBeInTheDocument();
 
     expect(learnViewSource).toContain(
       "--lesson-content-panel-mobile-reading-inset: var(--space-20)",

--- a/frontend/src/lib/components/LearnView.ownership.test.ts
+++ b/frontend/src/lib/components/LearnView.ownership.test.ts
@@ -3,6 +3,7 @@ import { fireEvent, render } from "@testing-library/svelte";
 import { tick } from "svelte";
 import type { CitationFetchOptions } from "../services/chat";
 import type { GuidedLessonContentCallbacks } from "../services/guided";
+import learnViewSource from "./LearnView.svelte?raw";
 
 const {
   fetchTocMock,
@@ -153,5 +154,23 @@ describe("LearnView async request ownership", () => {
     await tick();
 
     expect(citationAbortSignal()?.aborted).toBe(true);
+  });
+
+  it("reserves mobile chat FAB clearance below the scrollable lesson panel", async () => {
+    const learnView = await renderSelectedLesson();
+    const lessonContentPanel =
+      learnView.container.querySelector<HTMLElement>(".lesson-content-panel");
+    if (!lessonContentPanel) {
+      throw new Error("Expected a scrollable lesson content panel");
+    }
+
+    expect(lessonContentPanel).toHaveClass("lesson-content-panel");
+
+    expect(learnViewSource).toContain(
+      "--lesson-content-panel-mobile-reading-inset: var(--space-20)",
+    );
+    expect(learnViewSource).toContain(
+      "padding-bottom: var(--lesson-content-panel-mobile-reading-inset)",
+    );
   });
 });

--- a/frontend/src/lib/components/LearnView.svelte
+++ b/frontend/src/lib/components/LearnView.svelte
@@ -1041,6 +1041,9 @@
             border-right: none;
             border-bottom: none;
             overflow-y: auto;
+            /* Uses the larger mobile FAB footprint so compact breakpoints retain clearance. */
+            --lesson-content-panel-mobile-reading-inset: var(--space-20);
+            padding-bottom: var(--lesson-content-panel-mobile-reading-inset);
         }
     }
 
@@ -1059,6 +1062,7 @@
 
         .lesson-content-panel {
             padding: var(--space-4);
+            padding-bottom: var(--lesson-content-panel-mobile-reading-inset);
         }
     }
 

--- a/frontend/src/lib/components/LearnView.test.ts
+++ b/frontend/src/lib/components/LearnView.test.ts
@@ -53,6 +53,39 @@ async function openLessonAndSendMessage(
   await fireEvent.click(learnView.getByRole("button", { name: "Send message" }));
 }
 
+async function openMobileGuidedChat(learnView: Awaited<ReturnType<typeof renderLearnView>>) {
+  await fireEvent.click(await learnView.findByRole("button", { name: /test lesson/i }));
+  const mobileChatTrigger = learnView.getByRole("button", {
+    name: "Ask questions about this lesson",
+  });
+  await fireEvent.click(mobileChatTrigger);
+
+  const mobileChatDrawer = await learnView.findByRole("dialog", {
+    name: "Lesson chat",
+  });
+  const mobileMessageInput = mobileChatDrawer.querySelector("textarea[aria-label='Message input']");
+  if (!(mobileMessageInput instanceof HTMLTextAreaElement)) {
+    throw new Error("Expected mobile message input element to be a textarea");
+  }
+  const mobileSendButton = mobileChatDrawer.querySelector("button[aria-label='Send message']");
+  if (!(mobileSendButton instanceof HTMLButtonElement)) {
+    throw new Error("Expected mobile send button element to be a button");
+  }
+
+  return { mobileChatTrigger, mobileMessageInput, mobileSendButton };
+}
+
+async function submitMobileGuidedMessage(
+  mobileMessageInput: HTMLTextAreaElement,
+  mobileSendButton: HTMLButtonElement,
+): Promise<void> {
+  await fireEvent.input(mobileMessageInput, {
+    target: { value: "Explain records" },
+  });
+  await fireEvent.click(mobileSendButton);
+  await vi.waitFor(() => expect(mobileMessageInput).toBeDisabled());
+}
+
 function configureLessonCatalog(...guidedLessons: GuidedLesson[]): void {
   fetchTocMock.mockResolvedValue(guidedLessons);
 }
@@ -159,6 +192,86 @@ describe("LearnView guided chat streaming stability", () => {
     await fireEvent.click(closeChatButton);
     await tick();
 
+    expect(mobileChatTrigger).toHaveFocus();
+  });
+
+  it("restores mobile drawer input focus after a submitted stream completes with focus in the form", async () => {
+    let completeStream: () => void = () => {
+      throw new Error("Expected guided stream completion callback to be set");
+    };
+    streamGuidedChatMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          completeStream = resolve;
+        }),
+    );
+
+    const learnView = await renderLearnView();
+    const { mobileMessageInput, mobileSendButton } = await openMobileGuidedChat(learnView);
+    mobileMessageInput.focus();
+
+    await submitMobileGuidedMessage(mobileMessageInput, mobileSendButton);
+    expect(mobileMessageInput).toHaveFocus();
+
+    completeStream();
+
+    await vi.waitFor(() => {
+      expect(mobileMessageInput).toBeEnabled();
+      expect(mobileMessageInput).toHaveFocus();
+    });
+  });
+
+  it("restores mobile drawer input focus after a submitted stream completes with focus on the document body", async () => {
+    let completeStream: () => void = () => {
+      throw new Error("Expected guided stream completion callback to be set");
+    };
+    streamGuidedChatMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          completeStream = resolve;
+        }),
+    );
+
+    const learnView = await renderLearnView();
+    const { mobileMessageInput, mobileSendButton } = await openMobileGuidedChat(learnView);
+    await submitMobileGuidedMessage(mobileMessageInput, mobileSendButton);
+
+    const transientFocusControl = document.createElement("button");
+    learnView.container.append(transientFocusControl);
+    transientFocusControl.focus();
+    transientFocusControl.remove();
+    expect(document.activeElement).toBe(document.body);
+
+    completeStream();
+
+    await vi.waitFor(() => {
+      expect(mobileMessageInput).toBeEnabled();
+      expect(mobileMessageInput).toHaveFocus();
+    });
+  });
+
+  it("preserves mobile trigger focus after a submitted stream completes", async () => {
+    let completeStream: () => void = () => {
+      throw new Error("Expected guided stream completion callback to be set");
+    };
+    streamGuidedChatMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          completeStream = resolve;
+        }),
+    );
+
+    const learnView = await renderLearnView();
+    const { mobileChatTrigger, mobileMessageInput, mobileSendButton } =
+      await openMobileGuidedChat(learnView);
+    await submitMobileGuidedMessage(mobileMessageInput, mobileSendButton);
+
+    mobileChatTrigger.focus();
+    expect(mobileChatTrigger).toHaveFocus();
+
+    completeStream();
+
+    await vi.waitFor(() => expect(mobileMessageInput).toBeEnabled());
     expect(mobileChatTrigger).toHaveFocus();
   });
 

--- a/frontend/src/lib/services/pageMetadata.ts
+++ b/frontend/src/lib/services/pageMetadata.ts
@@ -57,27 +57,36 @@ const APPLICATION_ROUTE_BY_PATH = {
   [ROOT_APPLICATION_PATH]: {
     view: "chat",
     isCanonicalViewPath: true,
+    recoversDescendantPathsToCanonicalView: false,
     pageMetadata: DEFAULT_PAGE_METADATA,
   },
   [CHAT_APPLICATION_PATH]: {
     view: "chat",
     isCanonicalViewPath: false,
+    recoversDescendantPathsToCanonicalView: false,
     pageMetadata: CHAT_PAGE_METADATA,
   },
   [GUIDED_APPLICATION_PATH]: {
     view: "learn",
     isCanonicalViewPath: false,
+    recoversDescendantPathsToCanonicalView: true,
     pageMetadata: GUIDED_PAGE_METADATA,
   },
   [LEARN_APPLICATION_PATH]: {
     view: "learn",
     isCanonicalViewPath: true,
+    recoversDescendantPathsToCanonicalView: true,
     pageMetadata: GUIDED_PAGE_METADATA,
   },
 } as const;
 
 type ApplicationPath = keyof typeof APPLICATION_ROUTE_BY_PATH;
 type ApplicationRoute = (typeof APPLICATION_ROUTE_BY_PATH)[ApplicationPath];
+
+type ApplicationRouteResolution = {
+  readonly applicationRoute: ApplicationRoute;
+  readonly canonicalRecoveryPath: string | null;
+};
 
 function normalizeApplicationPath(pathname: string): string {
   return pathname.length > 1 && pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
@@ -87,11 +96,36 @@ function isApplicationPath(pathname: string): pathname is ApplicationPath {
   return Object.hasOwn(APPLICATION_ROUTE_BY_PATH, pathname);
 }
 
-function applicationRouteForPath(pathname: string): ApplicationRoute {
+function applicationRouteResolutionForPath(pathname: string): ApplicationRouteResolution {
   const normalizedPathname = normalizeApplicationPath(pathname);
-  return isApplicationPath(normalizedPathname)
-    ? APPLICATION_ROUTE_BY_PATH[normalizedPathname]
-    : APPLICATION_ROUTE_BY_PATH[ROOT_APPLICATION_PATH];
+  if (isApplicationPath(normalizedPathname)) {
+    return {
+      applicationRoute: APPLICATION_ROUTE_BY_PATH[normalizedPathname],
+      canonicalRecoveryPath: null,
+    };
+  }
+
+  const nestedLessonRoute = Object.entries(APPLICATION_ROUTE_BY_PATH).find(
+    ([applicationPath, applicationRoute]) =>
+      applicationRoute.recoversDescendantPathsToCanonicalView &&
+      normalizedPathname.startsWith(`${applicationPath}/`),
+  );
+  if (nestedLessonRoute) {
+    const [, applicationRoute] = nestedLessonRoute;
+    return {
+      applicationRoute,
+      canonicalRecoveryPath: canonicalPathForApplicationView(applicationRoute.view),
+    };
+  }
+
+  return {
+    applicationRoute: APPLICATION_ROUTE_BY_PATH[ROOT_APPLICATION_PATH],
+    canonicalRecoveryPath: null,
+  };
+}
+
+function applicationRouteForPath(pathname: string): ApplicationRoute {
+  return applicationRouteResolutionForPath(pathname).applicationRoute;
 }
 
 function updateNamedMetadata(metadataName: string, metadataText: string): void {
@@ -149,6 +183,11 @@ function updateStructuredData(canonicalUrl: string, pageDescription: string): vo
 /** Resolves the SPA view that corresponds to a browser pathname. */
 export function applicationViewForPath(pathname: string): ApplicationView {
   return applicationRouteForPath(pathname).view;
+}
+
+/** Resolves the canonical repair path for an unimplemented nested lesson route. */
+export function canonicalRecoveryPathForPath(pathname: string): string | null {
+  return applicationRouteResolutionForPath(pathname).canonicalRecoveryPath;
 }
 
 /** Resolves the canonical public path for a selected SPA view. */

--- a/frontend/src/lib/utils/url.test.ts
+++ b/frontend/src/lib/utils/url.test.ts
@@ -3,6 +3,7 @@ import {
   sanitizeUrl,
   buildFullUrl,
   deduplicateCitations,
+  citationUrlIdentity,
   FALLBACK_SOURCE_LABEL,
   getCitationType,
   getDisplaySource,
@@ -96,6 +97,12 @@ describe("buildFullUrl", () => {
     expect(buildFullUrl("https://example.com", "section")).toBe("https://example.com#section");
   });
 
+  it("preserves an encoded Java API anchor", () => {
+    expect(buildFullUrl("https://example.com/String.html", "%3Cinit%3E()")).toBe(
+      "https://example.com/String.html#%3Cinit%3E()",
+    );
+  });
+
   it("handles anchor - appends with hash separator", () => {
     // Note: buildFullUrl always prepends # to anchor, so #section becomes ##section
     // Callers should strip # from anchors before passing
@@ -121,7 +128,10 @@ describe("deduplicateCitations", () => {
     ];
     const deduplicatedCitations = deduplicateCitations(citations);
     expect(deduplicatedCitations).toHaveLength(2);
-    expect(deduplicatedCitations.map((c) => c.url)).toEqual(["https://a.com", "https://b.com"]);
+    expect(deduplicatedCitations.map((citation) => citation.url)).toEqual([
+      "https://a.com",
+      "https://b.com",
+    ]);
   });
 
   it("keeps first occurrence when deduplicating", () => {
@@ -131,6 +141,64 @@ describe("deduplicateCitations", () => {
     ];
     const deduplicatedCitations = deduplicateCitations(citations);
     expect(deduplicatedCitations[0].title).toBe("First");
+  });
+
+  it("preserves case-sensitive and encoded anchors while collapsing matching identities", () => {
+    const citations = [
+      {
+        url: "HTTPS://DOCS.example.com/String.html",
+        anchor: "Foo()",
+        title: "String Foo method",
+      },
+      {
+        url: "https://docs.example.com/string.html",
+        anchor: "foo()",
+        title: "String foo method",
+      },
+      {
+        url: "https://docs.example.com/STRING.html",
+        anchor: "Foo()",
+        title: "Duplicate String Foo method",
+      },
+      {
+        url: "https://docs.example.com/string.html",
+        anchor: "%3Cinit%3E()",
+        title: "String constructor",
+      },
+      {
+        url: "https://docs.example.com/STRING.html",
+        anchor: "%3Cinit%3E()",
+        title: "Duplicate constructor citation",
+      },
+    ];
+
+    const deduplicatedCitations = deduplicateCitations(citations);
+
+    expect(deduplicatedCitations.map((citation) => citation.anchor)).toEqual([
+      "Foo()",
+      "foo()",
+      "%3Cinit%3E()",
+    ]);
+    expect(deduplicatedCitations.map((citation) => citation.title)).toEqual([
+      "String Foo method",
+      "String foo method",
+      "String constructor",
+    ]);
+  });
+
+  it("normalizes only the base URL in citation identities", () => {
+    const uppercaseAnchorIdentity = citationUrlIdentity(
+      "HTTPS://DOCS.example.com/String.html",
+      "Foo()",
+    );
+    const lowercaseAnchorIdentity = citationUrlIdentity(
+      "https://docs.example.com/string.html",
+      "foo()",
+    );
+
+    expect(uppercaseAnchorIdentity).toBe("https://docs.example.com/string.html#Foo()");
+    expect(lowercaseAnchorIdentity).toBe("https://docs.example.com/string.html#foo()");
+    expect(uppercaseAnchorIdentity).not.toBe(lowercaseAnchorIdentity);
   });
 });
 

--- a/frontend/src/lib/utils/url.ts
+++ b/frontend/src/lib/utils/url.ts
@@ -188,13 +188,31 @@ export function buildFullUrl(baseUrl: string | undefined | null, anchor?: string
   return safeUrl;
 }
 
+/**
+ * Builds a canonical citation identity with a case-insensitive base URL and exact fragment.
+ *
+ * Delegates URL construction to buildFullUrl so link rendering and deduplication share the
+ * same safety rules, while retaining fragment case because Java API anchors are case-sensitive.
+ */
+export function citationUrlIdentity(baseUrl: string | undefined | null, anchor?: string): string {
+  const fullCitationUrl = buildFullUrl(baseUrl, anchor);
+  const fragmentStart = fullCitationUrl.indexOf(ANCHOR_SEPARATOR);
+
+  if (fragmentStart === -1) {
+    return fullCitationUrl.toLowerCase();
+  }
+
+  return `${fullCitationUrl.slice(0, fragmentStart).toLowerCase()}${fullCitationUrl.slice(fragmentStart)}`;
+}
+
 /** Constraint for objects with a URL property (used in deduplication). */
 interface HasUrl {
   url?: string | null;
+  anchor?: string;
 }
 
 /**
- * Deduplicates an array of objects by URL (case-insensitive).
+ * Deduplicates citations by a case-insensitive base URL and case-sensitive fragment.
  * Filters out objects with missing or invalid URL properties.
  *
  * @param citations - Array of objects with url property (null/undefined treated as empty)
@@ -206,12 +224,12 @@ export function deduplicateCitations<T extends HasUrl>(
   if (!citations || citations.length === 0) {
     return [];
   }
-  const seen = new Set<string>();
+  const seenCitationIdentities = new Set<string>();
   return citations.filter((citation) => {
     if (!citation || typeof citation.url !== "string") return false;
-    const key = citation.url.toLowerCase();
-    if (seen.has(key)) return false;
-    seen.add(key);
+    const citationIdentity = citationUrlIdentity(citation.url, citation.anchor);
+    if (seenCitationIdentities.has(citationIdentity)) return false;
+    seenCitationIdentities.add(citationIdentity);
     return true;
   });
 }

--- a/src/main/java/com/williamcallahan/javachat/config/DocsSourceRegistry.java
+++ b/src/main/java/com/williamcallahan/javachat/config/DocsSourceRegistry.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,6 +45,7 @@ public final class DocsSourceRegistry {
     private static final String SPRING_AI_API_2_BASE_KEY = "SPRING_AI_API_2_BASE";
 
     private static final String REDACTED_LOCAL_URL = "(local file path redacted)";
+    private static final String OFFICIAL_DOCUMENTATION_SOURCE_KIND = "official";
 
     private static final String DEFAULT_ORACLE_JAVASE_BASE = "https://www.oracle.com/java/technologies/javase/";
     private static final String DEFAULT_IBM_ARTICLES_BASE = "https://developer.ibm.com/articles/";
@@ -85,6 +87,8 @@ public final class DocsSourceRegistry {
     private static final List<JavaApiDocumentationSource> JAVA_API_DOCUMENTATION_SOURCES =
             JavaApiDocumentationManifest.load();
     private static final List<DocumentationSource> DOCUMENTATION_SOURCES = DocumentationSourceManifest.load();
+    private static final List<String> OFFICIAL_DOCUMENTATION_SOURCE_IDENTITIES =
+            projectOfficialDocumentationSourceIdentities(DOCUMENTATION_SOURCES, JAVA_API_DOCUMENTATION_SOURCES);
 
     public static final String ORACLE_JAVASE_BASE = resolveSetting(ORACLE_JAVASE_BASE_KEY, DEFAULT_ORACLE_JAVASE_BASE);
     public static final String IBM_ARTICLES_BASE = resolveSetting(IBM_ARTICLES_BASE_KEY, DEFAULT_IBM_ARTICLES_BASE);
@@ -268,6 +272,33 @@ public final class DocsSourceRegistry {
      */
     public static List<DocumentationSource> documentationSources() {
         return List.copyOf(DOCUMENTATION_SOURCES);
+    }
+
+    /**
+     * Returns retrieval identities for every official documentation source in the canonical manifests.
+     *
+     * <p>Non-Java documentation is identified by its canonical {@code docSet}; Java API documentation
+     * is identified by its canonical relative mirror path because that is the ingestion-owned
+     * {@code docSet} projection.</p>
+     *
+     * @return immutable source identities in non-Java then Java API manifest order
+     */
+    public static List<String> officialDocumentationSourceIdentities() {
+        return List.copyOf(OFFICIAL_DOCUMENTATION_SOURCE_IDENTITIES);
+    }
+
+    static List<String> projectOfficialDocumentationSourceIdentities(
+            List<DocumentationSource> documentationSources,
+            List<JavaApiDocumentationSource> javaApiDocumentationSources) {
+        Objects.requireNonNull(documentationSources, "documentationSources");
+        Objects.requireNonNull(javaApiDocumentationSources, "javaApiDocumentationSources");
+        return Stream.concat(
+                        documentationSources.stream()
+                                .filter(documentationSource ->
+                                        OFFICIAL_DOCUMENTATION_SOURCE_KIND.equals(documentationSource.sourceKind()))
+                                .map(DocumentationSource::docSet),
+                        javaApiDocumentationSources.stream().map(JavaApiDocumentationSource::relativeMirrorPath))
+                .toList();
     }
 
     /**

--- a/src/main/java/com/williamcallahan/javachat/service/ChatService.java
+++ b/src/main/java/com/williamcallahan/javachat/service/ChatService.java
@@ -77,11 +77,14 @@ public class ChatService {
     }
 
     /**
-     * Resolves citations for a query using the retrieval pipeline.
+     * Resolves citations through official sparse documentation discovery.
      */
     public List<Citation> citationsFor(String userQuery) {
-        List<Document> documents = retrievalService.retrieve(userQuery);
-        return retrievalService.toCitations(documents).citations();
+        RetrievalConstraint officialDocumentationConstraint =
+                RetrievalConstraint.forOfficialDocSets(DocsSourceRegistry.officialDocumentationSourceIdentities());
+        return retrievalService
+                .discoverCitations(userQuery, officialDocumentationConstraint)
+                .citations();
     }
 
     /**

--- a/src/main/java/com/williamcallahan/javachat/service/ChatService.java
+++ b/src/main/java/com/williamcallahan/javachat/service/ChatService.java
@@ -80,11 +80,9 @@ public class ChatService {
      * Resolves citations through official sparse documentation discovery.
      */
     public List<Citation> citationsFor(String userQuery) {
-        RetrievalConstraint officialDocumentationConstraint =
-                RetrievalConstraint.forOfficialDocSets(DocsSourceRegistry.officialDocumentationSourceIdentities());
-        return retrievalService
-                .discoverCitations(userQuery, officialDocumentationConstraint)
-                .citations();
+        RetrievalService.CitationOutcome citationOutcome =
+                retrievalService.discoverCitations(userQuery, officialDocumentationConstraint());
+        return citationOutcome.citationsOrThrow();
     }
 
     /**
@@ -137,17 +135,19 @@ public class ChatService {
 
         // Use reduced RAG for token-constrained models (GPT-5.x family)
         RetrievalService.RetrievalOutcome retrievalOutcome;
+        RetrievalConstraint retrievalConstraint = officialDocumentationConstraint();
         if (ModelConfiguration.isTokenConstrained(modelHint)) {
             retrievalOutcome = retrievalService.retrieveWithLimitOutcome(
                     latestUserMessage,
                     ModelConfiguration.RAG_LIMIT_CONSTRAINED,
-                    ModelConfiguration.RAG_TOKEN_LIMIT_CONSTRAINED);
+                    ModelConfiguration.RAG_TOKEN_LIMIT_CONSTRAINED,
+                    retrievalConstraint);
             logger.debug(
                     "Using reduced RAG: {} documents with max {} tokens each",
                     retrievalOutcome.documents().size(),
                     ModelConfiguration.RAG_TOKEN_LIMIT_CONSTRAINED);
         } else {
-            retrievalOutcome = retrievalService.retrieveOutcome(latestUserMessage);
+            retrievalOutcome = retrievalService.retrieveOutcome(latestUserMessage, retrievalConstraint);
         }
 
         List<Document> contextDocs = retrievalOutcome.documents();
@@ -176,6 +176,10 @@ public class ChatService {
                 new StructuredPrompt(systemSegment, contextSegments, conversationSegments, querySegment);
 
         return new StructuredPromptOutcome(structuredPrompt, retrievalOutcome.notices(), retrievalOutcome.documents());
+    }
+
+    private static RetrievalConstraint officialDocumentationConstraint() {
+        return RetrievalConstraint.forOfficialDocSets(DocsSourceRegistry.officialDocumentationSourceIdentities());
     }
 
     /**

--- a/src/main/java/com/williamcallahan/javachat/service/CitationConversionFailureException.java
+++ b/src/main/java/com/williamcallahan/javachat/service/CitationConversionFailureException.java
@@ -1,0 +1,48 @@
+package com.williamcallahan.javachat.service;
+
+import java.io.Serial;
+
+/**
+ * Signals that a citation response would omit one or more discovered source documents.
+ *
+ * <p>The failed conversion count makes the partial-result condition observable without exposing
+ * malformed source metadata to API consumers.</p>
+ */
+public final class CitationConversionFailureException extends IllegalStateException {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private static final String CITATION_CONVERSION_FAILURE_MESSAGE_PREFIX = "Citation conversion failed for ";
+    private static final String CITATION_CONVERSION_FAILURE_MESSAGE_SUFFIX = " source document(s)";
+
+    private final int failedConversionCount;
+
+    /**
+     * Creates a strict failure for a nonzero number of unconvertible source documents.
+     *
+     * @param failedConversionCount number of source documents that failed conversion
+     * @throws IllegalArgumentException when the failure count is not positive
+     */
+    public CitationConversionFailureException(int failedConversionCount) {
+        super(messageFor(failedConversionCount));
+        this.failedConversionCount = failedConversionCount;
+    }
+
+    /**
+     * Returns the number of source documents omitted by the failed conversion.
+     *
+     * @return positive source-document conversion failure count
+     */
+    public int failedConversionCount() {
+        return failedConversionCount;
+    }
+
+    private static String messageFor(int failedConversionCount) {
+        if (failedConversionCount < 1) {
+            throw new IllegalArgumentException("failedConversionCount must be positive");
+        }
+        return CITATION_CONVERSION_FAILURE_MESSAGE_PREFIX
+                + failedConversionCount
+                + CITATION_CONVERSION_FAILURE_MESSAGE_SUFFIX;
+    }
+}

--- a/src/main/java/com/williamcallahan/javachat/service/GuidedLearningService.java
+++ b/src/main/java/com/williamcallahan/javachat/service/GuidedLearningService.java
@@ -117,8 +117,7 @@ public class GuidedLearningService {
         GuidedLesson lesson = requireListedLesson(slug);
         String query = buildLessonQuery(lesson);
         RetrievalConstraint retrievalConstraint = retrievalConstraintFor(lesson);
-        List<Document> citationDocuments = retrievalService.retrieveForCitationDiscovery(query, retrievalConstraint);
-        return citationOutcomeForContextDocuments(citationDocuments).citations();
+        return retrievalService.discoverCitations(query, retrievalConstraint).citations();
     }
 
     /**

--- a/src/main/java/com/williamcallahan/javachat/service/GuidedLearningService.java
+++ b/src/main/java/com/williamcallahan/javachat/service/GuidedLearningService.java
@@ -117,7 +117,9 @@ public class GuidedLearningService {
         GuidedLesson lesson = requireListedLesson(slug);
         String query = buildLessonQuery(lesson);
         RetrievalConstraint retrievalConstraint = retrievalConstraintFor(lesson);
-        return retrievalService.discoverCitations(query, retrievalConstraint).citations();
+        RetrievalService.CitationOutcome citationOutcome =
+                retrievalService.discoverCitations(query, retrievalConstraint);
+        return citationOutcome.citationsOrThrow();
     }
 
     /**

--- a/src/main/java/com/williamcallahan/javachat/service/GuidedTOCProvider.java
+++ b/src/main/java/com/williamcallahan/javachat/service/GuidedTOCProvider.java
@@ -10,7 +10,6 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Stream;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
 
@@ -19,8 +18,6 @@ import org.springframework.stereotype.Service;
  */
 @Service
 public class GuidedTOCProvider {
-    private static final String OFFICIAL_SOURCE_KIND = "official";
-
     private final ObjectMapper objectMapper;
     private volatile List<GuidedLesson> cachedLessons = List.of();
     private volatile boolean tocLoaded = false;
@@ -117,22 +114,14 @@ public class GuidedTOCProvider {
     }
 
     private static String resolveOfficialDocSet(String lessonSlug, String sourceReference) {
-        List<String> matchingCanonicalSourceIdentities = canonicalOfficialSourceIdentities()
-                .filter(canonicalSourceIdentity -> canonicalSourceIdentity.equals(sourceReference))
-                .toList();
+        List<String> matchingCanonicalSourceIdentities =
+                DocsSourceRegistry.officialDocumentationSourceIdentities().stream()
+                        .filter(canonicalSourceIdentity -> canonicalSourceIdentity.equals(sourceReference))
+                        .toList();
         if (matchingCanonicalSourceIdentities.size() != 1) {
             throw new IllegalStateException(
                     "Guided TOC lesson references unknown official source: " + lessonSlug + " -> " + sourceReference);
         }
         return matchingCanonicalSourceIdentities.getFirst();
-    }
-
-    private static Stream<String> canonicalOfficialSourceIdentities() {
-        return Stream.concat(
-                DocsSourceRegistry.documentationSources().stream()
-                        .filter(documentationSource -> OFFICIAL_SOURCE_KIND.equals(documentationSource.sourceKind()))
-                        .map(DocsSourceRegistry.DocumentationSource::docSet),
-                DocsSourceRegistry.javaApiDocumentationSources().stream()
-                        .map(DocsSourceRegistry.JavaApiDocumentationSource::relativeMirrorPath));
     }
 }

--- a/src/main/java/com/williamcallahan/javachat/service/HybridSearchService.java
+++ b/src/main/java/com/williamcallahan/javachat/service/HybridSearchService.java
@@ -32,12 +32,13 @@ import org.springframework.ai.document.Document;
 import org.springframework.stereotype.Service;
 
 /**
- * Executes hybrid (dense + sparse) search across all Qdrant collections using RRF fusion.
+ * Executes hybrid search across all Qdrant collections and sparse-only official citation search.
  *
  * <p>For each collection, a Qdrant Query API request is issued with two prefetch stages
  * (dense nearest-neighbor and sparse BM25-style lexical search) fused via reciprocal rank
  * fusion (RRF). Queries are fanned out to all configured collections in parallel and results
- * are deduplicated by point UUID before returning top-K.</p>
+ * are deduplicated by point UUID before returning top-K. Citation discovery sends one direct sparse
+ * query only to the canonical documentation collection.</p>
  *
  * <p>Verified API contract (Step 0): this adapter uses direct {@code io.qdrant:client} 1.16.2
  * primitives rather than Spring AI VectorStore abstractions. Hybrid behavior depends on
@@ -50,6 +51,7 @@ public class HybridSearchService {
     private static final Logger log = LoggerFactory.getLogger(HybridSearchService.class);
 
     private static final int MAX_FAILURE_DETAIL_LENGTH = 240;
+    private static final long MINIMUM_QDRANT_QUERY_DURATION_NANOS = TimeUnit.MILLISECONDS.toNanos(1);
 
     private final QdrantClient qdrantClient;
     private final QueryEncodingServices queryEncoding;
@@ -140,21 +142,74 @@ public class HybridSearchService {
 
         Map<String, CompletableFuture<List<ScoredPoint>>> futuresByCollection =
                 LinkedHashMap.newLinkedHashMap(collectionNames.size());
-        for (String collection : collectionNames) {
+        long queryDeadlineNanos = queryDeadlineNanos(queryConfig.queryTimeout());
+        for (String collectionName : collectionNames) {
             QueryPoints queryRequest = Objects.requireNonNull(
-                    buildHybridQueryRequest(collection, encodedQuery, queryConfig, topK), "QueryPoints");
-            CompletableFuture<List<ScoredPoint>> future =
-                    QdrantListenableFutureBridge.toCompletableFuture(qdrantClient.queryAsync(queryRequest));
-            futuresByCollection.put(collection, future);
+                    buildHybridQueryRequest(collectionName, encodedQuery, queryConfig, topK), "QueryPoints");
+            CompletableFuture<List<ScoredPoint>> collectionQueryFuture =
+                    dispatchQueryBeforeDeadline(queryRequest, queryDeadlineNanos);
+            futuresByCollection.put(collectionName, collectionQueryFuture);
         }
 
+        CollectionQueryDispatch queryDispatch =
+                new CollectionQueryDispatch(futuresByCollection, queryConfig.queryTimeout(), queryDeadlineNanos);
+        return collectSearchOutcome(queryDispatch, topK, queryConfig, CollectionFailurePolicy.CONFIGURED);
+    }
+
+    /**
+     * Searches the canonical documentation collection for citation candidates using sparse lexical retrieval only.
+     *
+     * <p>This operation does not create a dense embedding, issue prefetch queries, perform RRF fusion,
+     * or include dynamically discovered GitHub collections.</p>
+     *
+     * @param query citation-discovery query text
+     * @param topK maximum number of citation candidates to return
+     * @param retrievalConstraint official documentation metadata constraint
+     * @return sparse search outcome containing documents and optional non-fatal notices
+     */
+    public SearchOutcome searchDocumentationCitationsOutcome(
+            String query, int topK, RetrievalConstraint retrievalConstraint) {
+        Objects.requireNonNull(query, "query");
+        Objects.requireNonNull(retrievalConstraint, "retrievalConstraint");
+        if (query.isBlank() || topK <= 0) {
+            return new SearchOutcome(List.of(), List.of());
+        }
+
+        LexicalSparseVectorEncoder.SparseVector sparseVector =
+                queryEncoding.sparseVectorEncoder().encode(query);
+        if (sparseVector.indices().isEmpty()) {
+            return new SearchOutcome(List.of(), List.of());
+        }
+
+        Optional<Filter> retrievalFilter = queryEncoding.constraintBuilder().buildFilter(retrievalConstraint);
+        EncodedCitationQuery encodedCitationQuery = new EncodedCitationQuery(sparseVector, retrievalFilter);
+        HybridQueryConfig queryConfig = HybridQueryConfig.fromProperties(appProperties);
+        String documentationCollectionName =
+                appProperties.getQdrant().getCollections().getDocs();
+        long queryDeadlineNanos = queryDeadlineNanos(queryConfig.queryTimeout());
+        QueryPoints queryRequest = buildDocumentationCitationQueryRequest(
+                documentationCollectionName, encodedCitationQuery, queryConfig, topK);
+        CompletableFuture<List<ScoredPoint>> documentationQueryFuture =
+                dispatchQueryBeforeDeadline(queryRequest, queryDeadlineNanos);
+        Map<String, CompletableFuture<List<ScoredPoint>>> documentationQueryByCollection =
+                Map.of(documentationCollectionName, documentationQueryFuture);
+        CollectionQueryDispatch queryDispatch = new CollectionQueryDispatch(
+                documentationQueryByCollection, queryConfig.queryTimeout(), queryDeadlineNanos);
+        return collectSearchOutcome(queryDispatch, topK, queryConfig, CollectionFailurePolicy.STRICT);
+    }
+
+    private SearchOutcome collectSearchOutcome(
+            CollectionQueryDispatch queryDispatch,
+            int topK,
+            HybridQueryConfig queryConfig,
+            CollectionFailurePolicy collectionFailurePolicy) {
         Map<String, ScoredPointMatch> scoredPointsByUuid = new LinkedHashMap<>();
         List<HybridSearchPartialFailureException.CollectionSearchFailure> collectionFailures = new ArrayList<>();
-        collectFanOutResults(futuresByCollection, queryConfig.queryTimeout(), scoredPointsByUuid, collectionFailures);
+        collectFanOutResults(queryDispatch, scoredPointsByUuid, collectionFailures);
 
-        if (!collectionFailures.isEmpty() && queryConfig.failOnPartialSearchError()) {
+        if (!collectionFailures.isEmpty() && collectionFailurePolicy.failsSearch(queryConfig)) {
             throw new HybridSearchPartialFailureException(
-                    "Hybrid retrieval failed for " + collectionFailures.size() + " collection(s)", collectionFailures);
+                    "Qdrant retrieval failed for " + collectionFailures.size() + " collection(s)", collectionFailures);
         }
 
         List<Document> rankedDocuments = scoredPointsByUuid.values().stream()
@@ -164,11 +219,30 @@ public class HybridSearchService {
                         scoredPointMatch.point(),
                         scoredPointMatch.id(),
                         scoredPointMatch.score(),
-                        scoredPointMatch.collection()))
+                        scoredPointMatch.collectionName()))
                 .toList();
         List<HybridSearchNotice> retrievalNotices =
                 collectionFailures.stream().map(HybridSearchService::toNotice).toList();
         return new SearchOutcome(rankedDocuments, retrievalNotices);
+    }
+
+    private static long queryDeadlineNanos(Duration queryTimeout) {
+        return System.nanoTime() + queryTimeout.toNanos();
+    }
+
+    private CompletableFuture<List<ScoredPoint>> dispatchQueryBeforeDeadline(
+            QueryPoints queryRequest, long queryDeadlineNanos) {
+        long remainingQueryDurationNanos = queryDeadlineNanos - System.nanoTime();
+        if (remainingQueryDurationNanos < MINIMUM_QDRANT_QUERY_DURATION_NANOS) {
+            return new CompletableFuture<>();
+        }
+        Duration remainingQueryDuration = Duration.ofNanos(remainingQueryDurationNanos);
+        try {
+            return QdrantListenableFutureBridge.toCompletableFuture(
+                    qdrantClient.queryAsync(queryRequest, remainingQueryDuration));
+        } catch (RuntimeException queryDispatchFailure) {
+            return CompletableFuture.failedFuture(queryDispatchFailure);
+        }
     }
 
     /**
@@ -178,7 +252,7 @@ public class HybridSearchService {
      * @param sparseVectorName Qdrant named vector key for sparse tokens
      * @param prefetchLimit per-collection prefetch candidate count
      * @param rrfK reciprocal rank fusion k parameter
-     * @param queryTimeout fan-out timeout per collection
+     * @param queryTimeout shared timeout budget for the complete collection fan-out
      * @param failOnPartialSearchError whether partial collection failures are fatal
      */
     record HybridQueryConfig(
@@ -250,11 +324,41 @@ public class HybridSearchService {
         }
     }
 
+    /** Groups sparse encoding and its exact metadata filter for citation discovery. */
+    private record EncodedCitationQuery(
+            LexicalSparseVectorEncoder.SparseVector sparseVector, Optional<Filter> retrievalFilter) {
+        EncodedCitationQuery {
+            Objects.requireNonNull(sparseVector, "sparseVector");
+            Objects.requireNonNull(retrievalFilter, "retrievalFilter");
+        }
+    }
+
+    /** Keeps every collection wait on the timeout deadline established before fan-out dispatch. */
+    private record CollectionQueryDispatch(
+            Map<String, CompletableFuture<List<ScoredPoint>>> futuresByCollection,
+            Duration queryTimeout,
+            long queryDeadlineNanos) {
+        CollectionQueryDispatch {
+            Objects.requireNonNull(futuresByCollection, "futuresByCollection");
+            Objects.requireNonNull(queryTimeout, "queryTimeout");
+        }
+    }
+
+    /** Selects whether collection query failures follow configuration or always fail retrieval. */
+    private enum CollectionFailurePolicy {
+        CONFIGURED,
+        STRICT;
+
+        private boolean failsSearch(HybridQueryConfig queryConfig) {
+            return this == STRICT || queryConfig.failOnPartialSearchError();
+        }
+    }
+
     private QueryPoints buildHybridQueryRequest(
-            String collection, EncodedQuery encodedQuery, HybridQueryConfig queryConfig, int limit) {
+            String collectionName, EncodedQuery encodedQuery, HybridQueryConfig queryConfig, int limit) {
 
         QueryPoints.Builder builder = QueryPoints.newBuilder()
-                .setCollectionName(collection)
+                .setCollectionName(collectionName)
                 .setWithPayload(WithPayloadSelector.newBuilder().setEnable(true).build())
                 .setLimit(limit);
         encodedQuery.retrievalFilter().ifPresent(builder::setFilter);
@@ -282,50 +386,72 @@ public class HybridSearchService {
         return builder.build();
     }
 
+    private QueryPoints buildDocumentationCitationQueryRequest(
+            String documentationCollectionName,
+            EncodedCitationQuery encodedCitationQuery,
+            HybridQueryConfig queryConfig,
+            int citationCandidateLimit) {
+        QueryPoints.Builder queryBuilder = QueryPoints.newBuilder()
+                .setCollectionName(documentationCollectionName)
+                .setQuery(nearest(
+                        Objects.requireNonNull(
+                                encodedCitationQuery.sparseVector().termFrequencies()),
+                        Objects.requireNonNull(
+                                encodedCitationQuery.sparseVector().integerIndices())))
+                .setUsing(queryConfig.sparseVectorName())
+                .setWithPayload(WithPayloadSelector.newBuilder().setEnable(true).build())
+                .setLimit(citationCandidateLimit);
+        encodedCitationQuery.retrievalFilter().ifPresent(queryBuilder::setFilter);
+        return queryBuilder.build();
+    }
+
     private void collectFanOutResults(
-            Map<String, CompletableFuture<List<ScoredPoint>>> futuresByCollection,
-            Duration timeout,
+            CollectionQueryDispatch queryDispatch,
             Map<String, ScoredPointMatch> scoredPointsByUuid,
             List<HybridSearchPartialFailureException.CollectionSearchFailure> collectionFailures) {
 
-        for (Map.Entry<String, CompletableFuture<List<ScoredPoint>>> futureByCollectionEntry :
-                futuresByCollection.entrySet()) {
-            String collection = futureByCollectionEntry.getKey();
-            CompletableFuture<List<ScoredPoint>> future = futureByCollectionEntry.getValue();
+        for (Map.Entry<String, CompletableFuture<List<ScoredPoint>>> collectionQueryEntry :
+                queryDispatch.futuresByCollection().entrySet()) {
+            String collectionName = collectionQueryEntry.getKey();
+            CompletableFuture<List<ScoredPoint>> collectionQueryFuture = collectionQueryEntry.getValue();
             try {
-                List<ScoredPoint> points = future.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
-                mergePoints(points, collection, scoredPointsByUuid);
+                long remainingWaitNanos = Math.max(0L, queryDispatch.queryDeadlineNanos() - System.nanoTime());
+                List<ScoredPoint> scoredPoints = collectionQueryFuture.get(remainingWaitNanos, TimeUnit.NANOSECONDS);
+                mergePoints(scoredPoints, collectionName, scoredPointsByUuid);
             } catch (InterruptedException _) {
                 Thread.currentThread().interrupt();
-                future.cancel(true);
-                log.warn("[QDRANT] Search interrupted for collection={}", collection);
+                collectionQueryFuture.cancel(true);
+                log.warn("[QDRANT] Search interrupted for collection={}", collectionName);
                 collectionFailures.add(new HybridSearchPartialFailureException.CollectionSearchFailure(
-                        collection, "Interrupted", "Hybrid query was interrupted"));
+                        collectionName, "Interrupted", "Hybrid query was interrupted"));
             } catch (ExecutionException executionException) {
                 Throwable cause = executionException.getCause();
                 String exceptionType = cause == null
                         ? executionException.getClass().getSimpleName()
                         : cause.getClass().getSimpleName();
                 String failureMessage = cause == null ? executionException.getMessage() : cause.getMessage();
-                log.warn("[QDRANT] Search failed for collection={} (exceptionType={})", collection, exceptionType);
+                log.warn("[QDRANT] Search failed for collection={} (exceptionType={})", collectionName, exceptionType);
                 collectionFailures.add(new HybridSearchPartialFailureException.CollectionSearchFailure(
-                        collection, exceptionType, sanitizeFailureDetails(failureMessage)));
+                        collectionName, exceptionType, sanitizeFailureDetails(failureMessage)));
             } catch (TimeoutException _) {
-                future.cancel(true);
-                log.warn("[QDRANT] Search timed out for collection={}", collection);
+                collectionQueryFuture.cancel(true);
+                log.warn("[QDRANT] Search timed out for collection={}", collectionName);
                 collectionFailures.add(new HybridSearchPartialFailureException.CollectionSearchFailure(
-                        collection, "Timeout", "Hybrid query exceeded timeout " + timeout.toMillis() + "ms"));
+                        collectionName,
+                        "Timeout",
+                        "Hybrid query exceeded timeout "
+                                + queryDispatch.queryTimeout().toMillis() + "ms"));
             }
         }
     }
 
     private static void mergePoints(
-            List<ScoredPoint> points, String collection, Map<String, ScoredPointMatch> scoredPointsByUuid) {
+            List<ScoredPoint> points, String collectionName, Map<String, ScoredPointMatch> scoredPointsByUuid) {
         for (ScoredPoint point : points) {
             String pointId = extractPointId(point);
             ScoredPointMatch existing = scoredPointsByUuid.get(pointId);
             if (existing == null || point.getScore() > existing.score()) {
-                scoredPointsByUuid.put(pointId, new ScoredPointMatch(pointId, point.getScore(), point, collection));
+                scoredPointsByUuid.put(pointId, new ScoredPointMatch(pointId, point.getScore(), point, collectionName));
             }
         }
     }
@@ -371,5 +497,5 @@ public class HybridSearchService {
         return flattenedFailure.substring(0, MAX_FAILURE_DETAIL_LENGTH) + "...";
     }
 
-    private record ScoredPointMatch(String id, double score, ScoredPoint point, String collection) {}
+    private record ScoredPointMatch(String id, double score, ScoredPoint point, String collectionName) {}
 }

--- a/src/main/java/com/williamcallahan/javachat/service/HybridSearchService.java
+++ b/src/main/java/com/williamcallahan/javachat/service/HybridSearchService.java
@@ -420,10 +420,13 @@ public class HybridSearchService {
                 mergePoints(scoredPoints, collectionName, scoredPointsByUuid);
             } catch (InterruptedException _) {
                 Thread.currentThread().interrupt();
-                collectionQueryFuture.cancel(true);
+                cancelPendingQueries(queryDispatch);
                 log.warn("[QDRANT] Search interrupted for collection={}", collectionName);
-                collectionFailures.add(new HybridSearchPartialFailureException.CollectionSearchFailure(
-                        collectionName, "Interrupted", "Hybrid query was interrupted"));
+                HybridSearchPartialFailureException.CollectionSearchFailure interruptionFailure =
+                        new HybridSearchPartialFailureException.CollectionSearchFailure(
+                                collectionName, "Interrupted", "Qdrant query was interrupted");
+                throw new HybridSearchPartialFailureException(
+                        "Qdrant retrieval was interrupted", List.of(interruptionFailure));
             } catch (ExecutionException executionException) {
                 Throwable cause = executionException.getCause();
                 String exceptionType = cause == null
@@ -439,10 +442,14 @@ public class HybridSearchService {
                 collectionFailures.add(new HybridSearchPartialFailureException.CollectionSearchFailure(
                         collectionName,
                         "Timeout",
-                        "Hybrid query exceeded timeout "
+                        "Qdrant query exceeded timeout "
                                 + queryDispatch.queryTimeout().toMillis() + "ms"));
             }
         }
+    }
+
+    private static void cancelPendingQueries(CollectionQueryDispatch queryDispatch) {
+        queryDispatch.futuresByCollection().values().forEach(queryFuture -> queryFuture.cancel(true));
     }
 
     private static void mergePoints(

--- a/src/main/java/com/williamcallahan/javachat/service/QdrantListenableFutureBridge.java
+++ b/src/main/java/com/williamcallahan/javachat/service/QdrantListenableFutureBridge.java
@@ -4,6 +4,7 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -31,10 +32,20 @@ final class QdrantListenableFutureBridge {
      *
      * @param qdrantQueryFuture asynchronous Qdrant query future
      * @param <T> successful completion type
-     * @return completable future that mirrors success or failure from the source future
+     * @return completable future that mirrors completion and propagates caller cancellation to the source future
      */
     static <T> CompletableFuture<T> toCompletableFuture(ListenableFuture<T> qdrantQueryFuture) {
-        CompletableFuture<T> completableFuture = new CompletableFuture<>();
+        Objects.requireNonNull(qdrantQueryFuture, "qdrantQueryFuture");
+        CompletableFuture<T> completableFuture = new CompletableFuture<>() {
+            @Override
+            public boolean cancel(boolean mayInterruptIfRunning) {
+                boolean cancellationAccepted = super.cancel(mayInterruptIfRunning);
+                if (cancellationAccepted) {
+                    qdrantQueryFuture.cancel(mayInterruptIfRunning);
+                }
+                return cancellationAccepted;
+            }
+        };
         Futures.addCallback(
                 qdrantQueryFuture,
                 new FutureCallback<>() {

--- a/src/main/java/com/williamcallahan/javachat/service/RetrievalConstraint.java
+++ b/src/main/java/com/williamcallahan/javachat/service/RetrievalConstraint.java
@@ -65,6 +65,27 @@ public record RetrievalConstraint(
     }
 
     /**
+     * Returns this constraint combined with an exact document-version requirement.
+     *
+     * @param requiredDocumentVersion document version token extracted from the query
+     * @return constraint retaining every existing field plus the required version
+     * @throws IllegalArgumentException when an existing version conflicts with the required version
+     */
+    public RetrievalConstraint withDocVersion(String requiredDocumentVersion) {
+        String sanitizedRequiredDocumentVersion = sanitize(requiredDocumentVersion);
+        if (sanitizedRequiredDocumentVersion.isBlank()) {
+            return this;
+        }
+        if (!docVersion.isBlank() && !docVersion.equals(sanitizedRequiredDocumentVersion)) {
+            throw new IllegalArgumentException("Conflicting document version constraints");
+        }
+        if (docVersion.equals(sanitizedRequiredDocumentVersion)) {
+            return this;
+        }
+        return new RetrievalConstraint(sanitizedRequiredDocumentVersion, sourceKind, docType, sourceName, docSet);
+    }
+
+    /**
      * Returns true when at least one server-side filter can be applied.
      *
      * @return true when the constraint has one or more non-empty fields

--- a/src/main/java/com/williamcallahan/javachat/service/RetrievalService.java
+++ b/src/main/java/com/williamcallahan/javachat/service/RetrievalService.java
@@ -115,28 +115,35 @@ public class RetrievalService {
     }
 
     /**
-     * Retrieves official documents for static citation discovery using hybrid RRF ranking only.
+     * Discovers static citations from one sparse official-documentation query.
      *
-     * <p>Lesson citation panels need a deterministic source list before a learner asks a question.
-     * This operation intentionally uses the Qdrant hybrid ranking already produced by the single
-     * retrieval path and does not make a second LLM reranking request. Chat-answer retrieval
-     * continues to use {@link #retrieve(String)} and its configured reranker.</p>
+     * <p>Candidate documents are converted and deduplicated by their final citation URL and anchor
+     * before the configured citation limit is applied. Chat-answer context retrieval continues to
+     * use {@link #retrieve(String)} and its configured hybrid and reranking pipeline.</p>
      *
      * @param query citation-discovery query
      * @param retrievalConstraint exact server-side constraint for the citation sources
-     * @return hybrid-ranked documents limited to the configured citation count
+     * @return limited citations plus every candidate conversion failure
      */
-    public List<Document> retrieveForCitationDiscovery(String query, RetrievalConstraint retrievalConstraint) {
+    public CitationOutcome discoverCitations(String query, RetrievalConstraint retrievalConstraint) {
         Objects.requireNonNull(retrievalConstraint, "retrievalConstraint");
         if (query == null || query.isBlank()) {
-            return List.of();
+            return new CitationOutcome(List.of(), 0);
         }
-        Optional<VersionFilterPatterns> versionFilter = QueryVersionExtractor.extractFilterPatterns(query);
-        CandidateRetrieval candidateRetrieval = retrieveCandidates(query, retrievalConstraint, versionFilter);
-        int citationDocumentLimit = appProperties.getRag().getSearchCitations();
-        return candidateRetrieval.documents().stream()
-                .limit(citationDocumentLimit)
+        int citationLimit = appProperties.getRag().getSearchCitations();
+        if (citationLimit <= 0) {
+            return new CitationOutcome(List.of(), 0);
+        }
+        int citationCandidateLimit = Math.max(appProperties.getRag().getSearchTopK(), citationLimit);
+        String boostedQuery = QueryVersionExtractor.boostQueryWithVersionContext(query);
+        HybridSearchService.SearchOutcome citationSearchOutcome =
+                hybridSearchService.searchDocumentationCitationsOutcome(
+                        boostedQuery, citationCandidateLimit, retrievalConstraint);
+        CitationOutcome candidateCitationOutcome = toCitations(citationSearchOutcome.documents());
+        List<Citation> limitedCitations = candidateCitationOutcome.citations().stream()
+                .limit(citationLimit)
                 .toList();
+        return new CitationOutcome(limitedCitations, candidateCitationOutcome.failedConversionCount());
     }
 
     /**
@@ -368,12 +375,17 @@ public class RetrievalService {
                 String title = stringMetadataValue(sourceDocMetadata, METADATA_TITLE);
                 String packageName = stringMetadataValue(sourceDocMetadata, METADATA_PACKAGE);
                 String documentType = stringMetadataValue(sourceDocMetadata, METADATA_DOC_TYPE);
-                String url = refineCitationUrl(rawUrl, sourceDocument.getText(), packageName, documentType);
-                String citationIdentity = citationIdentityFor(rawUrl, url);
+                String refinedCitationUrl =
+                        refineCitationUrl(rawUrl, sourceDocument.getText(), packageName, documentType);
+                String citationIdentity = citationIdentityFor(rawUrl, refinedCitationUrl);
                 if (!citationIdentity.isBlank() && !retainedCitationIdentities.add(citationIdentity)) {
                     continue;
                 }
-                citations.add(new Citation(url, title, "", trimmedCitationSnippet(sourceDocument.getText())));
+                citations.add(new Citation(
+                        fragmentlessCitationSourceUrl(refinedCitationUrl),
+                        title,
+                        citationAnchor(refinedCitationUrl),
+                        trimmedCitationSnippet(sourceDocument.getText())));
             } catch (RuntimeException citationConversionFailure) {
                 failedConversionCount++;
                 log.warn(
@@ -396,6 +408,11 @@ public class RetrievalService {
     private static String fragmentlessCitationSourceUrl(String citationUrl) {
         int fragmentDelimiterIndex = citationUrl.indexOf(URL_FRAGMENT_DELIMITER);
         return fragmentDelimiterIndex < 0 ? citationUrl : citationUrl.substring(0, fragmentDelimiterIndex);
+    }
+
+    private static String citationAnchor(String citationUrl) {
+        int fragmentDelimiterIndex = citationUrl.indexOf(URL_FRAGMENT_DELIMITER);
+        return fragmentDelimiterIndex < 0 ? "" : citationUrl.substring(fragmentDelimiterIndex + 1);
     }
 
     /**

--- a/src/main/java/com/williamcallahan/javachat/service/RetrievalService.java
+++ b/src/main/java/com/williamcallahan/javachat/service/RetrievalService.java
@@ -135,10 +135,12 @@ public class RetrievalService {
             return new CitationOutcome(List.of(), 0);
         }
         int citationCandidateLimit = Math.max(appProperties.getRag().getSearchTopK(), citationLimit);
+        Optional<VersionFilterPatterns> versionFilter = QueryVersionExtractor.extractFilterPatterns(query);
+        RetrievalConstraint combinedRetrievalConstraint = combineWithVersionFilter(retrievalConstraint, versionFilter);
         String boostedQuery = QueryVersionExtractor.boostQueryWithVersionContext(query);
         HybridSearchService.SearchOutcome citationSearchOutcome =
                 hybridSearchService.searchDocumentationCitationsOutcome(
-                        boostedQuery, citationCandidateLimit, retrievalConstraint);
+                        boostedQuery, citationCandidateLimit, combinedRetrievalConstraint);
         CitationOutcome candidateCitationOutcome = toCitations(citationSearchOutcome.documents());
         List<Citation> limitedCitations = candidateCitationOutcome.citations().stream()
                 .limit(citationLimit)
@@ -161,8 +163,8 @@ public class RetrievalService {
     /**
      * Retrieves documents and notices within the caller-owned metadata constraint.
      *
-     * <p>The same constraint instance is passed to hybrid search so feature-specific source scopes
-     * cannot drift into an unconstrained retrieval path.</p>
+     * <p>Feature-specific source scopes are retained while any query-derived Java version is added
+     * to the same server-side Qdrant filter.</p>
      *
      * @param query retrieval query
      * @param retrievalConstraint exact server-side constraint for the retrieval
@@ -174,7 +176,15 @@ public class RetrievalService {
             return new RetrievalOutcome(List.of(), List.of());
         }
         Optional<VersionFilterPatterns> versionFilter = QueryVersionExtractor.extractFilterPatterns(query);
-        return retrieveOutcome(query, retrievalConstraint, versionFilter);
+        RetrievalConstraint combinedRetrievalConstraint = combineWithVersionFilter(retrievalConstraint, versionFilter);
+        return retrieveOutcome(query, combinedRetrievalConstraint, versionFilter);
+    }
+
+    private static RetrievalConstraint combineWithVersionFilter(
+            RetrievalConstraint retrievalConstraint, Optional<VersionFilterPatterns> versionFilter) {
+        return versionFilter
+                .map(filterPatterns -> retrievalConstraint.withDocVersion(filterPatterns.versionNumber()))
+                .orElse(retrievalConstraint);
     }
 
     private RetrievalOutcome retrieveOutcome(
@@ -215,24 +225,43 @@ public class RetrievalService {
     /**
      * Retrieve documents with custom limits for token-constrained models.
      */
-    public RetrievalOutcome retrieveWithLimitOutcome(String query, int maxDocs, int maxTokensPerDoc) {
-        RetrievalOutcome outcome = retrieveOutcome(query);
+    public RetrievalOutcome retrieveWithLimitOutcome(String query, int maxDocuments, int maxTokensPerDocument) {
+        return limitRetrievalOutcome(retrieveOutcome(query), maxDocuments, maxTokensPerDocument);
+    }
+
+    /**
+     * Retrieves constrained documents while capping document count and per-document token budget.
+     *
+     * @param query retrieval query
+     * @param maxDocuments maximum number of documents to retain
+     * @param maxTokensPerDocument maximum estimated tokens retained per document
+     * @param retrievalConstraint exact server-side constraint for the retrieval
+     * @return constrained, truncated retrieval outcome
+     */
+    public RetrievalOutcome retrieveWithLimitOutcome(
+            String query, int maxDocuments, int maxTokensPerDocument, RetrievalConstraint retrievalConstraint) {
+        return limitRetrievalOutcome(retrieveOutcome(query, retrievalConstraint), maxDocuments, maxTokensPerDocument);
+    }
+
+    private RetrievalOutcome limitRetrievalOutcome(
+            RetrievalOutcome outcome, int maxDocuments, int maxTokensPerDocument) {
         List<Document> documents = outcome.documents();
         if (documents.isEmpty()) {
             return outcome;
         }
-        List<Document> truncatedDocs = documents.stream()
-                .limit(Math.max(1, maxDocs))
-                .map(document -> truncateDocumentToTokenLimit(document, maxTokensPerDoc))
+        List<Document> truncatedDocuments = documents.stream()
+                .limit(Math.max(1, maxDocuments))
+                .map(document -> truncateDocumentToTokenLimit(document, maxTokensPerDocument))
                 .toList();
-        return new RetrievalOutcome(truncatedDocs, outcome.notices());
+        return new RetrievalOutcome(truncatedDocuments, outcome.notices());
     }
 
     /**
      * Retrieves documents while capping document count and per-document token budget.
      */
-    public List<Document> retrieveWithLimit(String query, int maxDocs, int maxTokensPerDoc) {
-        return retrieveWithLimitOutcome(query, maxDocs, maxTokensPerDoc).documents();
+    public List<Document> retrieveWithLimit(String query, int maxDocuments, int maxTokensPerDocument) {
+        return retrieveWithLimitOutcome(query, maxDocuments, maxTokensPerDocument)
+                .documents();
     }
 
     private List<Document> applyVersionFilterIfPresent(
@@ -336,9 +365,9 @@ public class RetrievalService {
     /**
      * Outcome of converting documents into citations, surfacing any partial conversion failures.
      *
-     * <p>Callers must inspect {@code failedConversionCount} to detect partial failures rather than
-     * silently receiving an incomplete citation list. A zero count means all documents converted
-     * successfully.</p>
+     * <p>Callers must inspect {@code failedConversionCount} or call {@link #citationsOrThrow()} to
+     * avoid silently receiving an incomplete citation list. A zero count means all documents
+     * converted successfully.</p>
      *
      * @param citations successfully converted citations
      * @param failedConversionCount number of documents that failed citation conversion
@@ -349,6 +378,23 @@ public class RetrievalService {
             if (failedConversionCount < 0) {
                 throw new IllegalArgumentException("failedConversionCount cannot be negative");
             }
+        }
+
+        /**
+         * Returns fully converted citations or rejects the incomplete conversion outcome.
+         *
+         * <p>Static citation responses cannot represent a source list truthfully when any source
+         * document failed conversion, so callers must surface the typed failure instead of returning
+         * only the successfully converted subset.</p>
+         *
+         * @return immutable citations when every source document converted successfully
+         * @throws CitationConversionFailureException when one or more source documents failed conversion
+         */
+        public List<Citation> citationsOrThrow() {
+            if (failedConversionCount > 0) {
+                throw new CitationConversionFailureException(failedConversionCount);
+            }
+            return citations;
         }
     }
 

--- a/src/main/java/com/williamcallahan/javachat/web/ChatController.java
+++ b/src/main/java/com/williamcallahan/javachat/web/ChatController.java
@@ -140,8 +140,8 @@ public class ChatController extends BaseController {
                     AtomicInteger chunkCount = new AtomicInteger(0);
                     PIPELINE_LOG.info("[{}] Using OpenAI Java SDK for streaming (structured prompt)", requestToken);
 
-                    // Emit citations inline at stream end - compute before streaming starts
-                    // Citation conversion failures are surfaced to UI via status event
+                    // Cite the exact official documents supplied to the model so source attribution
+                    // cannot drift from the answer context. Conversion failures remain observable.
                     RetrievalService.CitationOutcome citationOutcome =
                             retrievalService.toCitations(promptOutcome.documents());
                     final List<Citation> finalCitations = citationOutcome.citations();
@@ -166,7 +166,7 @@ public class ChatController extends BaseController {
                                 // Heartbeats terminate when data stream completes (success or error)
                                 Flux<ServerSentEvent<String>> heartbeats = sseSupport.heartbeats(dataStream);
 
-                                // Combine retrieval notices with citation warning if present
+                                // Surface retrieval and citation-conversion notices before response content.
                                 Flux<ServerSentEvent<String>> statusEvents = Flux.fromIterable(promptOutcome.notices())
                                         .map(notice -> sseSupport.statusEvent(notice.summary(), notice.details()));
                                 statusEvents = statusEvents.concatWith(sseSupport.citationPartialFailureStatusFlux(

--- a/src/test/java/com/williamcallahan/javachat/config/DocsSourceRegistryTest.java
+++ b/src/test/java/com/williamcallahan/javachat/config/DocsSourceRegistryTest.java
@@ -1,11 +1,15 @@
 package com.williamcallahan.javachat.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.williamcallahan.javachat.config.DocsSourceRegistry.DocumentationSource;
 import com.williamcallahan.javachat.config.DocsSourceRegistry.JavaApiDocumentationSource;
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -25,6 +29,39 @@ class DocsSourceRegistryTest {
         List<DocumentationSource> documentationSources = DocsSourceRegistry.documentationSources();
 
         assertThrows(UnsupportedOperationException.class, documentationSources::removeFirst);
+    }
+
+    @Test
+    void projectsImmutableOfficialSourceIdentitiesFromBothCanonicalManifests() {
+        List<String> expectedSourceIdentities = Stream.concat(
+                        DocsSourceRegistry.documentationSources().stream().map(DocumentationSource::docSet),
+                        DocsSourceRegistry.javaApiDocumentationSources().stream()
+                                .map(JavaApiDocumentationSource::relativeMirrorPath))
+                .toList();
+
+        List<String> officialSourceIdentities = DocsSourceRegistry.officialDocumentationSourceIdentities();
+
+        assertEquals(expectedSourceIdentities, officialSourceIdentities);
+        assertThrows(UnsupportedOperationException.class, officialSourceIdentities::removeFirst);
+    }
+
+    @Test
+    void excludesSyntheticNonOfficialSourcesWithoutRestatingCanonicalSourceIdentities() {
+        DocumentationSource canonicalOfficialSource =
+                DocsSourceRegistry.documentationSources().getFirst();
+        JavaApiDocumentationSource canonicalJavaApiSource =
+                DocsSourceRegistry.javaApiDocumentationSources().getFirst();
+        DocumentationSource syntheticNonOfficialSource = mock(DocumentationSource.class);
+        when(syntheticNonOfficialSource.sourceKind()).thenReturn("community");
+        when(syntheticNonOfficialSource.docSet()).thenReturn("synthetic-community-docs");
+
+        List<String> projectedSourceIdentities = DocsSourceRegistry.projectOfficialDocumentationSourceIdentities(
+                List.of(canonicalOfficialSource, syntheticNonOfficialSource), List.of(canonicalJavaApiSource));
+
+        assertEquals(
+                List.of(canonicalOfficialSource.docSet(), canonicalJavaApiSource.relativeMirrorPath()),
+                projectedSourceIdentities);
+        assertFalse(projectedSourceIdentities.contains(syntheticNonOfficialSource.docSet()));
     }
 
     @Test

--- a/src/test/java/com/williamcallahan/javachat/service/ChatServiceTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/ChatServiceTest.java
@@ -1,0 +1,50 @@
+package com.williamcallahan.javachat.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.williamcallahan.javachat.config.AppProperties;
+import com.williamcallahan.javachat.config.DocsSourceRegistry;
+import com.williamcallahan.javachat.config.SystemPromptConfig;
+import com.williamcallahan.javachat.model.Citation;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/** Verifies chat citation lookup remains isolated from answer-context retrieval and reranking. */
+class ChatServiceTest {
+
+    private static final String CITATION_QUERY = "Java records";
+
+    @Test
+    void citationsUseSparseDiscoveryConstrainedByEveryCanonicalOfficialSourceIdentity() {
+        RetrievalService retrievalService = mock(RetrievalService.class);
+        ChatService chatService = new ChatService(
+                mock(OpenAIStreamingService.class),
+                retrievalService,
+                mock(SystemPromptConfig.class),
+                new AppProperties());
+        Citation expectedCitation = new Citation("https://docs.example.test/Record.html", "Record", "", "Record API");
+        when(retrievalService.discoverCitations(eq(CITATION_QUERY), any(RetrievalConstraint.class)))
+                .thenReturn(new RetrievalService.CitationOutcome(List.of(expectedCitation), 0));
+
+        List<Citation> citations = chatService.citationsFor(CITATION_QUERY);
+
+        ArgumentCaptor<RetrievalConstraint> constraintCaptor = ArgumentCaptor.forClass(RetrievalConstraint.class);
+        verify(retrievalService).discoverCitations(eq(CITATION_QUERY), constraintCaptor.capture());
+        RetrievalConstraint citationConstraint = constraintCaptor.getValue();
+        assertEquals("official", citationConstraint.sourceKind());
+        assertEquals(DocsSourceRegistry.officialDocumentationSourceIdentities(), citationConstraint.docSet());
+        assertEquals(List.of(expectedCitation), citations);
+        verify(retrievalService, never()).retrieve(anyString());
+        verify(retrievalService, never()).retrieve(anyString(), any(RetrievalConstraint.class));
+        verify(retrievalService, never()).retrieveOutcome(anyString());
+        verify(retrievalService, never()).retrieveOutcome(anyString(), any(RetrievalConstraint.class));
+    }
+}

--- a/src/test/java/com/williamcallahan/javachat/service/ChatServiceTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/ChatServiceTest.java
@@ -1,6 +1,7 @@
 package com.williamcallahan.javachat.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -11,16 +12,19 @@ import static org.mockito.Mockito.when;
 
 import com.williamcallahan.javachat.config.AppProperties;
 import com.williamcallahan.javachat.config.DocsSourceRegistry;
+import com.williamcallahan.javachat.config.ModelConfiguration;
 import com.williamcallahan.javachat.config.SystemPromptConfig;
 import com.williamcallahan.javachat.model.Citation;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-/** Verifies chat citation lookup remains isolated from answer-context retrieval and reranking. */
+/** Verifies chat answer context and static citations remain grounded in official documentation. */
 class ChatServiceTest {
 
     private static final String CITATION_QUERY = "Java records";
+    private static final String VERSIONED_CONTEXT_QUERY = "Java 17 List.of";
+    private static final String NON_TOKEN_CONSTRAINED_MODEL = "gpt-4.1";
 
     @Test
     void citationsUseSparseDiscoveryConstrainedByEveryCanonicalOfficialSourceIdentity() {
@@ -46,5 +50,74 @@ class ChatServiceTest {
         verify(retrievalService, never()).retrieve(anyString(), any(RetrievalConstraint.class));
         verify(retrievalService, never()).retrieveOutcome(anyString());
         verify(retrievalService, never()).retrieveOutcome(anyString(), any(RetrievalConstraint.class));
+    }
+
+    @Test
+    void citationsRejectPartialCitationConversionOutcomes() {
+        RetrievalService retrievalService = mock(RetrievalService.class);
+        ChatService chatService = new ChatService(
+                mock(OpenAIStreamingService.class),
+                retrievalService,
+                mock(SystemPromptConfig.class),
+                new AppProperties());
+        when(retrievalService.discoverCitations(eq(CITATION_QUERY), any(RetrievalConstraint.class)))
+                .thenReturn(new RetrievalService.CitationOutcome(
+                        List.of(new Citation("https://docs.example.test/Record.html", "Record", "", "Record API")), 1));
+
+        CitationConversionFailureException conversionFailure =
+                assertThrows(CitationConversionFailureException.class, () -> chatService.citationsFor(CITATION_QUERY));
+
+        assertEquals(1, conversionFailure.failedConversionCount());
+    }
+
+    @Test
+    void versionedStructuredPromptUsesOfficialContextForTheDefaultTokenConstrainedModel() {
+        RetrievalService retrievalService = mock(RetrievalService.class);
+        SystemPromptConfig systemPromptConfig = mock(SystemPromptConfig.class);
+        when(systemPromptConfig.getCoreSystemPrompt()).thenReturn("You are a Java tutor.");
+        when(retrievalService.retrieveWithLimitOutcome(
+                        eq(VERSIONED_CONTEXT_QUERY),
+                        eq(ModelConfiguration.RAG_LIMIT_CONSTRAINED),
+                        eq(ModelConfiguration.RAG_TOKEN_LIMIT_CONSTRAINED),
+                        any(RetrievalConstraint.class)))
+                .thenReturn(new RetrievalService.RetrievalOutcome(List.of(), List.of()));
+        ChatService chatService = new ChatService(
+                mock(OpenAIStreamingService.class), retrievalService, systemPromptConfig, new AppProperties());
+
+        chatService.buildStructuredPromptWithContextOutcome(
+                List.of(), VERSIONED_CONTEXT_QUERY, ModelConfiguration.DEFAULT_MODEL);
+
+        ArgumentCaptor<RetrievalConstraint> constraintCaptor = ArgumentCaptor.forClass(RetrievalConstraint.class);
+        verify(retrievalService)
+                .retrieveWithLimitOutcome(
+                        eq(VERSIONED_CONTEXT_QUERY),
+                        eq(ModelConfiguration.RAG_LIMIT_CONSTRAINED),
+                        eq(ModelConfiguration.RAG_TOKEN_LIMIT_CONSTRAINED),
+                        constraintCaptor.capture());
+        RetrievalConstraint answerContextConstraint = constraintCaptor.getValue();
+        assertEquals("official", answerContextConstraint.sourceKind());
+        assertEquals(DocsSourceRegistry.officialDocumentationSourceIdentities(), answerContextConstraint.docSet());
+        verify(retrievalService, never()).discoverCitations(anyString(), any(RetrievalConstraint.class));
+    }
+
+    @Test
+    void versionedStructuredPromptUsesOfficialContextForNonTokenConstrainedModels() {
+        RetrievalService retrievalService = mock(RetrievalService.class);
+        SystemPromptConfig systemPromptConfig = mock(SystemPromptConfig.class);
+        when(systemPromptConfig.getCoreSystemPrompt()).thenReturn("You are a Java tutor.");
+        when(retrievalService.retrieveOutcome(eq(VERSIONED_CONTEXT_QUERY), any(RetrievalConstraint.class)))
+                .thenReturn(new RetrievalService.RetrievalOutcome(List.of(), List.of()));
+        ChatService chatService = new ChatService(
+                mock(OpenAIStreamingService.class), retrievalService, systemPromptConfig, new AppProperties());
+
+        chatService.buildStructuredPromptWithContextOutcome(
+                List.of(), VERSIONED_CONTEXT_QUERY, NON_TOKEN_CONSTRAINED_MODEL);
+
+        ArgumentCaptor<RetrievalConstraint> constraintCaptor = ArgumentCaptor.forClass(RetrievalConstraint.class);
+        verify(retrievalService).retrieveOutcome(eq(VERSIONED_CONTEXT_QUERY), constraintCaptor.capture());
+        RetrievalConstraint answerContextConstraint = constraintCaptor.getValue();
+        assertEquals("official", answerContextConstraint.sourceKind());
+        assertEquals(DocsSourceRegistry.officialDocumentationSourceIdentities(), answerContextConstraint.docSet());
+        verify(retrievalService, never()).discoverCitations(anyString(), any(RetrievalConstraint.class));
     }
 }

--- a/src/test/java/com/williamcallahan/javachat/service/GuidedLearningServiceCitationTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/GuidedLearningServiceCitationTest.java
@@ -57,9 +57,9 @@ class GuidedLearningServiceCitationTest {
         RetrievalService retrievalService = mock(RetrievalService.class);
         when(retrievalService.retrieve(anyString(), any(RetrievalConstraint.class)))
                 .thenReturn(List.of(officialSourceDocument));
-        when(retrievalService.retrieveForCitationDiscovery(anyString(), any(RetrievalConstraint.class)))
-                .thenReturn(List.of(officialSourceDocument));
         Citation officialCitation = new Citation(officialSourceUrl(guidedLesson), "Strings", "", "substring");
+        when(retrievalService.discoverCitations(anyString(), any(RetrievalConstraint.class)))
+                .thenReturn(new RetrievalService.CitationOutcome(List.of(officialCitation), 0));
         when(retrievalService.toCitations(List.of(officialSourceDocument)))
                 .thenReturn(new RetrievalService.CitationOutcome(List.of(officialCitation), 0));
 
@@ -92,7 +92,7 @@ class GuidedLearningServiceCitationTest {
                 ArgumentCaptor.forClass(RetrievalConstraint.class);
         verify(retrievalService, org.mockito.Mockito.times(2))
                 .retrieve(anyString(), retrievalConstraintCaptor.capture());
-        verify(retrievalService).retrieveForCitationDiscovery(anyString(), retrievalConstraintCaptor.capture());
+        verify(retrievalService).discoverCitations(anyString(), retrievalConstraintCaptor.capture());
         for (RetrievalConstraint guidedConstraint : retrievalConstraintCaptor.getAllValues()) {
             assertEquals("official", guidedConstraint.sourceKind());
             assertEquals(guidedLesson.getDocSet(), guidedConstraint.docSet());

--- a/src/test/java/com/williamcallahan/javachat/service/GuidedLearningServiceCitationTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/GuidedLearningServiceCitationTest.java
@@ -208,6 +208,31 @@ class GuidedLearningServiceCitationTest {
         assertEquals(expectedCitationOutcome, actualCitationOutcome);
     }
 
+    @Test
+    void lessonCitationsRejectPartialCitationConversionOutcomes() {
+        GuidedLesson guidedLesson = guidedLesson();
+        GuidedTOCProvider tocProvider = mock(GuidedTOCProvider.class);
+        when(tocProvider.findBySlug(LESSON_SLUG)).thenReturn(Optional.of(guidedLesson));
+
+        RetrievalService retrievalService = mock(RetrievalService.class);
+        when(retrievalService.discoverCitations(anyString(), any(RetrievalConstraint.class)))
+                .thenReturn(new RetrievalService.CitationOutcome(
+                        List.of(new Citation(officialSourceUrl(guidedLesson), "Strings", "", OFFICIAL_SOURCE_TEXT)),
+                        1));
+
+        GuidedLearningService guidedLearningService = guidedLearningService(
+                tocProvider,
+                retrievalService,
+                mock(EnrichmentService.class),
+                mock(ChatService.class),
+                systemPromptConfig());
+
+        CitationConversionFailureException conversionFailure = assertThrows(
+                CitationConversionFailureException.class, () -> guidedLearningService.citationsForLesson(LESSON_SLUG));
+
+        assertEquals(1, conversionFailure.failedConversionCount());
+    }
+
     private static GuidedLearningService guidedLearningService(
             GuidedTOCProvider tocProvider,
             RetrievalService retrievalService,

--- a/src/test/java/com/williamcallahan/javachat/service/GuidedTOCProviderTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/GuidedTOCProviderTest.java
@@ -24,7 +24,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,7 +32,6 @@ import org.springframework.boot.test.autoconfigure.json.JsonTest;
 /** Verifies guided source references remain manifest-owned and project into the public lesson contract. */
 @JsonTest
 class GuidedTOCProviderTest {
-    private static final String SOURCE_KIND_OFFICIAL = "official";
     private static final String CANONICAL_SOURCE_REFERENCE_TEST_SLUG = "strings";
     private static final String CALLER_MUTATED_LESSON_TITLE = "Caller-mutated lesson title";
     private static final String UNKNOWN_SOURCE_REFERENCE_TEST_SLUG = "unknown-source-reference";
@@ -50,13 +48,7 @@ class GuidedTOCProviderTest {
                 .findBySlug(CANONICAL_SOURCE_REFERENCE_TEST_SLUG)
                 .orElseThrow();
 
-        List<String> expectedDocSets = Stream.concat(
-                        DocsSourceRegistry.documentationSources().stream()
-                                .filter(documentationSource ->
-                                        SOURCE_KIND_OFFICIAL.equals(documentationSource.sourceKind()))
-                                .map(DocsSourceRegistry.DocumentationSource::docSet),
-                        DocsSourceRegistry.javaApiDocumentationSources().stream()
-                                .map(DocsSourceRegistry.JavaApiDocumentationSource::relativeMirrorPath))
+        List<String> expectedDocSets = DocsSourceRegistry.officialDocumentationSourceIdentities().stream()
                 .filter(listedLesson.sourceReferences()::contains)
                 .toList();
 

--- a/src/test/java/com/williamcallahan/javachat/service/HybridSearchServiceTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/HybridSearchServiceTest.java
@@ -231,6 +231,45 @@ class HybridSearchServiceTest {
                     .allMatch(logEvent -> logEvent.getFormattedMessage().contains("Search timed out for collection=")));
         }
         assertEquals(4, timedOutSearchOutcome.notices().size());
+        assertTrue(timedOutSearchOutcome.notices().stream()
+                .allMatch(retrievalNotice -> retrievalNotice.details().contains("Qdrant query exceeded timeout")));
+        assertEquals(4, stalledQdrantQueryFutures.size());
+        assertTrue(stalledQdrantQueryFutures.stream().allMatch(SettableFuture::isCancelled));
+    }
+
+    @Test
+    void interruptionCancelsEveryPendingQueryAndFailsRetrievalEvenWhenPartialFailuresAreNonFatal() {
+        appProperties.getQdrant().setFailOnPartialSearchError(false);
+        when(embeddingClient.embed(HYBRID_QUERY, LlmGatewayTier.LIVE)).thenReturn(new float[] {0.1f, 0.2f, 0.3f});
+        when(sparseEncoder.encode(HYBRID_QUERY))
+                .thenReturn(new LexicalSparseVectorEncoder.SparseVector(List.of(1L), List.of(1.0f)));
+        List<SettableFuture<List<ScoredPoint>>> stalledQdrantQueryFutures = new ArrayList<>();
+        doAnswer(invocation -> {
+                    SettableFuture<List<ScoredPoint>> stalledQdrantQueryFuture = SettableFuture.create();
+                    stalledQdrantQueryFutures.add(stalledQdrantQueryFuture);
+                    return stalledQdrantQueryFuture;
+                })
+                .when(qdrantClient)
+                .queryAsync(notNull(), notNull());
+
+        HybridSearchService hybridSearchService = buildSearchService();
+        HybridSearchPartialFailureException interruptionFailure;
+        boolean interruptStatusPreserved;
+        Thread.currentThread().interrupt();
+        try {
+            interruptionFailure = assertThrows(
+                    HybridSearchPartialFailureException.class,
+                    () -> hybridSearchService.searchOutcome(HYBRID_QUERY, 5, RetrievalConstraint.none()));
+        } finally {
+            interruptStatusPreserved = Thread.interrupted();
+        }
+
+        assertTrue(interruptStatusPreserved);
+        assertEquals("Qdrant retrieval was interrupted", interruptionFailure.getMessage());
+        assertEquals(1, interruptionFailure.collectionFailures().size());
+        assertEquals(
+                "Qdrant query was interrupted",
+                interruptionFailure.collectionFailures().getFirst().failureDetails());
         assertEquals(4, stalledQdrantQueryFutures.size());
         assertTrue(stalledQdrantQueryFutures.stream().allMatch(SettableFuture::isCancelled));
     }

--- a/src/test/java/com/williamcallahan/javachat/service/HybridSearchServiceTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/HybridSearchServiceTest.java
@@ -4,40 +4,57 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeout;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.SettableFuture;
 import com.williamcallahan.javachat.application.search.LexicalSparseVectorEncoder;
 import com.williamcallahan.javachat.config.AppProperties;
+import com.williamcallahan.javachat.config.QdrantGitHubCollectionDiscovery;
 import com.williamcallahan.javachat.support.logging.ExpectedLogEvents;
 import io.qdrant.client.QdrantClient;
 import io.qdrant.client.grpc.Points.PrefetchQuery;
 import io.qdrant.client.grpc.Points.QueryPoints;
 import io.qdrant.client.grpc.Points.ScoredPoint;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 /**
- * Verifies hybrid retrieval behavior for server-side filtering, fusion tuning, and partial failures.
+ * Verifies hybrid and sparse citation retrieval behavior at the direct Qdrant request boundary.
  */
 class HybridSearchServiceTest {
 
     private static final Logger HYBRID_SEARCH_LOGGER = (Logger) LoggerFactory.getLogger(HybridSearchService.class);
     private static final String COLLECTION_FAILURE_WARNING =
             "[QDRANT] Search failed for collection=java-chat-books (exceptionType=RuntimeException)";
+    private static final String CITATION_COLLECTION_FAILURE_WARNING =
+            "[QDRANT] Search failed for collection=java-docs (exceptionType=RuntimeException)";
+    private static final String HYBRID_QUERY = "Java 25 streams";
+    private static final String CITATION_QUERY = "Java records";
+    private static final Duration DISPATCH_BUDGET_TEST_TIMEOUT = Duration.ofMillis(500);
+    private static final long FIRST_DISPATCH_DELAY_MILLIS = 50;
+    private static final Duration SHARED_QUERY_TIMEOUT = Duration.ofMillis(150);
+    private static final Duration SHARED_DEADLINE_ASSERTION_LIMIT = Duration.ofMillis(450);
+    private static final UUID SCORED_POINT_UUID = UUID.fromString("97c1f646-bd04-443e-a29f-e0283fe27e5b");
 
     private QdrantClient qdrantClient;
     private EmbeddingClient embeddingClient;
@@ -53,29 +70,39 @@ class HybridSearchServiceTest {
     }
 
     @Test
-    void appliesServerFilterToQueryAndPrefetchWithConfiguredRrfK() {
+    void appliesServerFilterToHybridPrefetchAndDispatchesEachQueryWithTheConfiguredDuration() {
         appProperties.getQdrant().setRrfK(77);
+        appProperties.getQdrant().setQueryTimeout(DISPATCH_BUDGET_TEST_TIMEOUT);
 
-        when(embeddingClient.embed("Java 25 streams", LlmGatewayTier.LIVE)).thenReturn(new float[] {0.1f, 0.2f, 0.3f});
-        when(sparseEncoder.encode("Java 25 streams"))
+        when(embeddingClient.embed(HYBRID_QUERY, LlmGatewayTier.LIVE)).thenReturn(new float[] {0.1f, 0.2f, 0.3f});
+        when(sparseEncoder.encode(HYBRID_QUERY))
                 .thenReturn(new LexicalSparseVectorEncoder.SparseVector(List.of(1L, 3L), List.of(2.0f, 1.0f)));
 
         List<QueryPoints> capturedQueries = new ArrayList<>();
+        List<Duration> capturedQueryTimeouts = new ArrayList<>();
         doAnswer(invocation -> {
                     capturedQueries.add(invocation.getArgument(0));
+                    capturedQueryTimeouts.add(invocation.getArgument(1));
+                    if (capturedQueryTimeouts.size() == 1) {
+                        TimeUnit.MILLISECONDS.sleep(FIRST_DISPATCH_DELAY_MILLIS);
+                    }
                     return Futures.immediateFuture(List.of(scoredPoint()));
                 })
                 .when(qdrantClient)
-                .queryAsync(notNull());
+                .queryAsync(notNull(), notNull());
 
         HybridSearchService hybridSearchService = buildSearchService();
-
         RetrievalConstraint retrievalConstraint = RetrievalConstraint.forDocVersion("25");
-        hybridSearchService.searchOutcome("Java 25 streams", 5, retrievalConstraint);
+
+        hybridSearchService.searchOutcome(HYBRID_QUERY, 5, retrievalConstraint);
 
         assertEquals(4, capturedQueries.size());
-        QueryPoints capturedQuery = capturedQueries.get(0);
-
+        assertTrue(capturedQueryTimeouts.stream()
+                .allMatch(queryTimeout -> !queryTimeout.isZero()
+                        && !queryTimeout.isNegative()
+                        && queryTimeout.compareTo(DISPATCH_BUDGET_TEST_TIMEOUT) <= 0));
+        assertTrue(capturedQueryTimeouts.getLast().compareTo(capturedQueryTimeouts.getFirst()) < 0);
+        QueryPoints capturedQuery = capturedQueries.getFirst();
         assertEquals(77, capturedQuery.getQuery().getRrf().getK());
         assertTrue(capturedQuery.hasFilter());
         assertTrue(capturedQuery.getFilter().toString().contains("docVersion"));
@@ -83,6 +110,129 @@ class HybridSearchServiceTest {
         for (PrefetchQuery prefetchQuery : capturedQuery.getPrefetchList()) {
             assertTrue(prefetchQuery.hasFilter());
         }
+        verify(qdrantClient, never()).queryAsync(any(QueryPoints.class));
+    }
+
+    @Test
+    void citationSearchUsesOnlyTheSparseOfficialDocumentationRequestAndDurationOverload() {
+        appProperties.getQdrant().setSparseVectorName("bm25");
+        when(sparseEncoder.encode(CITATION_QUERY))
+                .thenReturn(new LexicalSparseVectorEncoder.SparseVector(List.of(2L, 7L), List.of(3.0f, 1.0f)));
+        QdrantGitHubCollectionDiscovery gitHubCollectionDiscovery = mock(QdrantGitHubCollectionDiscovery.class);
+        when(gitHubCollectionDiscovery.getDiscoveredCollections()).thenReturn(List.of("github-example-project"));
+
+        List<QueryPoints> capturedQueries = new ArrayList<>();
+        List<Duration> capturedQueryTimeouts = new ArrayList<>();
+        doAnswer(invocation -> {
+                    capturedQueries.add(invocation.getArgument(0));
+                    capturedQueryTimeouts.add(invocation.getArgument(1));
+                    return Futures.immediateFuture(List.of(scoredPoint()));
+                })
+                .when(qdrantClient)
+                .queryAsync(notNull(), notNull());
+
+        HybridSearchService hybridSearchService = buildSearchServiceWithGitHubDiscovery(gitHubCollectionDiscovery);
+        RetrievalConstraint officialDocumentationConstraint =
+                RetrievalConstraint.forOfficialDocSets(List.of("dev-java", "java/java25-complete"));
+
+        HybridSearchService.SearchOutcome citationSearchOutcome =
+                hybridSearchService.searchDocumentationCitationsOutcome(
+                        CITATION_QUERY, 3, officialDocumentationConstraint);
+
+        assertEquals(1, capturedQueries.size());
+        assertEquals(1, capturedQueryTimeouts.size());
+        Duration citationQueryTimeout = capturedQueryTimeouts.getFirst();
+        assertFalse(citationQueryTimeout.isZero());
+        assertFalse(citationQueryTimeout.isNegative());
+        assertTrue(citationQueryTimeout.compareTo(appProperties.getQdrant().getQueryTimeout()) <= 0);
+        QueryPoints citationQuery = capturedQueries.getFirst();
+        assertEquals(appProperties.getQdrant().getCollections().getDocs(), citationQuery.getCollectionName());
+        assertEquals("bm25", citationQuery.getUsing());
+        assertEquals(3, citationQuery.getLimit());
+        assertTrue(citationQuery.getWithPayload().getEnable());
+        assertEquals(0, citationQuery.getPrefetchCount());
+        assertTrue(citationQuery.getQuery().hasNearest());
+        assertFalse(citationQuery.getQuery().hasRrf());
+        assertTrue(citationQuery.getQuery().getNearest().hasSparse());
+        assertEquals(
+                List.of(2, 7), citationQuery.getQuery().getNearest().getSparse().getIndicesList());
+        assertTrue(citationQuery.hasFilter());
+        String officialFilter = citationQuery.getFilter().toString();
+        assertTrue(officialFilter.contains("sourceKind"));
+        assertTrue(officialFilter.contains("official"));
+        assertTrue(officialFilter.contains("docSet"));
+        assertTrue(officialFilter.contains("dev-java"));
+        assertEquals(1, citationSearchOutcome.documents().size());
+        assertEquals(
+                appProperties.getQdrant().getCollections().getDocs(),
+                citationSearchOutcome.documents().getFirst().getMetadata().get("collection"));
+        verifyNoInteractions(embeddingClient);
+        verify(gitHubCollectionDiscovery, never()).getDiscoveredCollections();
+        verify(qdrantClient, never()).queryAsync(any(QueryPoints.class));
+    }
+
+    @Test
+    void citationSearchRemainsStrictWhenHybridPartialFailuresAreConfiguredAsNonFatal() {
+        appProperties.getQdrant().setFailOnPartialSearchError(false);
+        when(sparseEncoder.encode(CITATION_QUERY))
+                .thenReturn(new LexicalSparseVectorEncoder.SparseVector(List.of(2L), List.of(1.0f)));
+        doAnswer(invocation -> Futures.immediateFailedFuture(new RuntimeException("documentation unavailable")))
+                .when(qdrantClient)
+                .queryAsync(notNull(), notNull());
+        HybridSearchService hybridSearchService = buildSearchService();
+        RetrievalConstraint officialDocumentationConstraint =
+                RetrievalConstraint.forOfficialDocSets(List.of("dev-java"));
+
+        HybridSearchPartialFailureException citationSearchFailure;
+        try (ExpectedLogEvents expectedLogEvents = ExpectedLogEvents.capture(HYBRID_SEARCH_LOGGER)) {
+            citationSearchFailure = assertThrows(
+                    HybridSearchPartialFailureException.class,
+                    () -> hybridSearchService.searchDocumentationCitationsOutcome(
+                            CITATION_QUERY, 3, officialDocumentationConstraint));
+
+            assertEquals(1, expectedLogEvents.events().size());
+            assertEquals(
+                    CITATION_COLLECTION_FAILURE_WARNING,
+                    expectedLogEvents.events().getFirst().getFormattedMessage());
+        }
+
+        assertEquals(1, citationSearchFailure.collectionFailures().size());
+        assertEquals(
+                appProperties.getQdrant().getCollections().getDocs(),
+                citationSearchFailure.collectionFailures().getFirst().collectionName());
+        verifyNoInteractions(embeddingClient);
+    }
+
+    @Test
+    void sharesOneDispatchDeadlineAcrossMultipleStalledHybridQueries() {
+        appProperties.getQdrant().setFailOnPartialSearchError(false);
+        appProperties.getQdrant().setQueryTimeout(SHARED_QUERY_TIMEOUT);
+        when(embeddingClient.embed(HYBRID_QUERY, LlmGatewayTier.LIVE)).thenReturn(new float[] {0.1f, 0.2f, 0.3f});
+        when(sparseEncoder.encode(HYBRID_QUERY))
+                .thenReturn(new LexicalSparseVectorEncoder.SparseVector(List.of(1L), List.of(1.0f)));
+        List<SettableFuture<List<ScoredPoint>>> stalledQdrantQueryFutures = new ArrayList<>();
+        doAnswer(invocation -> {
+                    SettableFuture<List<ScoredPoint>> stalledQdrantQueryFuture = SettableFuture.create();
+                    stalledQdrantQueryFutures.add(stalledQdrantQueryFuture);
+                    return stalledQdrantQueryFuture;
+                })
+                .when(qdrantClient)
+                .queryAsync(notNull(), notNull());
+
+        HybridSearchService hybridSearchService = buildSearchService();
+        HybridSearchService.SearchOutcome timedOutSearchOutcome;
+        try (ExpectedLogEvents expectedLogEvents = ExpectedLogEvents.capture(HYBRID_SEARCH_LOGGER)) {
+            timedOutSearchOutcome = assertTimeout(
+                    SHARED_DEADLINE_ASSERTION_LIMIT,
+                    () -> hybridSearchService.searchOutcome(HYBRID_QUERY, 5, RetrievalConstraint.none()));
+
+            assertEquals(4, expectedLogEvents.events().size());
+            assertTrue(expectedLogEvents.events().stream()
+                    .allMatch(logEvent -> logEvent.getFormattedMessage().contains("Search timed out for collection=")));
+        }
+        assertEquals(4, timedOutSearchOutcome.notices().size());
+        assertEquals(4, stalledQdrantQueryFutures.size());
+        assertTrue(stalledQdrantQueryFutures.stream().allMatch(SettableFuture::isCancelled));
     }
 
     @Test
@@ -91,12 +241,12 @@ class HybridSearchServiceTest {
         stubPartialFailureQueryResponses("collections health");
 
         HybridSearchService hybridSearchService = buildSearchService();
-        RetrievalConstraint constraint = RetrievalConstraint.none();
+        RetrievalConstraint retrievalConstraint = RetrievalConstraint.none();
 
         try (ExpectedLogEvents expectedLogEvents = ExpectedLogEvents.capture(HYBRID_SEARCH_LOGGER)) {
             assertThrows(
                     HybridSearchPartialFailureException.class,
-                    () -> hybridSearchService.searchOutcome("collections health", 5, constraint));
+                    () -> hybridSearchService.searchOutcome("collections health", 5, retrievalConstraint));
             assertCollectionFailureWarning(expectedLogEvents);
         }
     }
@@ -107,11 +257,11 @@ class HybridSearchServiceTest {
         stubPartialFailureQueryResponses("collections health");
 
         HybridSearchService hybridSearchService = buildSearchService();
-        RetrievalConstraint constraint = RetrievalConstraint.none();
+        RetrievalConstraint retrievalConstraint = RetrievalConstraint.none();
 
         HybridSearchService.SearchOutcome searchOutcome;
         try (ExpectedLogEvents expectedLogEvents = ExpectedLogEvents.capture(HYBRID_SEARCH_LOGGER)) {
-            searchOutcome = hybridSearchService.searchOutcome("collections health", 5, constraint);
+            searchOutcome = hybridSearchService.searchOutcome("collections health", 5, retrievalConstraint);
             assertCollectionFailureWarning(expectedLogEvents);
         }
 
@@ -126,13 +276,22 @@ class HybridSearchServiceTest {
                 Optional.empty());
     }
 
+    private HybridSearchService buildSearchServiceWithGitHubDiscovery(
+            QdrantGitHubCollectionDiscovery gitHubCollectionDiscovery) {
+        return new HybridSearchService(
+                qdrantClient,
+                new QueryEncodingServices(embeddingClient, sparseEncoder, new QdrantRetrievalConstraintBuilder()),
+                appProperties,
+                Optional.of(gitHubCollectionDiscovery));
+    }
+
     private void stubPartialFailureQueryResponses(String queryText) {
         when(embeddingClient.embed(queryText, LlmGatewayTier.LIVE)).thenReturn(new float[] {0.5f, 0.1f, 0.4f});
         when(sparseEncoder.encode(queryText))
                 .thenReturn(new LexicalSparseVectorEncoder.SparseVector(List.of(2L), List.of(1.0f)));
 
         AtomicInteger invocationCounter = new AtomicInteger();
-        doAnswer(unusedInvocation -> {
+        doAnswer(invocation -> {
                     int invocationIndex = invocationCounter.getAndIncrement();
                     if (invocationIndex == 0) {
                         return Futures.immediateFailedFuture(new RuntimeException("collection unavailable"));
@@ -140,7 +299,7 @@ class HybridSearchServiceTest {
                     return Futures.immediateFuture(List.of(scoredPoint()));
                 })
                 .when(qdrantClient)
-                .queryAsync(notNull());
+                .queryAsync(notNull(), notNull());
     }
 
     private static void assertCollectionFailureWarning(ExpectedLogEvents expectedLogEvents) {
@@ -153,7 +312,7 @@ class HybridSearchServiceTest {
 
     private static ScoredPoint scoredPoint() {
         return ScoredPoint.newBuilder()
-                .setId(io.qdrant.client.PointIdFactory.id(Objects.requireNonNull(UUID.randomUUID())))
+                .setId(io.qdrant.client.PointIdFactory.id(SCORED_POINT_UUID))
                 .setScore(0.9f)
                 .putPayload("doc_content", io.qdrant.client.ValueFactory.value("Java stream examples"))
                 .putPayload("url", io.qdrant.client.ValueFactory.value("https://docs.example.com/java/streams"))

--- a/src/test/java/com/williamcallahan/javachat/service/QdrantListenableFutureBridgeTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/QdrantListenableFutureBridgeTest.java
@@ -1,0 +1,56 @@
+package com.williamcallahan.javachat.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.util.concurrent.SettableFuture;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/** Verifies Qdrant future completion and cancellation cross the Guava-to-JDK boundary unchanged. */
+class QdrantListenableFutureBridgeTest {
+
+    @Test
+    void mirrorsSuccessfulCompletion() {
+        SettableFuture<String> qdrantQueryFuture = SettableFuture.create();
+        CompletableFuture<String> bridgedQueryFuture =
+                QdrantListenableFutureBridge.toCompletableFuture(qdrantQueryFuture);
+
+        qdrantQueryFuture.set("completed query");
+
+        assertEquals("completed query", bridgedQueryFuture.join());
+    }
+
+    @Test
+    void mirrorsExceptionalCompletion() {
+        SettableFuture<String> qdrantQueryFuture = SettableFuture.create();
+        CompletableFuture<String> bridgedQueryFuture =
+                QdrantListenableFutureBridge.toCompletableFuture(qdrantQueryFuture);
+        IllegalStateException queryFailure = new IllegalStateException("query failed");
+
+        qdrantQueryFuture.setException(queryFailure);
+
+        CompletionException completionFailure = assertThrows(CompletionException.class, bridgedQueryFuture::join);
+        assertSame(queryFailure, completionFailure.getCause());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void propagatesCancellationAndItsInterruptFlagToTheQdrantFuture(boolean mayInterruptIfRunning) {
+        SettableFuture<String> qdrantQueryFuture = spy(SettableFuture.create());
+        CompletableFuture<String> bridgedQueryFuture =
+                QdrantListenableFutureBridge.toCompletableFuture(qdrantQueryFuture);
+
+        assertTrue(bridgedQueryFuture.cancel(mayInterruptIfRunning));
+
+        verify(qdrantQueryFuture).cancel(mayInterruptIfRunning);
+        assertTrue(bridgedQueryFuture.isCancelled());
+    }
+}

--- a/src/test/java/com/williamcallahan/javachat/service/RetrievalConstraintTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/RetrievalConstraintTest.java
@@ -35,4 +35,23 @@ class RetrievalConstraintTest {
                 UnsupportedOperationException.class,
                 () -> retrievalConstraint.docSet().add("dev-java"));
     }
+
+    @Test
+    void combinesDocumentVersionWithEveryExistingOfficialSourceField() {
+        RetrievalConstraint officialDocumentationConstraint =
+                RetrievalConstraint.forOfficialDocSets(List.of("dev-java", "java/java17-complete"));
+
+        RetrievalConstraint combinedConstraint = officialDocumentationConstraint.withDocVersion("17");
+
+        assertEquals("17", combinedConstraint.docVersion());
+        assertEquals("official", combinedConstraint.sourceKind());
+        assertEquals(officialDocumentationConstraint.docSet(), combinedConstraint.docSet());
+    }
+
+    @Test
+    void rejectsConflictingDocumentVersions() {
+        RetrievalConstraint java17Constraint = RetrievalConstraint.forDocVersion("17");
+
+        assertThrows(IllegalArgumentException.class, () -> java17Constraint.withDocVersion("25"));
+    }
 }

--- a/src/test/java/com/williamcallahan/javachat/service/RetrievalServiceCitationTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/RetrievalServiceCitationTest.java
@@ -1,0 +1,263 @@
+package com.williamcallahan.javachat.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.williamcallahan.javachat.config.AppProperties;
+import com.williamcallahan.javachat.config.DocsSourceRegistry;
+import com.williamcallahan.javachat.model.Citation;
+import com.williamcallahan.javachat.support.logging.ExpectedLogEvents;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.document.Document;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+
+/** Verifies citation URL projection, deduplication identity, JSON shape, and conversion failures. */
+@JsonTest
+class RetrievalServiceCitationTest {
+
+    private static final Logger RETRIEVAL_SERVICE_LOGGER = (Logger) LoggerFactory.getLogger(RetrievalService.class);
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    void collapsesDocumentsResolvedToTheSameJavadocMemberAnchor() {
+        String stringJavadocUrl = javaLangStringJavadocUrl();
+        RetrievalService.CitationOutcome citationOutcome = citationService()
+                .toCitations(List.of(
+                        javadocCitationDocument("first-substring-chunk", "substring(int,int)"),
+                        javadocCitationDocument("duplicate-substring-chunk", "substring(int,int)")));
+
+        assertEquals(
+                List.of(stringJavadocUrl),
+                citationOutcome.citations().stream().map(Citation::getUrl).toList());
+        assertEquals(
+                "substring(int,int)", citationOutcome.citations().getFirst().getAnchor());
+        assertEquals(0, citationOutcome.failedConversionCount());
+    }
+
+    @Test
+    void retainsDistinctFullUrlIdentitiesWhileProjectingAnchorsOutOfTheUrl() {
+        String stringJavadocUrl = javaLangStringJavadocUrl();
+        RetrievalService.CitationOutcome citationOutcome = citationService()
+                .toCitations(List.of(
+                        javadocCitationDocument("substring-chunk", "substring(int,int)"),
+                        javadocCitationDocument("char-at-chunk", "charAt(int)")));
+
+        assertEquals(
+                List.of(stringJavadocUrl, stringJavadocUrl),
+                citationOutcome.citations().stream().map(Citation::getUrl).toList());
+        assertEquals(
+                List.of("substring(int,int)", "charAt(int)"),
+                citationOutcome.citations().stream().map(Citation::getAnchor).toList());
+        assertEquals(0, citationOutcome.failedConversionCount());
+    }
+
+    @Test
+    void serializedCitationSplitsAtTheFirstFragmentDelimiterWithoutDecodingTheAnchor() {
+        String citationPageUrl = "https://example.test/reference/arrays";
+        String encodedCitationAnchor = "method%28java.lang.String%5B%5D%29#details%20section";
+        Document encodedAnchorDocument = Document.builder()
+                .id("encoded-anchor-document")
+                .text("Array method reference")
+                .metadata("url", citationPageUrl + "#" + encodedCitationAnchor)
+                .metadata("title", "Array method")
+                .metadata("docType", "tutorial")
+                .build();
+
+        Citation projectedCitation = citationService()
+                .toCitations(List.of(encodedAnchorDocument))
+                .citations()
+                .getFirst();
+        JsonNode citationJson = objectMapper.valueToTree(projectedCitation);
+
+        assertEquals(citationPageUrl, citationJson.path("url").textValue());
+        assertEquals(encodedCitationAnchor, citationJson.path("anchor").textValue());
+    }
+
+    @Test
+    void doesNotGenerateRecordAnchorFromUppercaseInvocationArguments() {
+        String recordJavadocUrl =
+                DocsSourceRegistry.javaApiDocumentationSources().getFirst().remoteBaseUrl()
+                        + "java.base/java/lang/Record.html";
+        Document recordDocument = Document.builder()
+                .id("record-equals-invocation")
+                .text("return equals(this.SomeField, r.OTHER_FIELD);")
+                .metadata("url", recordJavadocUrl)
+                .metadata("package", "java.lang")
+                .metadata("docType", "api-docs")
+                .build();
+
+        RetrievalService.CitationOutcome citationOutcome = citationService().toCitations(List.of(recordDocument));
+
+        assertEquals(
+                List.of(recordJavadocUrl),
+                citationOutcome.citations().stream().map(Citation::getUrl).toList());
+        assertEquals(0, citationOutcome.failedConversionCount());
+    }
+
+    @Test
+    void doesNotRefineMemberAnchorsOutsideApiDocs() {
+        String stringJavadocUrl = javaLangStringJavadocUrl();
+        Document tutorialDocument = Document.builder()
+                .id("tutorial-substring-chunk")
+                .text("substring(int,int)")
+                .metadata("url", stringJavadocUrl)
+                .metadata("package", "java.lang")
+                .metadata("docType", "tutorial")
+                .build();
+
+        RetrievalService.CitationOutcome citationOutcome = citationService().toCitations(List.of(tutorialDocument));
+
+        assertEquals(
+                List.of(stringJavadocUrl),
+                citationOutcome.citations().stream().map(Citation::getUrl).toList());
+        assertEquals(0, citationOutcome.failedConversionCount());
+    }
+
+    @Test
+    void doesNotRefineNestedTypeUrlsOutsideApiDocs() {
+        String mapJavadocUrl =
+                DocsSourceRegistry.javaApiDocumentationSources().getFirst().remoteBaseUrl()
+                        + "java.base/java/util/Map.html";
+        Document tutorialDocument = Document.builder()
+                .id("tutorial-map-entry-chunk")
+                .text("Map.Entry")
+                .metadata("url", mapJavadocUrl)
+                .metadata("package", "java.util")
+                .metadata("docType", "tutorial")
+                .build();
+
+        RetrievalService.CitationOutcome citationOutcome = citationService().toCitations(List.of(tutorialDocument));
+
+        assertEquals(
+                List.of(mapJavadocUrl),
+                citationOutcome.citations().stream().map(Citation::getUrl).toList());
+        assertEquals(0, citationOutcome.failedConversionCount());
+    }
+
+    @Test
+    void collapsesFragmentlessDocumentsFromTheSamePage() {
+        String stringJavadocUrl = javaLangStringJavadocUrl();
+        RetrievalService.CitationOutcome citationOutcome = citationService()
+                .toCitations(List.of(
+                        javadocCitationDocument("first-class-overview-chunk", "Class overview"),
+                        javadocCitationDocument("duplicate-class-overview-chunk", "Class overview")));
+
+        assertEquals(
+                List.of(stringJavadocUrl),
+                citationOutcome.citations().stream().map(Citation::getUrl).toList());
+        assertEquals(0, citationOutcome.failedConversionCount());
+    }
+
+    @Test
+    void retainsDistinctPdfPageAnchors() {
+        String pdfCitationUrl = "https://example.test/books/Reference.pdf";
+        RetrievalService.CitationOutcome citationOutcome = citationService()
+                .toCitations(List.of(
+                        Document.builder()
+                                .id("first-pdf-page-chunk")
+                                .text("First PDF page")
+                                .metadata("url", pdfCitationUrl + "#page=1")
+                                .build(),
+                        Document.builder()
+                                .id("second-pdf-page-chunk")
+                                .text("Second PDF page")
+                                .metadata("url", pdfCitationUrl + "#page=2")
+                                .build()));
+
+        assertEquals(
+                List.of(pdfCitationUrl, pdfCitationUrl),
+                citationOutcome.citations().stream().map(Citation::getUrl).toList());
+        assertEquals(
+                List.of("page=1", "page=2"),
+                citationOutcome.citations().stream().map(Citation::getAnchor).toList());
+        assertEquals(0, citationOutcome.failedConversionCount());
+    }
+
+    @Test
+    void reportsFailedConversionCountAndKeepsValidCitations() {
+        RetrievalService retrievalService = citationService();
+        Document malformedDocument = Document.builder()
+                .id("malformed-doc")
+                .text("Malformed metadata")
+                .build();
+        malformedDocument.getMetadata().put("url", new BrokenUrlValue());
+        malformedDocument.getMetadata().put("title", "Broken citation");
+
+        Document validDocument =
+                Document.builder().id("valid-doc").text("Valid snippet").build();
+        validDocument.getMetadata().put("url", "https://docs.oracle.com/javase/8/docs/api/java/lang/String.html");
+        validDocument.getMetadata().put("title", "String");
+
+        RetrievalService.CitationOutcome citationOutcome;
+        try (ExpectedLogEvents expectedLogEvents = ExpectedLogEvents.capture(RETRIEVAL_SERVICE_LOGGER)) {
+            citationOutcome = retrievalService.toCitations(List.of(malformedDocument, validDocument));
+
+            assertEquals(2, expectedLogEvents.events().size());
+            var conversionFailureWarning = expectedLogEvents.events().getFirst();
+            assertEquals(Level.WARN, conversionFailureWarning.getLevel());
+            assertEquals(
+                    "Citation conversion failed (exceptionType=IllegalStateException,"
+                            + " docUrl=[unprintable:BrokenUrlValue], docTitle=Broken citation)",
+                    conversionFailureWarning.getFormattedMessage());
+            assertNotNull(conversionFailureWarning.getThrowableProxy());
+            assertEquals(
+                    IllegalStateException.class.getName(),
+                    conversionFailureWarning.getThrowableProxy().getClassName());
+
+            var conversionSummaryWarning = expectedLogEvents.events().get(1);
+            assertEquals(Level.WARN, conversionSummaryWarning.getLevel());
+            assertEquals(
+                    "Citation conversion completed with 1 failure(s) out of 2 documents",
+                    conversionSummaryWarning.getFormattedMessage());
+            assertNull(conversionSummaryWarning.getThrowableProxy());
+        }
+
+        assertEquals(1, citationOutcome.citations().size());
+        assertEquals(1, citationOutcome.failedConversionCount());
+        assertEquals("String", citationOutcome.citations().getFirst().getTitle());
+        assertTrue(citationOutcome.citations().getFirst().getUrl().contains("docs.oracle.com"));
+    }
+
+    private static RetrievalService citationService() {
+        return new RetrievalService(
+                mock(HybridSearchService.class),
+                new AppProperties(),
+                mock(RerankerService.class),
+                mock(DocumentFactory.class));
+    }
+
+    private static Document javadocCitationDocument(String documentId, String sourceText) {
+        return Document.builder()
+                .id(documentId)
+                .text(sourceText)
+                .metadata("url", javaLangStringJavadocUrl())
+                .metadata("package", "java.lang")
+                .metadata("docType", "api-docs")
+                .build();
+    }
+
+    private static String javaLangStringJavadocUrl() {
+        return DocsSourceRegistry.javaApiDocumentationSources().getFirst().remoteBaseUrl()
+                + "java.base/java/lang/String.html";
+    }
+
+    /** Simulates malformed metadata values whose string conversion fails at runtime. */
+    private static final class BrokenUrlValue {
+        @Override
+        public String toString() {
+            throw new IllegalStateException("broken url value");
+        }
+    }
+}

--- a/src/test/java/com/williamcallahan/javachat/service/RetrievalServiceCitationTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/RetrievalServiceCitationTest.java
@@ -3,6 +3,7 @@ package com.williamcallahan.javachat.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
@@ -228,6 +229,10 @@ class RetrievalServiceCitationTest {
         assertEquals(1, citationOutcome.failedConversionCount());
         assertEquals("String", citationOutcome.citations().getFirst().getTitle());
         assertTrue(citationOutcome.citations().getFirst().getUrl().contains("docs.oracle.com"));
+
+        CitationConversionFailureException conversionFailure =
+                assertThrows(CitationConversionFailureException.class, citationOutcome::citationsOrThrow);
+        assertEquals(1, conversionFailure.failedConversionCount());
     }
 
     private static RetrievalService citationService() {

--- a/src/test/java/com/williamcallahan/javachat/service/RetrievalServiceTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/RetrievalServiceTest.java
@@ -1,36 +1,29 @@
 package com.williamcallahan.javachat.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
 import com.williamcallahan.javachat.config.AppProperties;
 import com.williamcallahan.javachat.config.DocsSourceRegistry;
-import com.williamcallahan.javachat.support.logging.ExpectedLogEvents;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.slf4j.LoggerFactory;
 import org.springframework.ai.document.Document;
 
 /**
  * Verifies retrieval outcome behavior around hybrid-search notices and strict failures.
  */
 class RetrievalServiceTest {
-
-    private static final Logger RETRIEVAL_SERVICE_LOGGER = (Logger) LoggerFactory.getLogger(RetrievalService.class);
 
     @Test
     void constrainedRetrievalPassesTheCallerConstraintInstanceToHybridSearch() {
@@ -50,40 +43,65 @@ class RetrievalServiceTest {
     }
 
     @Test
-    void citationDiscoveryUsesConfiguredCitationLimitWithoutInvokingTheLlmReranker() {
+    void citationDiscoveryLimitsAfterFinalUrlAndAnchorDeduplication() {
         HybridSearchService hybridSearchService = mock(HybridSearchService.class);
         RerankerService rerankerService = mock(RerankerService.class);
         AppProperties appProperties = new AppProperties();
-        appProperties.getRag().setSearchReturnK(3);
-        appProperties.getRag().setSearchCitations(1);
+        appProperties.getRag().setSearchTopK(4);
+        appProperties.getRag().setSearchCitations(2);
         RetrievalService retrievalService =
                 new RetrievalService(hybridSearchService, appProperties, rerankerService, mock(DocumentFactory.class));
         RetrievalConstraint guidedConstraint =
                 RetrievalConstraint.forOfficialDocSets(List.of("dev-java", "java/java25-complete"));
-        Document firstHybridDocument = Document.builder()
-                .id("first-hybrid-document")
-                .text("String API documentation")
-                .metadata("hash", "first-hash")
-                .build();
-        Document secondHybridDocument = Document.builder()
-                .id("second-hybrid-document")
-                .text("String tutorial")
-                .metadata("hash", "second-hash")
-                .build();
-        Document thirdHybridDocument = Document.builder()
-                .id("third-hybrid-document")
-                .text("String examples")
-                .metadata("hash", "third-hash")
-                .build();
-        when(hybridSearchService.searchOutcome(anyString(), anyInt(), same(guidedConstraint)))
-                .thenReturn(new HybridSearchService.SearchOutcome(
-                        List.of(firstHybridDocument, secondHybridDocument, thirdHybridDocument), List.of()));
+        String repeatedCitationUrl = "https://docs.example.test/String.html#substring(int,int)";
+        String uniqueCitationUrl = "https://docs.example.test/List.html#get(int)";
+        List<Document> citationCandidates = List.of(
+                citationCandidateDocument(
+                        "first-string-chunk", "First String chunk", "first-hash", repeatedCitationUrl),
+                citationCandidateDocument(
+                        "second-string-chunk", "Second String chunk", "second-hash", repeatedCitationUrl),
+                citationCandidateDocument(
+                        "third-string-chunk", "Third String chunk", "third-hash", repeatedCitationUrl),
+                citationCandidateDocument("list-chunk", "List chunk", "list-hash", uniqueCitationUrl));
+        when(hybridSearchService.searchDocumentationCitationsOutcome(anyString(), eq(4), same(guidedConstraint)))
+                .thenReturn(new HybridSearchService.SearchOutcome(citationCandidates, List.of()));
 
-        List<Document> citationDocuments =
-                retrievalService.retrieveForCitationDiscovery("Java strings", guidedConstraint);
+        RetrievalService.CitationOutcome citationOutcome =
+                retrievalService.discoverCitations("Java strings", guidedConstraint);
 
-        assertEquals(List.of(firstHybridDocument), citationDocuments);
-        verify(hybridSearchService).searchOutcome(anyString(), anyInt(), same(guidedConstraint));
+        assertEquals(
+                List.of("https://docs.example.test/String.html", "https://docs.example.test/List.html"),
+                citationOutcome.citations().stream()
+                        .map(citation -> citation.getUrl())
+                        .toList());
+        assertEquals(
+                List.of("substring(int,int)", "get(int)"),
+                citationOutcome.citations().stream()
+                        .map(citation -> citation.getAnchor())
+                        .toList());
+        assertEquals(0, citationOutcome.failedConversionCount());
+        verify(hybridSearchService).searchDocumentationCitationsOutcome(anyString(), eq(4), same(guidedConstraint));
+        verify(hybridSearchService, never()).searchOutcome(anyString(), anyInt(), any(RetrievalConstraint.class));
+        verify(rerankerService, never()).rerank(anyString(), anyList(), anyInt());
+    }
+
+    @Test
+    void zeroCitationLimitReturnsWithoutDispatchingAQuery() {
+        HybridSearchService hybridSearchService = mock(HybridSearchService.class);
+        RerankerService rerankerService = mock(RerankerService.class);
+        AppProperties appProperties = new AppProperties();
+        appProperties.getRag().setSearchCitations(0);
+        RetrievalService retrievalService =
+                new RetrievalService(hybridSearchService, appProperties, rerankerService, mock(DocumentFactory.class));
+        RetrievalConstraint guidedConstraint = RetrievalConstraint.forOfficialDocSets(List.of("dev-java"));
+
+        RetrievalService.CitationOutcome citationOutcome =
+                retrievalService.discoverCitations("Java strings", guidedConstraint);
+
+        assertTrue(citationOutcome.citations().isEmpty());
+        assertEquals(0, citationOutcome.failedConversionCount());
+        verify(hybridSearchService, never())
+                .searchDocumentationCitationsOutcome(anyString(), anyInt(), any(RetrievalConstraint.class));
         verify(rerankerService, never()).rerank(anyString(), anyList(), anyInt());
     }
 
@@ -97,14 +115,24 @@ class RetrievalServiceTest {
                 RetrievalConstraint.forOfficialDocSets(List.of("dev-java", "java/java25-complete"));
         HybridSearchPartialFailureException.CollectionSearchFailure collectionFailure =
                 new HybridSearchPartialFailureException.CollectionSearchFailure("java-docs", "Timeout", "5s");
-        when(hybridSearchService.searchOutcome(anyString(), anyInt(), same(guidedConstraint)))
+        when(hybridSearchService.searchDocumentationCitationsOutcome(anyString(), anyInt(), same(guidedConstraint)))
                 .thenThrow(new HybridSearchPartialFailureException("collection failure", List.of(collectionFailure)));
 
         assertThrows(
                 HybridSearchPartialFailureException.class,
-                () -> retrievalService.retrieveForCitationDiscovery("Java strings", guidedConstraint));
+                () -> retrievalService.discoverCitations("Java strings", guidedConstraint));
 
         verify(rerankerService, never()).rerank(anyString(), anyList(), anyInt());
+    }
+
+    private static Document citationCandidateDocument(
+            String documentId, String sourceText, String contentHash, String sourceUrl) {
+        return Document.builder()
+                .id(documentId)
+                .text(sourceText)
+                .metadata("hash", contentHash)
+                .metadata("url", sourceUrl)
+                .build();
     }
 
     @Test
@@ -197,148 +225,8 @@ class RetrievalServiceTest {
         assertEquals(3, citationOutcome.citations().size());
         assertEquals(stringJavadocUrl, citationOutcome.citations().get(1).getUrl());
         assertEquals("First Javadoc chunk", citationOutcome.citations().get(1).getSnippet());
-        assertEquals(
-                stringJavadocUrl + "#assert(...)",
-                citationOutcome.citations().get(2).getUrl());
-        assertEquals(0, citationOutcome.failedConversionCount());
-    }
-
-    @Test
-    void toCitationsCollapsesDocumentsResolvedToTheSameJavadocMemberAnchor() {
-        String stringJavadocUrl = javaLangStringJavadocUrl();
-        RetrievalService.CitationOutcome citationOutcome = citationService()
-                .toCitations(List.of(
-                        javadocCitationDocument("first-substring-chunk", "substring(int,int)"),
-                        javadocCitationDocument("duplicate-substring-chunk", "substring(int,int)")));
-
-        assertEquals(
-                List.of(stringJavadocUrl + "#substring(int,int)"),
-                citationOutcome.citations().stream()
-                        .map(citation -> citation.getUrl())
-                        .toList());
-        assertEquals(0, citationOutcome.failedConversionCount());
-    }
-
-    @Test
-    void toCitationsRetainsDocumentsResolvedToDistinctJavadocMemberAnchors() {
-        String stringJavadocUrl = javaLangStringJavadocUrl();
-        RetrievalService.CitationOutcome citationOutcome = citationService()
-                .toCitations(List.of(
-                        javadocCitationDocument("substring-chunk", "substring(int,int)"),
-                        javadocCitationDocument("char-at-chunk", "charAt(int)")));
-
-        assertEquals(
-                List.of(stringJavadocUrl + "#substring(int,int)", stringJavadocUrl + "#charAt(int)"),
-                citationOutcome.citations().stream()
-                        .map(citation -> citation.getUrl())
-                        .toList());
-        assertEquals(0, citationOutcome.failedConversionCount());
-    }
-
-    @Test
-    void toCitationsDoesNotGenerateRecordAnchorFromUppercaseInvocationArguments() {
-        String recordJavadocUrl =
-                DocsSourceRegistry.javaApiDocumentationSources().getFirst().remoteBaseUrl()
-                        + "java.base/java/lang/Record.html";
-        Document recordDocument = Document.builder()
-                .id("record-equals-invocation")
-                .text("return equals(this.SomeField, r.OTHER_FIELD);")
-                .metadata("url", recordJavadocUrl)
-                .metadata("package", "java.lang")
-                .metadata("docType", "api-docs")
-                .build();
-
-        RetrievalService.CitationOutcome citationOutcome = citationService().toCitations(List.of(recordDocument));
-
-        assertEquals(
-                List.of(recordJavadocUrl),
-                citationOutcome.citations().stream()
-                        .map(citation -> citation.getUrl())
-                        .toList());
-        assertEquals(0, citationOutcome.failedConversionCount());
-    }
-
-    @Test
-    void toCitationsDoesNotRefineMemberAnchorsOutsideApiDocs() {
-        String stringJavadocUrl = javaLangStringJavadocUrl();
-        Document tutorialDocument = Document.builder()
-                .id("tutorial-substring-chunk")
-                .text("substring(int,int)")
-                .metadata("url", stringJavadocUrl)
-                .metadata("package", "java.lang")
-                .metadata("docType", "tutorial")
-                .build();
-
-        RetrievalService.CitationOutcome citationOutcome = citationService().toCitations(List.of(tutorialDocument));
-
-        assertEquals(
-                List.of(stringJavadocUrl),
-                citationOutcome.citations().stream()
-                        .map(citation -> citation.getUrl())
-                        .toList());
-        assertEquals(0, citationOutcome.failedConversionCount());
-    }
-
-    @Test
-    void toCitationsDoesNotRefineNestedTypeUrlsOutsideApiDocs() {
-        String mapJavadocUrl =
-                DocsSourceRegistry.javaApiDocumentationSources().getFirst().remoteBaseUrl()
-                        + "java.base/java/util/Map.html";
-        Document tutorialDocument = Document.builder()
-                .id("tutorial-map-entry-chunk")
-                .text("Map.Entry")
-                .metadata("url", mapJavadocUrl)
-                .metadata("package", "java.util")
-                .metadata("docType", "tutorial")
-                .build();
-
-        RetrievalService.CitationOutcome citationOutcome = citationService().toCitations(List.of(tutorialDocument));
-
-        assertEquals(
-                List.of(mapJavadocUrl),
-                citationOutcome.citations().stream()
-                        .map(citation -> citation.getUrl())
-                        .toList());
-        assertEquals(0, citationOutcome.failedConversionCount());
-    }
-
-    @Test
-    void toCitationsCollapsesFragmentlessDocumentsFromTheSamePage() {
-        String stringJavadocUrl = javaLangStringJavadocUrl();
-        RetrievalService.CitationOutcome citationOutcome = citationService()
-                .toCitations(List.of(
-                        javadocCitationDocument("first-class-overview-chunk", "Class overview"),
-                        javadocCitationDocument("duplicate-class-overview-chunk", "Class overview")));
-
-        assertEquals(
-                List.of(stringJavadocUrl),
-                citationOutcome.citations().stream()
-                        .map(citation -> citation.getUrl())
-                        .toList());
-        assertEquals(0, citationOutcome.failedConversionCount());
-    }
-
-    @Test
-    void toCitationsRetainsDistinctPdfPageAnchors() {
-        String pdfCitationUrl = "https://example.test/books/Reference.pdf";
-        RetrievalService.CitationOutcome citationOutcome = citationService()
-                .toCitations(List.of(
-                        Document.builder()
-                                .id("first-pdf-page-chunk")
-                                .text("First PDF page")
-                                .metadata("url", pdfCitationUrl + "#page=1")
-                                .build(),
-                        Document.builder()
-                                .id("second-pdf-page-chunk")
-                                .text("Second PDF page")
-                                .metadata("url", pdfCitationUrl + "#page=2")
-                                .build()));
-
-        assertEquals(
-                List.of(pdfCitationUrl + "#page=1", pdfCitationUrl + "#page=2"),
-                citationOutcome.citations().stream()
-                        .map(citation -> citation.getUrl())
-                        .toList());
+        assertEquals(stringJavadocUrl, citationOutcome.citations().get(2).getUrl());
+        assertEquals("assert(...)", citationOutcome.citations().get(2).getAnchor());
         assertEquals(0, citationOutcome.failedConversionCount());
     }
 
@@ -405,89 +293,5 @@ class RetrievalServiceTest {
         assertThrows(
                 HybridSearchPartialFailureException.class,
                 () -> retrievalService.retrieveOutcome("Java stream basics"));
-    }
-
-    @Test
-    void toCitationsReportsFailedConversionCountAndKeepsValidCitations() {
-        HybridSearchService hybridSearchService = mock(HybridSearchService.class);
-        RerankerService rerankerService = mock(RerankerService.class);
-        DocumentFactory documentFactory = mock(DocumentFactory.class);
-        AppProperties appProperties = new AppProperties();
-        RetrievalService retrievalService =
-                new RetrievalService(hybridSearchService, appProperties, rerankerService, documentFactory);
-
-        Document malformedDocument = Document.builder()
-                .id("malformed-doc")
-                .text("Malformed metadata")
-                .build();
-        malformedDocument.getMetadata().put("url", new BrokenUrlValue());
-        malformedDocument.getMetadata().put("title", "Broken citation");
-
-        Document validDocument =
-                Document.builder().id("valid-doc").text("Valid snippet").build();
-        validDocument.getMetadata().put("url", "https://docs.oracle.com/javase/8/docs/api/java/lang/String.html");
-        validDocument.getMetadata().put("title", "String");
-
-        RetrievalService.CitationOutcome citationOutcome;
-        try (ExpectedLogEvents expectedLogEvents = ExpectedLogEvents.capture(RETRIEVAL_SERVICE_LOGGER)) {
-            citationOutcome = retrievalService.toCitations(List.of(malformedDocument, validDocument));
-
-            assertEquals(2, expectedLogEvents.events().size());
-            var conversionFailureWarning = expectedLogEvents.events().getFirst();
-            assertEquals(Level.WARN, conversionFailureWarning.getLevel());
-            assertEquals(
-                    "Citation conversion failed (exceptionType=IllegalStateException,"
-                            + " docUrl=[unprintable:BrokenUrlValue], docTitle=Broken citation)",
-                    conversionFailureWarning.getFormattedMessage());
-            assertNotNull(conversionFailureWarning.getThrowableProxy());
-            assertEquals(
-                    IllegalStateException.class.getName(),
-                    conversionFailureWarning.getThrowableProxy().getClassName());
-
-            var conversionSummaryWarning = expectedLogEvents.events().get(1);
-            assertEquals(Level.WARN, conversionSummaryWarning.getLevel());
-            assertEquals(
-                    "Citation conversion completed with 1 failure(s) out of 2 documents",
-                    conversionSummaryWarning.getFormattedMessage());
-            assertNull(conversionSummaryWarning.getThrowableProxy());
-        }
-
-        assertEquals(1, citationOutcome.citations().size());
-        assertEquals(1, citationOutcome.failedConversionCount());
-        assertEquals("String", citationOutcome.citations().get(0).getTitle());
-        assertTrue(citationOutcome.citations().get(0).getUrl().contains("docs.oracle.com"));
-    }
-
-    private static RetrievalService citationService() {
-        return new RetrievalService(
-                mock(HybridSearchService.class),
-                new AppProperties(),
-                mock(RerankerService.class),
-                mock(DocumentFactory.class));
-    }
-
-    private static Document javadocCitationDocument(String documentId, String sourceText) {
-        return Document.builder()
-                .id(documentId)
-                .text(sourceText)
-                .metadata("url", javaLangStringJavadocUrl())
-                .metadata("package", "java.lang")
-                .metadata("docType", "api-docs")
-                .build();
-    }
-
-    private static String javaLangStringJavadocUrl() {
-        return DocsSourceRegistry.javaApiDocumentationSources().getFirst().remoteBaseUrl()
-                + "java.base/java/lang/String.html";
-    }
-
-    /**
-     * Simulates malformed metadata values whose string conversion fails at runtime.
-     */
-    private static final class BrokenUrlValue {
-        @Override
-        public String toString() {
-            throw new IllegalStateException("broken url value");
-        }
     }
 }

--- a/src/test/java/com/williamcallahan/javachat/service/RetrievalServiceTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/RetrievalServiceTest.java
@@ -43,6 +43,27 @@ class RetrievalServiceTest {
     }
 
     @Test
+    void versionedConstrainedRetrievalCombinesOfficialScopeAndQueryVersionForHybridSearch() {
+        HybridSearchService hybridSearchService = mock(HybridSearchService.class);
+        RerankerService rerankerService = mock(RerankerService.class);
+        RetrievalService retrievalService = new RetrievalService(
+                hybridSearchService, new AppProperties(), rerankerService, mock(DocumentFactory.class));
+        RetrievalConstraint officialDocumentationConstraint =
+                RetrievalConstraint.forOfficialDocSets(List.of("dev-java", "java/java17-complete"));
+        RetrievalConstraint expectedCombinedConstraint = officialDocumentationConstraint.withDocVersion("17");
+        when(hybridSearchService.searchOutcome(anyString(), anyInt(), eq(expectedCombinedConstraint)))
+                .thenReturn(new HybridSearchService.SearchOutcome(List.of(), List.of()));
+        when(rerankerService.rerank(anyString(), anyList(), anyInt())).thenReturn(List.of());
+
+        retrievalService.retrieveOutcome("Java 17 List.of", officialDocumentationConstraint);
+
+        verify(hybridSearchService).searchOutcome(anyString(), anyInt(), eq(expectedCombinedConstraint));
+        assertEquals("17", expectedCombinedConstraint.docVersion());
+        assertEquals("official", expectedCombinedConstraint.sourceKind());
+        assertEquals(officialDocumentationConstraint.docSet(), expectedCombinedConstraint.docSet());
+    }
+
+    @Test
     void citationDiscoveryLimitsAfterFinalUrlAndAnchorDeduplication() {
         HybridSearchService hybridSearchService = mock(HybridSearchService.class);
         RerankerService rerankerService = mock(RerankerService.class);
@@ -82,6 +103,26 @@ class RetrievalServiceTest {
         assertEquals(0, citationOutcome.failedConversionCount());
         verify(hybridSearchService).searchDocumentationCitationsOutcome(anyString(), eq(4), same(guidedConstraint));
         verify(hybridSearchService, never()).searchOutcome(anyString(), anyInt(), any(RetrievalConstraint.class));
+        verify(rerankerService, never()).rerank(anyString(), anyList(), anyInt());
+    }
+
+    @Test
+    void versionedCitationDiscoveryCombinesOfficialScopeAndQueryVersionBeforeDispatch() {
+        HybridSearchService hybridSearchService = mock(HybridSearchService.class);
+        RerankerService rerankerService = mock(RerankerService.class);
+        RetrievalService retrievalService = new RetrievalService(
+                hybridSearchService, new AppProperties(), rerankerService, mock(DocumentFactory.class));
+        RetrievalConstraint officialDocumentationConstraint =
+                RetrievalConstraint.forOfficialDocSets(List.of("dev-java", "java/java17-complete"));
+        RetrievalConstraint expectedCombinedConstraint = officialDocumentationConstraint.withDocVersion("17");
+        when(hybridSearchService.searchDocumentationCitationsOutcome(
+                        anyString(), anyInt(), eq(expectedCombinedConstraint)))
+                .thenReturn(new HybridSearchService.SearchOutcome(List.of(), List.of()));
+
+        retrievalService.discoverCitations("Java 17 List.of", officialDocumentationConstraint);
+
+        verify(hybridSearchService)
+                .searchDocumentationCitationsOutcome(anyString(), anyInt(), eq(expectedCombinedConstraint));
         verify(rerankerService, never()).rerank(anyString(), anyList(), anyInt());
     }
 

--- a/src/test/java/com/williamcallahan/javachat/web/ChatControllerStreamingFailureTest.java
+++ b/src/test/java/com/williamcallahan/javachat/web/ChatControllerStreamingFailureTest.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -45,12 +46,14 @@ import com.williamcallahan.javachat.service.RetrievalService;
 import com.williamcallahan.javachat.service.StreamingResult;
 import com.williamcallahan.javachat.support.logging.ExpectedLogEvents;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
+import org.springframework.ai.document.Document;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.core.io.ClassPathResource;
@@ -232,6 +235,57 @@ class ChatControllerStreamingFailureTest {
         assertEquals(STATUS_STAGE_STREAM, terminalError.stage());
         verify(chatMemoryService, never()).getHistory(SESSION_ID);
         verifyNoInteractions(chatService, retrievalService);
+    }
+
+    @Test
+    void chatStreamCitesTheExactDocumentsUsedForPromptContextWithoutSecondDiscovery() throws JsonProcessingException {
+        ChatService chatService = mock(ChatService.class);
+        ChatMemoryService chatMemoryService = mock(ChatMemoryService.class);
+        OpenAIStreamingService streamingService = mock(OpenAIStreamingService.class);
+        RetrievalService retrievalService = mock(RetrievalService.class);
+        ChatController chatController = new ChatController(
+                chatService,
+                chatMemoryService,
+                streamingService,
+                retrievalService,
+                createSseSupport(),
+                new ExceptionResponseBuilder(),
+                new AppProperties());
+        Document officialPromptDocument = mock(Document.class);
+        Citation officialCitation = new Citation(
+                "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/List.html",
+                "List",
+                "of()",
+                "Creates an unmodifiable list.");
+        when(chatMemoryService.getHistory(SESSION_ID)).thenReturn(List.of());
+        when(chatService.buildStructuredPromptWithContextOutcome(
+                        anyList(), eq(USER_QUERY), eq(ModelConfiguration.DEFAULT_MODEL)))
+                .thenReturn(new ChatService.StructuredPromptOutcome(
+                        StructuredPrompt.fromRawPrompt("test", 1), List.of(), List.of(officialPromptDocument)));
+        when(retrievalService.toCitations(List.of(officialPromptDocument)))
+                .thenReturn(new RetrievalService.CitationOutcome(List.of(officialCitation), 0));
+        when(streamingService.isAvailable()).thenReturn(true);
+        when(streamingService.streamResponse(any(StructuredPrompt.class), anyDouble()))
+                .thenReturn(Mono.just(new StreamingResult(Flux.just("Hello"), RateLimitService.ApiProvider.OPENAI)));
+
+        List<ServerSentEvent<String>> streamEvents = Objects.requireNonNull(
+                chatController.stream(new ChatStreamRequest(SESSION_ID, USER_QUERY), new MockHttpServletResponse())
+                        .collectList()
+                        .block(),
+                "chat stream events");
+
+        assertEquals(EVENT_STATUS, streamEvents.getFirst().event());
+        ServerSentEvent<String> citationEvent = streamEvents.stream()
+                .filter(streamEvent -> EVENT_CITATION.equals(streamEvent.event()))
+                .findFirst()
+                .orElseThrow();
+        List<Citation> streamedCitations = Arrays.asList(objectMapper.readValue(
+                Objects.requireNonNull(citationEvent.data(), "citation event data"), Citation[].class));
+
+        assertEquals(1, streamedCitations.size());
+        assertEquals(officialCitation.getUrl(), streamedCitations.getFirst().getUrl());
+        verify(retrievalService).toCitations(List.of(officialPromptDocument));
+        verify(chatService, never()).citationsFor(anyString());
     }
 
     @Test


### PR DESCRIPTION
## Summary

- route static citation discovery through one sparse, official-documentation-only Qdrant request, with strict conversion failures, one shared deadline, cancellation propagation, and query-derived Java version filters
- constrain the single streamed-chat prompt retrieval to official documentation and emit citations from the exact documents supplied to the model, avoiding a second pre-provider query or provenance drift
- preserve citation URL anchors as a separate case-sensitive contract while deduplicating and limiting final citation identities
- restore submission-owned input focus without stealing intentional focus, ignore Enter during IME composition, recover unsupported nested learning routes to `/learn`, and reserve mobile reading space above the lesson chat action

## Production findings resolved

- unrelated GitHub repository citations for official Java documentation questions in both static and streamed chat paths
- citation requests performing dense embedding, cross-collection fan-out, and LLM reranking
- collection timeouts accumulating sequentially beyond the configured budget
- interrupted Qdrant fan-out continuing with partial results under non-strict configuration
- partial citation conversions returned as successful static responses
- versioned questions searching across the wrong official Java release
- URL fragments embedded in `url` while `anchor` remained empty
- chat focus lost after stream completion on mobile and IME Enter submitting incomplete text
- unsupported nested learning URLs rendering the chat view without URL recovery
- mobile lesson action overlapping reading content

## Validation

- 641 Java tests passed; 0 failures, errors, or skipped tests
- 172 frontend tests passed
- independent final audits found no remaining concrete blockers
- `make lint` passed, including ast-grep, Svelte checks, PMD, and SpotBugs
- `make build` passed
- signed commits and mandatory pre-commit/pre-push hooks passed