### PR TITLE
fix: improve static citation relevance and stream admission

### DIFF
--- a/src/main/java/com/williamcallahan/javachat/application/search/JavaApiMethodSelector.java
+++ b/src/main/java/com/williamcallahan/javachat/application/search/JavaApiMethodSelector.java
@@ -205,7 +205,7 @@ public record JavaApiMethodSelector(String packageName, String typePageName, Str
         if (nonNullText.isBlank()) {
             throw new IllegalArgumentException(fieldName + " cannot be blank");
         }
-        return nonNullText;
+        return nonNullText.trim();
     }
 
     private record ParsedQualifiedName(List<String> segments, int endIndex) {

--- a/src/main/java/com/williamcallahan/javachat/application/search/JavaApiMethodSelector.java
+++ b/src/main/java/com/williamcallahan/javachat/application/search/JavaApiMethodSelector.java
@@ -1,0 +1,216 @@
+package com.williamcallahan.javachat.application.search;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Identifies an explicitly named Java API type method within a natural-language query.
+ *
+ * <p>The selector owns the relationship between a query spelling such as {@code List.of} and the
+ * Javadoc page filename {@code List.html}. Sparse citation retrieval uses its expanded terms to
+ * bridge punctuation tokenization, while citation ranking uses the same selector to recognize the
+ * matching Javadoc type page. A qualified selector also owns its package path so {@code
+ * java.util.Date.toString} cannot match {@code java.sql.Date}.</p>
+ *
+ * @param packageName optional declaring package name, or empty for an unqualified selector
+ * @param typePageName Javadoc type page name without the {@code .html} suffix
+ * @param methodName Java method name named by the query
+ */
+public record JavaApiMethodSelector(String packageName, String typePageName, String methodName) {
+
+    private static final String JAVADOC_PAGE_SUFFIX = ".html";
+    private static final int MINIMUM_TYPE_METHOD_SEGMENT_COUNT = 2;
+    private static final Set<String> NON_METHOD_TERMINALS = Set.of("class", "super", "this", "java", "html");
+
+    /**
+     * Enforces a concrete Java API type and method spelling.
+     */
+    public JavaApiMethodSelector {
+        packageName = packageName == null ? "" : packageName.trim();
+        typePageName = requireNonBlank(typePageName, "typePageName");
+        methodName = requireNonBlank(methodName, "methodName");
+    }
+
+    /**
+     * Extracts the first explicit {@code Type.method} selector from a query.
+     *
+     * <p>Invocation parentheses are optional because learners commonly ask both {@code List.of()}
+     * and {@code Explain Stream.map}. Fully qualified type names and Javadoc nested-type page names
+     * are retained without re-parsing them elsewhere.</p>
+     *
+     * @param query learner query text
+     * @return first explicit Java API method selector, or empty when the query names none
+     */
+    public static Optional<JavaApiMethodSelector> fromQuery(String query) {
+        if (query == null || query.isBlank()) {
+            return Optional.empty();
+        }
+
+        int queryLength = query.length();
+        for (int queryIndex = 0; queryIndex < queryLength; queryIndex++) {
+            if (!isIdentifierStartAt(query, queryIndex) || hasIdentifierPrefix(query, queryIndex)) {
+                continue;
+            }
+            ParsedQualifiedName parsedQualifiedName = parseQualifiedName(query, queryIndex);
+            Optional<JavaApiMethodSelector> candidateSelector = fromQualifiedName(parsedQualifiedName.segments());
+            if (candidateSelector.isPresent()) {
+                return candidateSelector;
+            }
+            queryIndex = parsedQualifiedName.endIndex() - 1;
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Adds component terms for an explicit selector while retaining its punctuated spelling.
+     *
+     * <p>Lucene's {@code StandardAnalyzer} keeps {@code List.of} as one lexical term in the
+     * original query. Adding only {@code List} (or {@code Map.Entry}) recalls its declaring page
+     * without adding noisy common method terms such as {@code of}. Document-vector encoding remains
+     * unchanged.</p>
+     *
+     * @param citationQuery original sparse citation query
+     * @return original query plus selector component terms when a selector is present
+     */
+    public static String expandForSparseCitationQuery(String citationQuery) {
+        Objects.requireNonNull(citationQuery, "citationQuery");
+        return fromQuery(citationQuery)
+                .map(selector -> citationQuery + " " + selector.sparseQueryTerms())
+                .orElse(citationQuery);
+    }
+
+    /**
+     * Returns the exact Javadoc filename expected for this selector's declaring type.
+     *
+     * @return Javadoc page filename including its extension
+     */
+    public String typePageFileName() {
+        return typePageName + JAVADOC_PAGE_SUFFIX;
+    }
+
+    /**
+     * Determines whether a Javadoc URL path identifies this selector's declaring type.
+     *
+     * <p>Unqualified selectors match the type filename in any package. Qualified selectors require
+     * the exact package path immediately before that filename, preventing same-named JDK types in
+     * different packages from receiving the same citation priority.</p>
+     *
+     * @param javadocPath decoded Javadoc URL path
+     * @return true when the path names this selector's declaring type
+     */
+    public boolean matchesJavadocPath(String javadocPath) {
+        Objects.requireNonNull(javadocPath, "javadocPath");
+        int filenameStartIndex = javadocPath.lastIndexOf('/') + 1;
+        String candidateFilename = javadocPath.substring(filenameStartIndex);
+        if (!typePageFileName().equals(candidateFilename)) {
+            return false;
+        }
+        if (packageName.isBlank()) {
+            return true;
+        }
+        String qualifiedPagePathSuffix = "/" + packageName.replace('.', '/') + "/" + typePageFileName();
+        return javadocPath.endsWith(qualifiedPagePathSuffix);
+    }
+
+    /**
+     * Returns the exact declaring-type syntax for sparse query expansion.
+     *
+     * @return declaring type syntax, including nested-type delimiters when present
+     */
+    public String sparseQueryTerms() {
+        return typePageName;
+    }
+
+    private static ParsedQualifiedName parseQualifiedName(String query, int startIndex) {
+        List<String> segments = new ArrayList<>();
+        int currentIndex = startIndex;
+        while (currentIndex < query.length()) {
+            int segmentEndIndex = readIdentifierEnd(query, currentIndex);
+            segments.add(query.substring(currentIndex, segmentEndIndex));
+            if (segmentEndIndex >= query.length() || query.charAt(segmentEndIndex) != '.') {
+                return new ParsedQualifiedName(segments, segmentEndIndex);
+            }
+            int nextSegmentStartIndex = segmentEndIndex + 1;
+            if (!isIdentifierStartAt(query, nextSegmentStartIndex)) {
+                return new ParsedQualifiedName(segments, segmentEndIndex);
+            }
+            currentIndex = nextSegmentStartIndex;
+        }
+        return new ParsedQualifiedName(segments, currentIndex);
+    }
+
+    private static Optional<JavaApiMethodSelector> fromQualifiedName(List<String> segments) {
+        if (segments.size() < MINIMUM_TYPE_METHOD_SEGMENT_COUNT) {
+            return Optional.empty();
+        }
+
+        int methodSegmentIndex = segments.size() - 1;
+        String candidateMethodName = segments.get(methodSegmentIndex);
+        if (!Character.isLowerCase(candidateMethodName.charAt(0))
+                || NON_METHOD_TERMINALS.contains(candidateMethodName)) {
+            return Optional.empty();
+        }
+
+        int firstTypeSegmentIndex = firstTypeSegmentIndex(segments, methodSegmentIndex);
+        if (firstTypeSegmentIndex < 0 || hasNonTypeSegment(segments, firstTypeSegmentIndex, methodSegmentIndex)) {
+            return Optional.empty();
+        }
+
+        String candidatePackageName = String.join(".", segments.subList(0, firstTypeSegmentIndex));
+        String candidateTypePageName = String.join(".", segments.subList(firstTypeSegmentIndex, methodSegmentIndex));
+        return Optional.of(new JavaApiMethodSelector(candidatePackageName, candidateTypePageName, candidateMethodName));
+    }
+
+    private static int firstTypeSegmentIndex(List<String> segments, int methodSegmentIndex) {
+        for (int segmentIndex = 0; segmentIndex < methodSegmentIndex; segmentIndex++) {
+            if (Character.isUpperCase(segments.get(segmentIndex).charAt(0))) {
+                return segmentIndex;
+            }
+        }
+        return -1;
+    }
+
+    private static boolean hasNonTypeSegment(List<String> segments, int firstTypeSegmentIndex, int methodSegmentIndex) {
+        for (int segmentIndex = firstTypeSegmentIndex; segmentIndex < methodSegmentIndex; segmentIndex++) {
+            if (!Character.isUpperCase(segments.get(segmentIndex).charAt(0))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isIdentifierStartAt(String query, int queryIndex) {
+        return queryIndex >= 0
+                && queryIndex < query.length()
+                && Character.isJavaIdentifierStart(query.charAt(queryIndex));
+    }
+
+    private static boolean hasIdentifierPrefix(String query, int queryIndex) {
+        return queryIndex > 0 && Character.isJavaIdentifierPart(query.charAt(queryIndex - 1));
+    }
+
+    private static int readIdentifierEnd(String query, int startIndex) {
+        int currentIndex = startIndex + 1;
+        while (currentIndex < query.length() && Character.isJavaIdentifierPart(query.charAt(currentIndex))) {
+            currentIndex++;
+        }
+        return currentIndex;
+    }
+
+    private static String requireNonBlank(String text, String fieldName) {
+        String nonNullText = Objects.requireNonNull(text, fieldName);
+        if (nonNullText.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " cannot be blank");
+        }
+        return nonNullText;
+    }
+
+    private record ParsedQualifiedName(List<String> segments, int endIndex) {
+        private ParsedQualifiedName {
+            segments = List.copyOf(segments);
+        }
+    }
+}

--- a/src/main/java/com/williamcallahan/javachat/cli/GitHubRepoProcessor.java
+++ b/src/main/java/com/williamcallahan/javachat/cli/GitHubRepoProcessor.java
@@ -8,6 +8,7 @@ import com.williamcallahan.javachat.domain.ingestion.SourceFileLanguage;
 import com.williamcallahan.javachat.domain.ingestion.SourceFileProcessingResult;
 import com.williamcallahan.javachat.service.HybridVectorService;
 import com.williamcallahan.javachat.service.ProgressTracker;
+import com.williamcallahan.javachat.service.QdrantPayloadFieldSchema;
 import com.williamcallahan.javachat.service.ingestion.GitHubRepositoryIdentityResolver;
 import com.williamcallahan.javachat.service.ingestion.IngestedFilePruneService;
 import com.williamcallahan.javachat.service.ingestion.LocalDocsFileOutcome;
@@ -251,17 +252,22 @@ public class GitHubRepoProcessor {
     private void refreshCollectionMetadata(String collectionName, GitHubRepoMetadata repoMetadata) {
         Map<String, Value> metadataUpdates = new LinkedHashMap<>();
         if (!repoMetadata.commitHash().isBlank()) {
-            metadataUpdates.put("commitHash", ValueFactory.value(Objects.requireNonNull(repoMetadata.commitHash())));
+            metadataUpdates.put(
+                    QdrantPayloadFieldSchema.COMMIT_HASH_FIELD,
+                    ValueFactory.value(Objects.requireNonNull(repoMetadata.commitHash())));
         }
         if (!repoMetadata.repoBranch().isBlank()) {
-            metadataUpdates.put("repoBranch", ValueFactory.value(Objects.requireNonNull(repoMetadata.repoBranch())));
+            metadataUpdates.put(
+                    QdrantPayloadFieldSchema.REPO_BRANCH_FIELD,
+                    ValueFactory.value(Objects.requireNonNull(repoMetadata.repoBranch())));
         }
         if (metadataUpdates.isEmpty()) {
             return;
         }
 
         Filter repoFilter = Filter.newBuilder()
-                .addMust(matchKeyword("repoName", Objects.requireNonNull(repoMetadata.repoName())))
+                .addMust(matchKeyword(
+                        QdrantPayloadFieldSchema.REPO_NAME_FIELD, Objects.requireNonNull(repoMetadata.repoName())))
                 .build();
 
         hybridVectorService.updatePayloadByFilter(collectionName, metadataUpdates, repoFilter);

--- a/src/main/java/com/williamcallahan/javachat/config/DocsSourceRegistry.java
+++ b/src/main/java/com/williamcallahan/javachat/config/DocsSourceRegistry.java
@@ -90,6 +90,14 @@ public final class DocsSourceRegistry {
     private static final List<String> OFFICIAL_DOCUMENTATION_SOURCE_IDENTITIES =
             projectOfficialDocumentationSourceIdentities(DOCUMENTATION_SOURCES, JAVA_API_DOCUMENTATION_SOURCES);
 
+    /**
+     * Canonical provenance type for Java API documentation projected from Java API source mirrors.
+     *
+     * <p>Ingestion and citation retrieval share this value so Java API pages retain one semantic
+     * classification across the document lifecycle.</p>
+     */
+    public static final String JAVA_API_DOCUMENT_TYPE = "api-docs";
+
     public static final String ORACLE_JAVASE_BASE = resolveSetting(ORACLE_JAVASE_BASE_KEY, DEFAULT_ORACLE_JAVASE_BASE);
     public static final String IBM_ARTICLES_BASE = resolveSetting(IBM_ARTICLES_BASE_KEY, DEFAULT_IBM_ARTICLES_BASE);
     public static final String JETBRAINS_IDEA_2025_09_BASE =

--- a/src/main/java/com/williamcallahan/javachat/config/QdrantIndexInitializer.java
+++ b/src/main/java/com/williamcallahan/javachat/config/QdrantIndexInitializer.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.williamcallahan.javachat.service.EmbeddingClient;
+import com.williamcallahan.javachat.service.QdrantPayloadFieldSchema;
 import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -48,22 +49,22 @@ public class QdrantIndexInitializer {
     private static final String VECTOR_DISTANCE_COSINE = "Cosine";
     private static final String SPARSE_MODIFIER_IDF = "idf";
     private static final List<PayloadIndexSpec> REQUIRED_PAYLOAD_INDEXES = List.of(
-            new PayloadIndexSpec("url", SCHEMA_TYPE_KEYWORD),
-            new PayloadIndexSpec("hash", SCHEMA_TYPE_KEYWORD),
-            new PayloadIndexSpec("chunkIndex", SCHEMA_TYPE_INTEGER),
-            new PayloadIndexSpec("docSet", SCHEMA_TYPE_KEYWORD),
-            new PayloadIndexSpec("docPath", SCHEMA_TYPE_KEYWORD),
-            new PayloadIndexSpec("sourceName", SCHEMA_TYPE_KEYWORD),
-            new PayloadIndexSpec("sourceKind", SCHEMA_TYPE_KEYWORD),
-            new PayloadIndexSpec("docVersion", SCHEMA_TYPE_KEYWORD),
-            new PayloadIndexSpec("docType", SCHEMA_TYPE_KEYWORD),
-            new PayloadIndexSpec("repoUrl", SCHEMA_TYPE_KEYWORD),
-            new PayloadIndexSpec("repoOwner", SCHEMA_TYPE_KEYWORD),
-            new PayloadIndexSpec("repoName", SCHEMA_TYPE_KEYWORD),
-            new PayloadIndexSpec("repoKey", SCHEMA_TYPE_KEYWORD),
-            new PayloadIndexSpec("repoBranch", SCHEMA_TYPE_KEYWORD),
-            new PayloadIndexSpec("commitHash", SCHEMA_TYPE_KEYWORD),
-            new PayloadIndexSpec("license", SCHEMA_TYPE_KEYWORD));
+            new PayloadIndexSpec(QdrantPayloadFieldSchema.URL_FIELD, SCHEMA_TYPE_KEYWORD),
+            new PayloadIndexSpec(QdrantPayloadFieldSchema.HASH_FIELD, SCHEMA_TYPE_KEYWORD),
+            new PayloadIndexSpec(QdrantPayloadFieldSchema.CHUNK_INDEX_FIELD, SCHEMA_TYPE_INTEGER),
+            new PayloadIndexSpec(QdrantPayloadFieldSchema.DOC_SET_FIELD, SCHEMA_TYPE_KEYWORD),
+            new PayloadIndexSpec(QdrantPayloadFieldSchema.DOC_PATH_FIELD, SCHEMA_TYPE_KEYWORD),
+            new PayloadIndexSpec(QdrantPayloadFieldSchema.SOURCE_NAME_FIELD, SCHEMA_TYPE_KEYWORD),
+            new PayloadIndexSpec(QdrantPayloadFieldSchema.SOURCE_KIND_FIELD, SCHEMA_TYPE_KEYWORD),
+            new PayloadIndexSpec(QdrantPayloadFieldSchema.DOC_VERSION_FIELD, SCHEMA_TYPE_KEYWORD),
+            new PayloadIndexSpec(QdrantPayloadFieldSchema.DOC_TYPE_FIELD, SCHEMA_TYPE_KEYWORD),
+            new PayloadIndexSpec(QdrantPayloadFieldSchema.REPO_URL_FIELD, SCHEMA_TYPE_KEYWORD),
+            new PayloadIndexSpec(QdrantPayloadFieldSchema.REPO_OWNER_FIELD, SCHEMA_TYPE_KEYWORD),
+            new PayloadIndexSpec(QdrantPayloadFieldSchema.REPO_NAME_FIELD, SCHEMA_TYPE_KEYWORD),
+            new PayloadIndexSpec(QdrantPayloadFieldSchema.REPO_KEY_FIELD, SCHEMA_TYPE_KEYWORD),
+            new PayloadIndexSpec(QdrantPayloadFieldSchema.REPO_BRANCH_FIELD, SCHEMA_TYPE_KEYWORD),
+            new PayloadIndexSpec(QdrantPayloadFieldSchema.COMMIT_HASH_FIELD, SCHEMA_TYPE_KEYWORD),
+            new PayloadIndexSpec(QdrantPayloadFieldSchema.LICENSE_FIELD, SCHEMA_TYPE_KEYWORD));
 
     private final QdrantRestConnection qdrantRestConnection;
     private final AppProperties appProperties;

--- a/src/main/java/com/williamcallahan/javachat/service/AuditService.java
+++ b/src/main/java/com/williamcallahan/javachat/service/AuditService.java
@@ -196,8 +196,8 @@ public class AuditService {
             headers.set(QdrantRestConnection.API_KEY_HEADER, qdrantApiKey);
         }
 
-        QdrantScrollFilter scrollFilter =
-                new QdrantScrollFilter(List.of(new QdrantScrollMustCondition("url", new QdrantScrollMatch(url))));
+        QdrantScrollFilter scrollFilter = new QdrantScrollFilter(
+                List.of(new QdrantScrollMustCondition(QdrantPayloadFieldSchema.URL_FIELD, new QdrantScrollMatch(url))));
 
         // Paginate through all results using next_page_offset
         JsonNode nextOffset = null;
@@ -291,5 +291,7 @@ public class AuditService {
             @JsonProperty("payload") QdrantScrollPayload payload) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    private record QdrantScrollPayload(@JsonProperty("hash") String hash) {}
+    private record QdrantScrollPayload(
+            @JsonProperty(QdrantPayloadFieldSchema.HASH_FIELD)
+            String hash) {}
 }

--- a/src/main/java/com/williamcallahan/javachat/service/ChatService.java
+++ b/src/main/java/com/williamcallahan/javachat/service/ChatService.java
@@ -189,7 +189,7 @@ public class ChatService {
         List<ContextDocumentSegment> segments = new ArrayList<>();
         for (int docIndex = 0; docIndex < contextDocs.size(); docIndex++) {
             Document doc = contextDocs.get(docIndex);
-            Object rawUrlValue = doc.getMetadata().get("url");
+            Object rawUrlValue = doc.getMetadata().get(QdrantPayloadFieldSchema.URL_FIELD);
             String rawUrl = rawUrlValue != null ? rawUrlValue.toString() : "";
             String normalizedUrl = DocsSourceRegistry.normalizeDocUrl(rawUrl);
             String documentText = doc.getText();

--- a/src/main/java/com/williamcallahan/javachat/service/CitationCandidateRanker.java
+++ b/src/main/java/com/williamcallahan/javachat/service/CitationCandidateRanker.java
@@ -1,0 +1,134 @@
+package com.williamcallahan.javachat.service;
+
+import com.williamcallahan.javachat.application.search.JavaApiMethodSelector;
+import com.williamcallahan.javachat.config.DocsSourceRegistry;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import org.springframework.ai.document.Document;
+
+/**
+ * Orders sparse citation candidates using explicit Java API selector evidence.
+ *
+ * <p>Qdrant remains the sole retrieval authority. This ranker only reorders its bounded candidate
+ * list before citation URL deduplication and truncation, so exact Javadoc type pages win over
+ * accidental lexical matches without an additional RPC, embedding request, or model call.</p>
+ */
+final class CitationCandidateRanker {
+
+    private CitationCandidateRanker() {}
+
+    /**
+     * Orders a Qdrant candidate list by explicit Javadoc type-page and method-declaration evidence.
+     *
+     * <p>When the query names no Java API selector, this returns the original Qdrant order. Equal
+     * relevance tiers retain that order deterministically.</p>
+     *
+     * @param citationQuery learner query used for sparse citation retrieval
+     * @param citationCandidates Qdrant-ranked citation candidates
+     * @return immutable candidate list ordered for citation conversion
+     */
+    static List<Document> orderForCitationQuery(String citationQuery, List<Document> citationCandidates) {
+        Objects.requireNonNull(citationQuery, "citationQuery");
+        Objects.requireNonNull(citationCandidates, "citationCandidates");
+        return JavaApiMethodSelector.fromQuery(citationQuery)
+                .map(selector -> reorderForSelector(selector, citationCandidates))
+                .orElseGet(() -> List.copyOf(citationCandidates));
+    }
+
+    private static List<Document> reorderForSelector(
+            JavaApiMethodSelector selector, List<Document> citationCandidates) {
+        List<IndexedCitationCandidate> indexedCitationCandidates = new ArrayList<>(citationCandidates.size());
+        for (int candidatePosition = 0; candidatePosition < citationCandidates.size(); candidatePosition++) {
+            Document citationCandidate = Objects.requireNonNull(
+                    citationCandidates.get(candidatePosition), "citationCandidates[" + candidatePosition + "]");
+            indexedCitationCandidates.add(new IndexedCitationCandidate(
+                    citationCandidate, candidatePosition, relevanceTier(selector, citationCandidate)));
+        }
+        return indexedCitationCandidates.stream()
+                .sorted(Comparator.comparingInt(IndexedCitationCandidate::relevanceTier)
+                        .thenComparingInt(IndexedCitationCandidate::originalPosition))
+                .map(IndexedCitationCandidate::citationCandidate)
+                .toList();
+    }
+
+    private static int relevanceTier(JavaApiMethodSelector selector, Document citationCandidate) {
+        if (!hasApiDocumentationType(citationCandidate)) {
+            return 3;
+        }
+        boolean matchesTypePage = matchesTypePage(selector, citationCandidate);
+        boolean hasMethodDeclaration = hasMethodDeclarationEvidence(selector, citationCandidate);
+        if (matchesTypePage && hasMethodDeclaration) {
+            return 0;
+        }
+        if (matchesTypePage) {
+            return 1;
+        }
+        if (hasMethodDeclaration) {
+            return 2;
+        }
+        return 3;
+    }
+
+    private static boolean hasApiDocumentationType(Document citationCandidate) {
+        return DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE.equals(
+                citationCandidate.getMetadata().get(QdrantPayloadFieldSchema.DOC_TYPE_FIELD));
+    }
+
+    private static boolean matchesTypePage(JavaApiMethodSelector selector, Document citationCandidate) {
+        Object rawUrl = citationCandidate.getMetadata().get(QdrantPayloadFieldSchema.URL_FIELD);
+        if (!(rawUrl instanceof String sourceUrl) || sourceUrl.isBlank()) {
+            return false;
+        }
+        String documentPath = URI.create(sourceUrl).getPath();
+        if (documentPath == null || documentPath.isBlank()) {
+            return false;
+        }
+        return selector.matchesJavadocPath(documentPath);
+    }
+
+    private static boolean hasMethodDeclarationEvidence(JavaApiMethodSelector selector, Document citationCandidate) {
+        String documentText = citationCandidate.getText();
+        if (documentText == null || documentText.isBlank()) {
+            return false;
+        }
+
+        String methodName = selector.methodName();
+        int lastMethodStartIndex = documentText.length() - methodName.length();
+        for (int methodStartIndex = 0; methodStartIndex <= lastMethodStartIndex; methodStartIndex++) {
+            if (!hasIdentifierBoundaryBefore(documentText, methodStartIndex)
+                    || !documentText.regionMatches(methodStartIndex, methodName, 0, methodName.length())) {
+                continue;
+            }
+            int methodEndIndex = methodStartIndex + methodName.length();
+            if (!hasIdentifierBoundaryAfter(documentText, methodEndIndex)) {
+                continue;
+            }
+            int followingIndex = skipWhitespace(documentText, methodEndIndex);
+            if (followingIndex < documentText.length() && documentText.charAt(followingIndex) == '(') {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasIdentifierBoundaryBefore(String text, int index) {
+        return index == 0 || !Character.isJavaIdentifierPart(text.charAt(index - 1));
+    }
+
+    private static boolean hasIdentifierBoundaryAfter(String text, int index) {
+        return index == text.length() || !Character.isJavaIdentifierPart(text.charAt(index));
+    }
+
+    private static int skipWhitespace(String text, int startIndex) {
+        int currentIndex = startIndex;
+        while (currentIndex < text.length() && Character.isWhitespace(text.charAt(currentIndex))) {
+            currentIndex++;
+        }
+        return currentIndex;
+    }
+
+    private record IndexedCitationCandidate(Document citationCandidate, int originalPosition, int relevanceTier) {}
+}

--- a/src/main/java/com/williamcallahan/javachat/service/DocsIngestionService.java
+++ b/src/main/java/com/williamcallahan/javachat/service/DocsIngestionService.java
@@ -152,12 +152,12 @@ public class DocsIngestionService {
 
     private void markDocumentsIngested(List<org.springframework.ai.document.Document> documents) {
         for (org.springframework.ai.document.Document doc : documents) {
-            Object hashMetadata = doc.getMetadata().get("hash");
+            Object hashMetadata = doc.getMetadata().get(QdrantPayloadFieldSchema.HASH_FIELD);
             if (hashMetadata == null) {
                 continue;
             }
-            String title = DocumentFactory.metadataText(doc, "title");
-            String packageName = DocumentFactory.metadataText(doc, "package");
+            String title = DocumentFactory.metadataText(doc, QdrantPayloadFieldSchema.TITLE_FIELD);
+            String packageName = DocumentFactory.metadataText(doc, QdrantPayloadFieldSchema.PACKAGE_FIELD);
             try {
                 localStore.markHashIngested(hashMetadata.toString(), title, packageName);
             } catch (IOException markHashException) {

--- a/src/main/java/com/williamcallahan/javachat/service/DocumentFactory.java
+++ b/src/main/java/com/williamcallahan/javachat/service/DocumentFactory.java
@@ -40,11 +40,11 @@ public class DocumentFactory {
             String text, String url, String title, int chunkIndex, String packageName, String hash) {
 
         Map<String, ?> metadata = Map.of(
-                "url", url,
-                "title", title,
-                "chunkIndex", chunkIndex,
-                "package", packageName,
-                "hash", hash);
+                QdrantPayloadFieldSchema.URL_FIELD, url,
+                QdrantPayloadFieldSchema.TITLE_FIELD, title,
+                QdrantPayloadFieldSchema.CHUNK_INDEX_FIELD, chunkIndex,
+                QdrantPayloadFieldSchema.PACKAGE_FIELD, packageName,
+                QdrantPayloadFieldSchema.HASH_FIELD, hash);
 
         // Create and configure the document
         var document = createDocumentWithOptionalId(text, hash);
@@ -62,7 +62,8 @@ public class DocumentFactory {
      * @return A properly configured Spring AI Document
      */
     public org.springframework.ai.document.Document createLocalDocument(String text, String url) {
-        Map<String, ?> metadata = Map.of("url", url, "title", "Local Doc");
+        Map<String, ?> metadata =
+                Map.of(QdrantPayloadFieldSchema.URL_FIELD, url, QdrantPayloadFieldSchema.TITLE_FIELD, "Local Doc");
 
         var document = new org.springframework.ai.document.Document(text);
         document.getMetadata().putAll(metadata);
@@ -107,8 +108,8 @@ public class DocumentFactory {
             int pageStart,
             int pageEnd) {
         var doc = createDocument(text, url, title, chunkIndex, packageName, hash);
-        doc.getMetadata().put("pageStart", pageStart);
-        doc.getMetadata().put("pageEnd", pageEnd);
+        doc.getMetadata().put(QdrantPayloadFieldSchema.PAGE_START_FIELD, pageStart);
+        doc.getMetadata().put(QdrantPayloadFieldSchema.PAGE_END_FIELD, pageEnd);
         return doc;
     }
 

--- a/src/main/java/com/williamcallahan/javachat/service/EmbeddingBatchEmbedder.java
+++ b/src/main/java/com/williamcallahan/javachat/service/EmbeddingBatchEmbedder.java
@@ -91,7 +91,7 @@ final class EmbeddingBatchEmbedder {
         if (document == null) {
             return "unknown-url@" + fallbackIndex;
         }
-        Object urlMetadata = document.getMetadata().get("url");
+        Object urlMetadata = document.getMetadata().get(QdrantPayloadFieldSchema.URL_FIELD);
         if (urlMetadata instanceof String documentUrl && !documentUrl.isBlank()) {
             return documentUrl;
         }

--- a/src/main/java/com/williamcallahan/javachat/service/HybridSearchService.java
+++ b/src/main/java/com/williamcallahan/javachat/service/HybridSearchService.java
@@ -3,6 +3,7 @@ package com.williamcallahan.javachat.service;
 import static io.qdrant.client.QueryFactory.nearest;
 import static io.qdrant.client.QueryFactory.rrf;
 
+import com.williamcallahan.javachat.application.search.JavaApiMethodSelector;
 import com.williamcallahan.javachat.application.search.LexicalSparseVectorEncoder;
 import com.williamcallahan.javachat.config.AppProperties;
 import com.williamcallahan.javachat.config.QdrantGitHubCollectionDiscovery;
@@ -175,8 +176,9 @@ public class HybridSearchService {
             return new SearchOutcome(List.of(), List.of());
         }
 
+        String expandedCitationQuery = JavaApiMethodSelector.expandForSparseCitationQuery(query);
         LexicalSparseVectorEncoder.SparseVector sparseVector =
-                queryEncoding.sparseVectorEncoder().encode(query);
+                queryEncoding.sparseVectorEncoder().encode(expandedCitationQuery);
         if (sparseVector.indices().isEmpty()) {
             return new SearchOutcome(List.of(), List.of());
         }

--- a/src/main/java/com/williamcallahan/javachat/service/HybridVectorService.java
+++ b/src/main/java/com/williamcallahan/javachat/service/HybridVectorService.java
@@ -45,7 +45,6 @@ public class HybridVectorService {
     private static final long SCROLL_TIMEOUT_SECONDS = 30;
     private static final long SET_PAYLOAD_TIMEOUT_SECONDS = 30;
     private static final int SCROLL_PAGE_LIMIT = 256;
-    private static final String URL_PAYLOAD_FIELD = "url";
     private static final String NULL_MESSAGE_COLLECTION_KIND = "collectionKind";
     private static final String NULL_MESSAGE_COLLECTION_NAME = "collectionName";
 
@@ -183,7 +182,8 @@ public class HybridVectorService {
         }
 
         Set<String> collectedUrls = new LinkedHashSet<>();
-        List<String> urlPayloadFields = Objects.requireNonNull(List.of(URL_PAYLOAD_FIELD), "urlPayloadFields");
+        List<String> urlPayloadFields =
+                Objects.requireNonNull(List.of(QdrantPayloadFieldSchema.URL_FIELD), "urlPayloadFields");
         ScrollPoints.Builder scrollRequestBuilder = ScrollPoints.newBuilder()
                 .setCollectionName(collectionName)
                 .setWithPayload(WithPayloadSelectorFactory.include(urlPayloadFields))
@@ -198,7 +198,7 @@ public class HybridVectorService {
                     "Qdrant scroll URLs");
 
             for (RetrievedPoint retrievedPoint : scrollResponse.getResultList()) {
-                Value urlPayloadValue = retrievedPoint.getPayloadMap().get(URL_PAYLOAD_FIELD);
+                Value urlPayloadValue = retrievedPoint.getPayloadMap().get(QdrantPayloadFieldSchema.URL_FIELD);
                 if (urlPayloadValue != null && urlPayloadValue.hasStringValue()) {
                     String urlString = urlPayloadValue.getStringValue();
                     if (!urlString.isBlank()) {
@@ -313,7 +313,7 @@ public class HybridVectorService {
         }
 
         Filter filter = Filter.newBuilder()
-                .addMust(matchKeyword(URL_PAYLOAD_FIELD, url))
+                .addMust(matchKeyword(QdrantPayloadFieldSchema.URL_FIELD, url))
                 .build();
 
         RetrySupport.executeWithRetry(
@@ -333,7 +333,7 @@ public class HybridVectorService {
         }
 
         Filter filter = Filter.newBuilder()
-                .addMust(matchKeyword(URL_PAYLOAD_FIELD, url))
+                .addMust(matchKeyword(QdrantPayloadFieldSchema.URL_FIELD, url))
                 .build();
 
         Long count = RetrySupport.executeWithRetry(

--- a/src/main/java/com/williamcallahan/javachat/service/QdrantCollectionRouter.java
+++ b/src/main/java/com/williamcallahan/javachat/service/QdrantCollectionRouter.java
@@ -14,10 +14,6 @@ import org.springframework.stereotype.Service;
 @Service
 public class QdrantCollectionRouter {
 
-    private static final String METADATA_DOC_SET = "docSet";
-    private static final String METADATA_DOC_PATH = "docPath";
-    private static final String METADATA_DOC_TYPE = "docType";
-
     /**
      * Determines the collection bucket for a document based on its metadata.
      *
@@ -26,9 +22,9 @@ public class QdrantCollectionRouter {
      * @return collection kind for routing
      */
     public QdrantCollectionKind route(Map<String, ?> metadata, String url) {
-        String docSet = stringMetadata(metadata, METADATA_DOC_SET);
-        String docPath = stringMetadata(metadata, METADATA_DOC_PATH);
-        String docType = stringMetadata(metadata, METADATA_DOC_TYPE);
+        String docSet = stringMetadata(metadata, QdrantPayloadFieldSchema.DOC_SET_FIELD);
+        String docPath = stringMetadata(metadata, QdrantPayloadFieldSchema.DOC_PATH_FIELD);
+        String docType = stringMetadata(metadata, QdrantPayloadFieldSchema.DOC_TYPE_FIELD);
 
         return route(docSet, docPath, docType, url);
     }

--- a/src/main/java/com/williamcallahan/javachat/service/QdrantPayloadFieldSchema.java
+++ b/src/main/java/com/williamcallahan/javachat/service/QdrantPayloadFieldSchema.java
@@ -18,9 +18,15 @@ final class QdrantPayloadFieldSchema {
     /** Payload field key for the document text content. */
     static final String DOC_CONTENT_FIELD = "doc_content";
 
+    /** Payload metadata key for a canonical source URL. */
+    static final String URL_FIELD = "url";
+
+    /** Payload metadata key for documentation classification. */
+    static final String DOC_TYPE_FIELD = "docType";
+
     /** Metadata fields stored and retrieved as Qdrant string values. */
     static final Set<String> STRING_METADATA_FIELDS = Set.of(
-            "url",
+            URL_FIELD,
             "title",
             "package",
             "hash",
@@ -29,7 +35,7 @@ final class QdrantPayloadFieldSchema {
             "sourceName",
             "sourceKind",
             "docVersion",
-            "docType",
+            DOC_TYPE_FIELD,
             "filePath",
             "language",
             "repoUrl",

--- a/src/main/java/com/williamcallahan/javachat/service/QdrantPayloadFieldSchema.java
+++ b/src/main/java/com/williamcallahan/javachat/service/QdrantPayloadFieldSchema.java
@@ -11,44 +11,107 @@ import java.util.Set;
  * ({@link HybridSearchService}) reference these sets to ensure metadata fields
  * are written and read consistently.</p>
  */
-final class QdrantPayloadFieldSchema {
+public final class QdrantPayloadFieldSchema {
 
     private QdrantPayloadFieldSchema() {}
 
     /** Payload field key for the document text content. */
-    static final String DOC_CONTENT_FIELD = "doc_content";
+    public static final String DOC_CONTENT_FIELD = "doc_content";
 
     /** Payload metadata key for a canonical source URL. */
-    static final String URL_FIELD = "url";
+    public static final String URL_FIELD = "url";
+
+    /** Payload metadata key for a human-readable document title. */
+    public static final String TITLE_FIELD = "title";
+
+    /** Payload metadata key for a Java package name. */
+    public static final String PACKAGE_FIELD = "package";
+
+    /** Payload metadata key for the deterministic document content hash. */
+    public static final String HASH_FIELD = "hash";
+
+    /** Payload metadata key for the documentation-set provenance token. */
+    public static final String DOC_SET_FIELD = "docSet";
+
+    /** Payload metadata key for the path within a documentation set. */
+    public static final String DOC_PATH_FIELD = "docPath";
+
+    /** Payload metadata key for the source display name. */
+    public static final String SOURCE_NAME_FIELD = "sourceName";
+
+    /** Payload metadata key for the source provenance kind. */
+    public static final String SOURCE_KIND_FIELD = "sourceKind";
+
+    /** Payload metadata key for the source documentation version. */
+    public static final String DOC_VERSION_FIELD = "docVersion";
 
     /** Payload metadata key for documentation classification. */
-    static final String DOC_TYPE_FIELD = "docType";
+    public static final String DOC_TYPE_FIELD = "docType";
+
+    /** Payload metadata key for a source-file path. */
+    public static final String FILE_PATH_FIELD = "filePath";
+
+    /** Payload metadata key for a source language. */
+    public static final String LANGUAGE_FIELD = "language";
+
+    /** Payload metadata key for a repository URL. */
+    public static final String REPO_URL_FIELD = "repoUrl";
+
+    /** Payload metadata key for a repository owner. */
+    public static final String REPO_OWNER_FIELD = "repoOwner";
+
+    /** Payload metadata key for a repository name. */
+    public static final String REPO_NAME_FIELD = "repoName";
+
+    /** Payload metadata key for a stable repository identity key. */
+    public static final String REPO_KEY_FIELD = "repoKey";
+
+    /** Payload metadata key for a repository branch. */
+    public static final String REPO_BRANCH_FIELD = "repoBranch";
+
+    /** Payload metadata key for a repository commit hash. */
+    public static final String COMMIT_HASH_FIELD = "commitHash";
+
+    /** Payload metadata key for a repository license. */
+    public static final String LICENSE_FIELD = "license";
+
+    /** Payload metadata key for a repository description. */
+    public static final String REPO_DESCRIPTION_FIELD = "repoDescription";
+
+    /** Payload metadata key for a chunk's zero-based position. */
+    public static final String CHUNK_INDEX_FIELD = "chunkIndex";
+
+    /** Payload metadata key for the first page represented by a PDF chunk. */
+    public static final String PAGE_START_FIELD = "pageStart";
+
+    /** Payload metadata key for the final page represented by a PDF chunk. */
+    public static final String PAGE_END_FIELD = "pageEnd";
 
     /** Metadata fields stored and retrieved as Qdrant string values. */
     static final Set<String> STRING_METADATA_FIELDS = Set.of(
             URL_FIELD,
-            "title",
-            "package",
-            "hash",
-            "docSet",
-            "docPath",
-            "sourceName",
-            "sourceKind",
-            "docVersion",
+            TITLE_FIELD,
+            PACKAGE_FIELD,
+            HASH_FIELD,
+            DOC_SET_FIELD,
+            DOC_PATH_FIELD,
+            SOURCE_NAME_FIELD,
+            SOURCE_KIND_FIELD,
+            DOC_VERSION_FIELD,
             DOC_TYPE_FIELD,
-            "filePath",
-            "language",
-            "repoUrl",
-            "repoOwner",
-            "repoName",
-            "repoKey",
-            "repoBranch",
-            "commitHash",
-            "license",
-            "repoDescription");
+            FILE_PATH_FIELD,
+            LANGUAGE_FIELD,
+            REPO_URL_FIELD,
+            REPO_OWNER_FIELD,
+            REPO_NAME_FIELD,
+            REPO_KEY_FIELD,
+            REPO_BRANCH_FIELD,
+            COMMIT_HASH_FIELD,
+            LICENSE_FIELD,
+            REPO_DESCRIPTION_FIELD);
 
     /** Metadata fields stored and retrieved as Qdrant integer values. */
-    static final Set<String> INTEGER_METADATA_FIELDS = Set.of("chunkIndex", "pageStart", "pageEnd");
+    static final Set<String> INTEGER_METADATA_FIELDS = Set.of(CHUNK_INDEX_FIELD, PAGE_START_FIELD, PAGE_END_FIELD);
 
     /** Union of all metadata field names for type-agnostic iteration (e.g., upsert write path). */
     static final Set<String> ALL_METADATA_FIELDS;

--- a/src/main/java/com/williamcallahan/javachat/service/QdrantRetrievalConstraintBuilder.java
+++ b/src/main/java/com/williamcallahan/javachat/service/QdrantRetrievalConstraintBuilder.java
@@ -20,12 +20,6 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class QdrantRetrievalConstraintBuilder {
-    private static final String METADATA_DOC_VERSION = "docVersion";
-    private static final String METADATA_SOURCE_KIND = "sourceKind";
-    private static final String METADATA_DOC_TYPE = "docType";
-    private static final String METADATA_SOURCE_NAME = "sourceName";
-    private static final String METADATA_DOC_SET = "docSet";
-
     /**
      * Builds a Qdrant filter from the provided retrieval constraint.
      *
@@ -39,27 +33,30 @@ public class QdrantRetrievalConstraintBuilder {
         int mustConditionCount = 0;
 
         if (!retrievalConstraint.docVersion().isBlank()) {
-            filterBuilder.addMust(
-                    matchKeyword(METADATA_DOC_VERSION, Objects.requireNonNull(retrievalConstraint.docVersion())));
+            filterBuilder.addMust(matchKeyword(
+                    QdrantPayloadFieldSchema.DOC_VERSION_FIELD,
+                    Objects.requireNonNull(retrievalConstraint.docVersion())));
             mustConditionCount++;
         }
         if (!retrievalConstraint.sourceKind().isBlank()) {
-            filterBuilder.addMust(
-                    matchKeyword(METADATA_SOURCE_KIND, Objects.requireNonNull(retrievalConstraint.sourceKind())));
+            filterBuilder.addMust(matchKeyword(
+                    QdrantPayloadFieldSchema.SOURCE_KIND_FIELD,
+                    Objects.requireNonNull(retrievalConstraint.sourceKind())));
             mustConditionCount++;
         }
         if (!retrievalConstraint.docType().isBlank()) {
-            filterBuilder.addMust(
-                    matchKeyword(METADATA_DOC_TYPE, Objects.requireNonNull(retrievalConstraint.docType())));
+            filterBuilder.addMust(matchKeyword(
+                    QdrantPayloadFieldSchema.DOC_TYPE_FIELD, Objects.requireNonNull(retrievalConstraint.docType())));
             mustConditionCount++;
         }
         if (!retrievalConstraint.sourceName().isBlank()) {
-            filterBuilder.addMust(
-                    matchKeyword(METADATA_SOURCE_NAME, Objects.requireNonNull(retrievalConstraint.sourceName())));
+            filterBuilder.addMust(matchKeyword(
+                    QdrantPayloadFieldSchema.SOURCE_NAME_FIELD,
+                    Objects.requireNonNull(retrievalConstraint.sourceName())));
             mustConditionCount++;
         }
         if (!retrievalConstraint.docSet().isEmpty()) {
-            filterBuilder.addMust(matchKeywords(METADATA_DOC_SET, retrievalConstraint.docSet()));
+            filterBuilder.addMust(matchKeywords(QdrantPayloadFieldSchema.DOC_SET_FIELD, retrievalConstraint.docSet()));
             mustConditionCount++;
         }
 

--- a/src/main/java/com/williamcallahan/javachat/service/QdrantScoredPointDocumentMapper.java
+++ b/src/main/java/com/williamcallahan/javachat/service/QdrantScoredPointDocumentMapper.java
@@ -13,7 +13,6 @@ import org.springframework.ai.document.Document;
  * preserve only known metadata keys used by ranking, citations, and UI rendering.</p>
  */
 final class QdrantScoredPointDocumentMapper {
-    private static final String PAYLOAD_DOC_CONTENT = QdrantPayloadFieldSchema.DOC_CONTENT_FIELD;
     private static final String METADATA_KEY_SCORE = "score";
     private static final String METADATA_KEY_COLLECTION = "collection";
 
@@ -31,7 +30,7 @@ final class QdrantScoredPointDocumentMapper {
     static Document toDocument(ScoredPoint scoredPoint, String pointId, double fusedScore, String sourceCollection) {
         Document document = Document.builder()
                 .id(pointId)
-                .text(extractPayloadString(scoredPoint.getPayloadMap(), PAYLOAD_DOC_CONTENT))
+                .text(extractPayloadString(scoredPoint.getPayloadMap(), QdrantPayloadFieldSchema.DOC_CONTENT_FIELD))
                 .build();
 
         // Keep metadata explicit and typed; do not attempt to round-trip arbitrary payloads.

--- a/src/main/java/com/williamcallahan/javachat/service/RerankerService.java
+++ b/src/main/java/com/williamcallahan/javachat/service/RerankerService.java
@@ -143,8 +143,8 @@ public class RerankerService {
         for (int docIndex = 0; docIndex < documents.size(); docIndex++) {
             Document document = documents.get(docIndex);
             Map<String, ?> metadata = document.getMetadata();
-            String title = extractMetadataString(metadata, "title");
-            String url = extractMetadataString(metadata, "url");
+            String title = extractMetadataString(metadata, QdrantPayloadFieldSchema.TITLE_FIELD);
+            String url = extractMetadataString(metadata, QdrantPayloadFieldSchema.URL_FIELD);
             String text = document.getText();
             prompt.append("[")
                     .append(docIndex)
@@ -234,7 +234,7 @@ public class RerankerService {
         }
         StringBuilder hashBuilder = new StringBuilder();
         for (Document document : documents) {
-            Object url = document.getMetadata().get("url");
+            Object url = document.getMetadata().get(QdrantPayloadFieldSchema.URL_FIELD);
             String text = document.getText();
             hashBuilder.append(url != null ? url.toString() : (text != null ? text.hashCode() : 0));
             hashBuilder.append("|");

--- a/src/main/java/com/williamcallahan/javachat/service/RetrievalService.java
+++ b/src/main/java/com/williamcallahan/javachat/service/RetrievalService.java
@@ -33,11 +33,6 @@ public class RetrievalService {
     private static final int CITATION_SNIPPET_MAX_LENGTH = 500;
     private static final double TRUNCATION_BREAK_THRESHOLD = 0.8;
 
-    private static final String METADATA_URL = QdrantPayloadFieldSchema.URL_FIELD;
-    private static final String METADATA_TITLE = "title";
-    private static final String METADATA_PACKAGE = "package";
-    private static final String METADATA_HASH = "hash";
-    private static final String METADATA_DOC_TYPE = QdrantPayloadFieldSchema.DOC_TYPE_FIELD;
     private static final String DOCUMENT_TYPE_API_DOCS = DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE;
     private static final String FILE_URL_PREFIX = "file://";
     private static final char URL_FRAGMENT_DELIMITER = '#';
@@ -273,8 +268,8 @@ public class RetrievalService {
         VersionFilterPatterns filter = versionFilter.get();
         List<Document> matched = documents.stream()
                 .filter(document -> filter.matchesMetadata(
-                        stringMetadataValue(document.getMetadata(), METADATA_URL),
-                        stringMetadataValue(document.getMetadata(), METADATA_TITLE)))
+                        stringMetadataValue(document.getMetadata(), QdrantPayloadFieldSchema.URL_FIELD),
+                        stringMetadataValue(document.getMetadata(), QdrantPayloadFieldSchema.TITLE_FIELD)))
                 .toList();
         return matched.isEmpty() ? documents : matched;
     }
@@ -304,13 +299,13 @@ public class RetrievalService {
         List<Document> deduplicatedDocuments = new ArrayList<>(documents.size());
         int unidentifiedDocumentCount = 0;
         for (Document document : documents) {
-            String contentHash = stringMetadataValue(document.getMetadata(), METADATA_HASH);
+            String contentHash = stringMetadataValue(document.getMetadata(), QdrantPayloadFieldSchema.HASH_FIELD);
             if (!contentHash.isBlank()) {
                 if (!retainedContentHashes.add(contentHash)) {
                     continue;
                 }
             } else {
-                String documentUrl = stringMetadataValue(document.getMetadata(), METADATA_URL)
+                String documentUrl = stringMetadataValue(document.getMetadata(), QdrantPayloadFieldSchema.URL_FIELD)
                         .trim();
                 if (!documentUrl.isBlank()) {
                     String canonicalDocumentUrl = documentUrl.startsWith(FILE_URL_PREFIX)
@@ -418,10 +413,10 @@ public class RetrievalService {
             }
             try {
                 Map<String, ?> sourceDocMetadata = sourceDocument.getMetadata();
-                String rawUrl = stringMetadataValue(sourceDocMetadata, METADATA_URL);
-                String title = stringMetadataValue(sourceDocMetadata, METADATA_TITLE);
-                String packageName = stringMetadataValue(sourceDocMetadata, METADATA_PACKAGE);
-                String documentType = stringMetadataValue(sourceDocMetadata, METADATA_DOC_TYPE);
+                String rawUrl = stringMetadataValue(sourceDocMetadata, QdrantPayloadFieldSchema.URL_FIELD);
+                String title = stringMetadataValue(sourceDocMetadata, QdrantPayloadFieldSchema.TITLE_FIELD);
+                String packageName = stringMetadataValue(sourceDocMetadata, QdrantPayloadFieldSchema.PACKAGE_FIELD);
+                String documentType = stringMetadataValue(sourceDocMetadata, QdrantPayloadFieldSchema.DOC_TYPE_FIELD);
                 String refinedCitationUrl =
                         refineCitationUrl(rawUrl, sourceDocument.getText(), packageName, documentType);
                 String citationIdentity = citationIdentityFor(rawUrl, refinedCitationUrl);
@@ -438,8 +433,8 @@ public class RetrievalService {
                 log.warn(
                         "Citation conversion failed (exceptionType={}, docUrl={}, docTitle={})",
                         citationConversionFailure.getClass().getSimpleName(),
-                        safeMetadataValueForLogging(sourceDocument.getMetadata(), METADATA_URL),
-                        safeMetadataValueForLogging(sourceDocument.getMetadata(), METADATA_TITLE),
+                        safeMetadataValueForLogging(sourceDocument.getMetadata(), QdrantPayloadFieldSchema.URL_FIELD),
+                        safeMetadataValueForLogging(sourceDocument.getMetadata(), QdrantPayloadFieldSchema.TITLE_FIELD),
                         citationConversionFailure);
             }
         }
@@ -516,7 +511,9 @@ public class RetrievalService {
         }
         try {
             String metadataText = String.valueOf(metadataValue);
-            return METADATA_URL.equals(key) ? DocsSourceRegistry.normalizeDocUrl(metadataText) : metadataText;
+            return QdrantPayloadFieldSchema.URL_FIELD.equals(key)
+                    ? DocsSourceRegistry.normalizeDocUrl(metadataText)
+                    : metadataText;
         } catch (RuntimeException _) {
             return "[unprintable:" + metadataValue.getClass().getSimpleName() + "]";
         }

--- a/src/main/java/com/williamcallahan/javachat/service/RetrievalService.java
+++ b/src/main/java/com/williamcallahan/javachat/service/RetrievalService.java
@@ -33,12 +33,12 @@ public class RetrievalService {
     private static final int CITATION_SNIPPET_MAX_LENGTH = 500;
     private static final double TRUNCATION_BREAK_THRESHOLD = 0.8;
 
-    private static final String METADATA_URL = "url";
+    private static final String METADATA_URL = QdrantPayloadFieldSchema.URL_FIELD;
     private static final String METADATA_TITLE = "title";
     private static final String METADATA_PACKAGE = "package";
     private static final String METADATA_HASH = "hash";
-    private static final String METADATA_DOC_TYPE = "docType";
-    private static final String DOCUMENT_TYPE_API_DOCS = "api-docs";
+    private static final String METADATA_DOC_TYPE = QdrantPayloadFieldSchema.DOC_TYPE_FIELD;
+    private static final String DOCUMENT_TYPE_API_DOCS = DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE;
     private static final String FILE_URL_PREFIX = "file://";
     private static final char URL_FRAGMENT_DELIMITER = '#';
 
@@ -137,11 +137,12 @@ public class RetrievalService {
         int citationCandidateLimit = Math.max(appProperties.getRag().getSearchTopK(), citationLimit);
         Optional<VersionFilterPatterns> versionFilter = QueryVersionExtractor.extractFilterPatterns(query);
         RetrievalConstraint combinedRetrievalConstraint = combineWithVersionFilter(retrievalConstraint, versionFilter);
-        String boostedQuery = QueryVersionExtractor.boostQueryWithVersionContext(query);
         HybridSearchService.SearchOutcome citationSearchOutcome =
                 hybridSearchService.searchDocumentationCitationsOutcome(
-                        boostedQuery, citationCandidateLimit, combinedRetrievalConstraint);
-        CitationOutcome candidateCitationOutcome = toCitations(citationSearchOutcome.documents());
+                        query, citationCandidateLimit, combinedRetrievalConstraint);
+        List<Document> orderedCitationCandidates =
+                CitationCandidateRanker.orderForCitationQuery(query, citationSearchOutcome.documents());
+        CitationOutcome candidateCitationOutcome = toCitations(orderedCitationCandidates);
         List<Citation> limitedCitations = candidateCitationOutcome.citations().stream()
                 .limit(citationLimit)
                 .toList();

--- a/src/main/java/com/williamcallahan/javachat/service/ingestion/IngestionProvenanceDeriver.java
+++ b/src/main/java/com/williamcallahan/javachat/service/ingestion/IngestionProvenanceDeriver.java
@@ -138,7 +138,7 @@ public class IngestionProvenanceDeriver {
             return "book";
         }
         if (normalized.startsWith("java/")) {
-            return "api-docs";
+            return DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE;
         }
         if (normalized.startsWith("oracle/javase")) {
             return "release-notes";
@@ -149,7 +149,7 @@ public class IngestionProvenanceDeriver {
         if (url != null) {
             String lower = AsciiTextNormalizer.toLowerAscii(url);
             if (lower.contains("docs.oracle.com/en/java/javase/")) {
-                return "api-docs";
+                return DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE;
             }
             if (lower.contains("/pdfs/")) {
                 return "pdf";
@@ -203,7 +203,7 @@ public class IngestionProvenanceDeriver {
      * @param sourceName logical source identifier
      * @param sourceKind source category ("official", "vendor", "unknown")
      * @param docVersion version token when available
-     * @param docType doc type token ("api-docs", "release-notes", "blog", "pdf", etc.)
+     * @param docType doc type token (Java API, release-notes, blog, PDF, etc.)
      */
     public record IngestionProvenance(
             String docSet, String docPath, String sourceName, String sourceKind, String docVersion, String docType) {

--- a/src/main/java/com/williamcallahan/javachat/service/ingestion/IngestionProvenanceDeriver.java
+++ b/src/main/java/com/williamcallahan/javachat/service/ingestion/IngestionProvenanceDeriver.java
@@ -203,7 +203,8 @@ public class IngestionProvenanceDeriver {
      * @param sourceName logical source identifier
      * @param sourceKind source category ("official", "vendor", "unknown")
      * @param docVersion version token when available
-     * @param docType doc type token (Java API, release-notes, blog, PDF, etc.)
+     * @param docType normalized doc type token (for example,
+     *     {@link DocsSourceRegistry#JAVA_API_DOCUMENT_TYPE}, {@code release-notes}, {@code blog}, or {@code pdf})
      */
     public record IngestionProvenance(
             String docSet, String docPath, String sourceName, String sourceKind, String docVersion, String docType) {

--- a/src/main/java/com/williamcallahan/javachat/service/ingestion/LocalDocsFileIngestionProcessor.java
+++ b/src/main/java/com/williamcallahan/javachat/service/ingestion/LocalDocsFileIngestionProcessor.java
@@ -10,6 +10,7 @@ import com.williamcallahan.javachat.service.FileIngestionMarkerStore.FileIngesti
 import com.williamcallahan.javachat.service.LocalStoreService;
 import com.williamcallahan.javachat.service.ProgressTracker;
 import com.williamcallahan.javachat.service.QdrantCollectionKind;
+import com.williamcallahan.javachat.service.QdrantPayloadFieldSchema;
 import com.williamcallahan.javachat.service.ingestion.HtmlContentGuard.GuardDecision;
 import com.williamcallahan.javachat.service.ingestion.HtmlContentGuard.GuardInput;
 import com.williamcallahan.javachat.service.ingestion.IngestionProvenanceDeriver.IngestionProvenance;
@@ -401,12 +402,12 @@ public class LocalDocsFileIngestionProcessor {
     private void markDocumentsIngested(List<Document> documents) {
         LocalStoreService localStore = storage.localStore();
         for (Document indexedDocument : documents) {
-            Object hashMetadata = indexedDocument.getMetadata().get("hash");
+            Object hashMetadata = indexedDocument.getMetadata().get(QdrantPayloadFieldSchema.HASH_FIELD);
             if (hashMetadata == null) {
                 continue;
             }
-            String title = DocumentFactory.metadataText(indexedDocument, "title");
-            String packageName = DocumentFactory.metadataText(indexedDocument, "package");
+            String title = DocumentFactory.metadataText(indexedDocument, QdrantPayloadFieldSchema.TITLE_FIELD);
+            String packageName = DocumentFactory.metadataText(indexedDocument, QdrantPayloadFieldSchema.PACKAGE_FIELD);
             try {
                 localStore.markHashIngested(hashMetadata.toString(), title, packageName);
             } catch (IOException markHashException) {
@@ -431,22 +432,22 @@ public class LocalDocsFileIngestionProcessor {
         Objects.requireNonNull(provenance, "provenance");
         for (Document indexedDocument : documents) {
             if (!provenance.docSet().isBlank()) {
-                indexedDocument.getMetadata().put("docSet", provenance.docSet());
+                indexedDocument.getMetadata().put(QdrantPayloadFieldSchema.DOC_SET_FIELD, provenance.docSet());
             }
             if (!provenance.docPath().isBlank()) {
-                indexedDocument.getMetadata().put("docPath", provenance.docPath());
+                indexedDocument.getMetadata().put(QdrantPayloadFieldSchema.DOC_PATH_FIELD, provenance.docPath());
             }
             if (!provenance.sourceName().isBlank()) {
-                indexedDocument.getMetadata().put("sourceName", provenance.sourceName());
+                indexedDocument.getMetadata().put(QdrantPayloadFieldSchema.SOURCE_NAME_FIELD, provenance.sourceName());
             }
             if (!provenance.sourceKind().isBlank()) {
-                indexedDocument.getMetadata().put("sourceKind", provenance.sourceKind());
+                indexedDocument.getMetadata().put(QdrantPayloadFieldSchema.SOURCE_KIND_FIELD, provenance.sourceKind());
             }
             if (!provenance.docVersion().isBlank()) {
-                indexedDocument.getMetadata().put("docVersion", provenance.docVersion());
+                indexedDocument.getMetadata().put(QdrantPayloadFieldSchema.DOC_VERSION_FIELD, provenance.docVersion());
             }
             if (!provenance.docType().isBlank()) {
-                indexedDocument.getMetadata().put("docType", provenance.docType());
+                indexedDocument.getMetadata().put(QdrantPayloadFieldSchema.DOC_TYPE_FIELD, provenance.docType());
             }
         }
     }

--- a/src/main/java/com/williamcallahan/javachat/service/ingestion/SourceCodeFileIngestionProcessor.java
+++ b/src/main/java/com/williamcallahan/javachat/service/ingestion/SourceCodeFileIngestionProcessor.java
@@ -7,6 +7,7 @@ import com.williamcallahan.javachat.domain.ingestion.SourceFileProcessingResult;
 import com.williamcallahan.javachat.service.ChunkProcessingService;
 import com.williamcallahan.javachat.service.FileIngestionMarkerStore.FileIngestionRecord;
 import com.williamcallahan.javachat.service.ProgressTracker;
+import com.williamcallahan.javachat.service.QdrantPayloadFieldSchema;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.MalformedInputException;
@@ -440,39 +441,39 @@ public class SourceCodeFileIngestionProcessor {
             String documentType) {
         for (Document indexedDocument : indexedDocuments) {
             var metadata = indexedDocument.getMetadata();
-            metadata.put("filePath", relativePath);
+            metadata.put(QdrantPayloadFieldSchema.FILE_PATH_FIELD, relativePath);
             if (!sourceLanguage.isEmpty()) {
-                metadata.put("language", sourceLanguage);
+                metadata.put(QdrantPayloadFieldSchema.LANGUAGE_FIELD, sourceLanguage);
             }
-            metadata.put("docType", documentType);
-            metadata.put("docSet", DOCUMENT_SET_PREFIX + repositoryMetadata.repoKey());
-            metadata.put("sourceKind", "github");
-            metadata.put("sourceName", repositoryMetadata.repoOwner());
-            metadata.put("repoUrl", repositoryMetadata.repoUrl());
-            metadata.put("repoOwner", repositoryMetadata.repoOwner());
-            metadata.put("repoName", repositoryMetadata.repoName());
-            metadata.put("repoKey", repositoryMetadata.repoKey());
+            metadata.put(QdrantPayloadFieldSchema.DOC_TYPE_FIELD, documentType);
+            metadata.put(QdrantPayloadFieldSchema.DOC_SET_FIELD, DOCUMENT_SET_PREFIX + repositoryMetadata.repoKey());
+            metadata.put(QdrantPayloadFieldSchema.SOURCE_KIND_FIELD, "github");
+            metadata.put(QdrantPayloadFieldSchema.SOURCE_NAME_FIELD, repositoryMetadata.repoOwner());
+            metadata.put(QdrantPayloadFieldSchema.REPO_URL_FIELD, repositoryMetadata.repoUrl());
+            metadata.put(QdrantPayloadFieldSchema.REPO_OWNER_FIELD, repositoryMetadata.repoOwner());
+            metadata.put(QdrantPayloadFieldSchema.REPO_NAME_FIELD, repositoryMetadata.repoName());
+            metadata.put(QdrantPayloadFieldSchema.REPO_KEY_FIELD, repositoryMetadata.repoKey());
             if (!repositoryMetadata.repoBranch().isBlank()) {
-                metadata.put("repoBranch", repositoryMetadata.repoBranch());
+                metadata.put(QdrantPayloadFieldSchema.REPO_BRANCH_FIELD, repositoryMetadata.repoBranch());
             }
             if (!repositoryMetadata.commitHash().isBlank()) {
-                metadata.put("commitHash", repositoryMetadata.commitHash());
+                metadata.put(QdrantPayloadFieldSchema.COMMIT_HASH_FIELD, repositoryMetadata.commitHash());
             }
             if (!repositoryMetadata.license().isBlank()) {
-                metadata.put("license", repositoryMetadata.license());
+                metadata.put(QdrantPayloadFieldSchema.LICENSE_FIELD, repositoryMetadata.license());
             }
             if (!repositoryMetadata.repoDescription().isBlank()) {
-                metadata.put("repoDescription", repositoryMetadata.repoDescription());
+                metadata.put(QdrantPayloadFieldSchema.REPO_DESCRIPTION_FIELD, repositoryMetadata.repoDescription());
             }
         }
     }
 
     private void markDocumentsIngested(List<Document> indexedDocuments) {
         for (Document indexedDocument : indexedDocuments) {
-            Object hashMetadata = indexedDocument.getMetadata().get("hash");
+            Object hashMetadata = indexedDocument.getMetadata().get(QdrantPayloadFieldSchema.HASH_FIELD);
             if (hashMetadata == null) {
-                String sourceUrl =
-                        Objects.toString(indexedDocument.getMetadata().get("url"), "(unknown)");
+                String sourceUrl = Objects.toString(
+                        indexedDocument.getMetadata().get(QdrantPayloadFieldSchema.URL_FIELD), "(unknown)");
                 throw new IllegalStateException(
                         "Document missing required 'hash' metadata after chunking pipeline; url=" + sourceUrl);
             }

--- a/src/main/java/com/williamcallahan/javachat/support/DocumentContentAdapter.java
+++ b/src/main/java/com/williamcallahan/javachat/support/DocumentContentAdapter.java
@@ -1,6 +1,7 @@
 package com.williamcallahan.javachat.support;
 
 import com.williamcallahan.javachat.domain.RetrievedContent;
+import com.williamcallahan.javachat.service.QdrantPayloadFieldSchema;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -13,8 +14,6 @@ import org.springframework.ai.document.Document;
  * infrastructure layer handles the Spring AI integration.</p>
  */
 public final class DocumentContentAdapter implements RetrievedContent {
-
-    private static final String METADATA_URL = "url";
 
     private final Document document;
 
@@ -57,6 +56,7 @@ public final class DocumentContentAdapter implements RetrievedContent {
     @Override
     public Optional<String> getSourceUrl() {
         Map<String, ?> metadata = document.getMetadata();
-        return Optional.ofNullable(metadata.get(METADATA_URL)).map(String::valueOf);
+        return Optional.ofNullable(metadata.get(QdrantPayloadFieldSchema.URL_FIELD))
+                .map(String::valueOf);
     }
 }

--- a/src/main/java/com/williamcallahan/javachat/web/ChatController.java
+++ b/src/main/java/com/williamcallahan/javachat/web/ChatController.java
@@ -37,6 +37,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
 
 /**
  * Exposes chat endpoints for streaming responses, session history management, and diagnostics.
@@ -119,77 +120,91 @@ public class ChatController extends BaseController {
         PIPELINE_LOG.info("[{}] NEW CHAT REQUEST", requestToken);
         PIPELINE_LOG.info("[{}] {}", requestToken, PIPELINE_LOG_SEPARATOR);
 
-        return Flux.concat(sseSupport.responsePreparationStatus(), Flux.defer(() -> {
-                    // Avoid reading session state or performing retrieval when the configured provider cannot stream.
-                    if (!openAIStreamingService.isAvailable()) {
-                        PIPELINE_LOG.warn("[{}] OpenAI streaming service unavailable", requestToken);
-                        return sseSupport.configuredProviderConfigurationError();
-                    }
+        return Flux.concat(
+                        sseSupport.responsePreparationStatus(),
+                        Flux.defer(() -> {
+                                    // Avoid reading session state or performing retrieval when the configured provider
+                                    // cannot stream.
+                                    if (!openAIStreamingService.isAvailable()) {
+                                        PIPELINE_LOG.warn("[{}] OpenAI streaming service unavailable", requestToken);
+                                        return sseSupport.configuredProviderConfigurationError();
+                                    }
 
-                    List<Message> history = chatMemory.getHistory(sessionId);
-                    PIPELINE_LOG.info("[{}] Chat history loaded", requestToken);
+                                    List<Message> history = chatMemory.getHistory(sessionId);
+                                    PIPELINE_LOG.info("[{}] Chat history loaded", requestToken);
 
-                    // Build structured prompt for intelligent truncation
-                    // Pass model hint to optimize RAG for token-constrained models
-                    ChatService.StructuredPromptOutcome promptOutcome =
-                            chatService.buildStructuredPromptWithContextOutcome(
-                                    history, latest, ModelConfiguration.DEFAULT_MODEL);
+                                    // Build structured prompt for intelligent truncation
+                                    // Pass model hint to optimize RAG for token-constrained models
+                                    ChatService.StructuredPromptOutcome promptOutcome =
+                                            chatService.buildStructuredPromptWithContextOutcome(
+                                                    history, latest, ModelConfiguration.DEFAULT_MODEL);
 
-                    // Use OpenAI streaming only (legacy fallback removed)
-                    StringBuilder fullResponse = new StringBuilder();
-                    AtomicInteger chunkCount = new AtomicInteger(0);
-                    PIPELINE_LOG.info("[{}] Using OpenAI Java SDK for streaming (structured prompt)", requestToken);
+                                    // Use OpenAI streaming only (legacy fallback removed)
+                                    StringBuilder fullResponse = new StringBuilder();
+                                    AtomicInteger chunkCount = new AtomicInteger(0);
+                                    PIPELINE_LOG.info(
+                                            "[{}] Using OpenAI Java SDK for streaming (structured prompt)",
+                                            requestToken);
 
-                    // Cite the exact official documents supplied to the model so source attribution
-                    // cannot drift from the answer context. Conversion failures remain observable.
-                    RetrievalService.CitationOutcome citationOutcome =
-                            retrievalService.toCitations(promptOutcome.documents());
-                    final List<Citation> finalCitations = citationOutcome.citations();
+                                    // Cite the exact official documents supplied to the model so source attribution
+                                    // cannot drift from the answer context. Conversion failures remain observable.
+                                    RetrievalService.CitationOutcome citationOutcome =
+                                            retrievalService.toCitations(promptOutcome.documents());
+                                    final List<Citation> finalCitations = citationOutcome.citations();
 
-                    // Stream with provider transparency - surfaces which LLM is responding
-                    return openAIStreamingService
-                            .streamResponse(
-                                    promptOutcome.structuredPrompt(),
-                                    appProperties.getLlm().getTemperature())
-                            .flatMapMany(streamingResult -> {
-                                // Provider event first - surfaces which LLM is handling this request
-                                ServerSentEvent<String> providerEvent =
-                                        sseSupport.providerEvent(streamingResult.providerDisplayName());
+                                    // Stream with provider transparency - surfaces which LLM is responding
+                                    return openAIStreamingService
+                                            .streamResponse(
+                                                    promptOutcome.structuredPrompt(),
+                                                    appProperties.getLlm().getTemperature())
+                                            .flatMapMany(streamingResult -> {
+                                                // Provider event first - surfaces which LLM is handling this request
+                                                ServerSentEvent<String> providerEvent =
+                                                        sseSupport.providerEvent(streamingResult.providerDisplayName());
 
-                                // Stream with structure-aware truncation - preserves semantic boundaries
-                                Flux<String> dataStream =
-                                        sseSupport.prepareDataStream(streamingResult.textChunks(), chunk -> {
-                                            fullResponse.append(chunk);
-                                            chunkCount.incrementAndGet();
-                                        });
+                                                // Stream with structure-aware truncation - preserves semantic
+                                                // boundaries
+                                                Flux<String> dataStream = sseSupport.prepareDataStream(
+                                                        streamingResult.textChunks(), chunk -> {
+                                                            fullResponse.append(chunk);
+                                                            chunkCount.incrementAndGet();
+                                                        });
 
-                                // Heartbeats terminate when data stream completes (success or error)
-                                Flux<ServerSentEvent<String>> heartbeats = sseSupport.heartbeats(dataStream);
+                                                // Heartbeats terminate when data stream completes (success or error)
+                                                Flux<ServerSentEvent<String>> heartbeats =
+                                                        sseSupport.heartbeats(dataStream);
 
-                                // Surface retrieval and citation-conversion notices before response content.
-                                Flux<ServerSentEvent<String>> statusEvents = Flux.fromIterable(promptOutcome.notices())
-                                        .map(notice -> sseSupport.statusEvent(notice.summary(), notice.details()));
-                                statusEvents = statusEvents.concatWith(sseSupport.citationPartialFailureStatusFlux(
-                                        citationOutcome.failedConversionCount()));
+                                                // Surface retrieval and citation-conversion notices before response
+                                                // content.
+                                                Flux<ServerSentEvent<String>> statusEvents = Flux.fromIterable(
+                                                                promptOutcome.notices())
+                                                        .map(notice -> sseSupport.statusEvent(
+                                                                notice.summary(), notice.details()));
+                                                statusEvents = statusEvents.concatWith(
+                                                        sseSupport.citationPartialFailureStatusFlux(
+                                                                citationOutcome.failedConversionCount()));
 
-                                // Wrap chunks in JSON to preserve whitespace
-                                Flux<ServerSentEvent<String>> dataEvents = dataStream.map(sseSupport::textEvent);
+                                                // Wrap chunks in JSON to preserve whitespace
+                                                Flux<ServerSentEvent<String>> dataEvents =
+                                                        dataStream.map(sseSupport::textEvent);
 
-                                Flux<ServerSentEvent<String>> citationEvent =
-                                        Flux.just(sseSupport.citationEvent(finalCitations));
+                                                Flux<ServerSentEvent<String>> citationEvent =
+                                                        Flux.just(sseSupport.citationEvent(finalCitations));
 
-                                // Start selected-provider and status events before the ref-counted data stream.
-                                return Flux.concat(
-                                        Flux.just(providerEvent),
-                                        statusEvents,
-                                        Flux.merge(dataEvents, heartbeats),
-                                        citationEvent);
-                            })
-                            .doOnComplete(() -> {
-                                chatMemory.addExchange(sessionId, latest, fullResponse.toString());
-                                PIPELINE_LOG.info("[{}] STREAMING COMPLETE", requestToken);
-                            });
-                }))
+                                                // Start selected-provider and status events before the ref-counted data
+                                                // stream.
+                                                return Flux.concat(
+                                                        Flux.just(providerEvent),
+                                                        statusEvents,
+                                                        Flux.merge(dataEvents, heartbeats),
+                                                        citationEvent);
+                                            })
+                                            .doOnComplete(() -> {
+                                                chatMemory.addExchange(sessionId, latest, fullResponse.toString());
+                                                PIPELINE_LOG.info("[{}] STREAMING COMPLETE", requestToken);
+                                            });
+                                })
+                                .subscribeOn(Schedulers.boundedElastic()))
                 .onErrorResume(error -> {
                     Optional<ReportedStreamingFailure> terminalFailureContext =
                             ReportedStreamingFailure.findInCauseChain(error);

--- a/src/test/java/com/williamcallahan/javachat/application/search/JavaApiMethodSelectorTest.java
+++ b/src/test/java/com/williamcallahan/javachat/application/search/JavaApiMethodSelectorTest.java
@@ -1,0 +1,69 @@
+package com.williamcallahan.javachat.application.search;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/** Verifies Java API method-selector parsing and sparse citation query expansion. */
+class JavaApiMethodSelectorTest {
+
+    @Test
+    void recognizesPunctuatedTypeMethodInvocationAndAppendsOnlyTheDeclaringType() {
+        String citationQuery = "What does Java List.of() return?";
+
+        JavaApiMethodSelector selector =
+                JavaApiMethodSelector.fromQuery(citationQuery).orElseThrow();
+
+        assertEquals("", selector.packageName());
+        assertEquals("List", selector.typePageName());
+        assertEquals("of", selector.methodName());
+        assertEquals("List.html", selector.typePageFileName());
+        assertEquals("List", selector.sparseQueryTerms());
+        assertEquals(citationQuery + " List", JavaApiMethodSelector.expandForSparseCitationQuery(citationQuery));
+    }
+
+    @Test
+    void recognizesTypeMethodWithoutInvocationParentheses() {
+        JavaApiMethodSelector selector =
+                JavaApiMethodSelector.fromQuery("Explain Stream.map in Java").orElseThrow();
+
+        assertEquals("", selector.packageName());
+        assertEquals("Stream", selector.typePageName());
+        assertEquals("map", selector.methodName());
+        assertEquals("Stream", selector.sparseQueryTerms());
+    }
+
+    @Test
+    void retainsPackageAndNestedJavadocTypeSyntaxFromAQualifiedSelector() {
+        JavaApiMethodSelector selector = JavaApiMethodSelector.fromQuery(
+                        "How does java.util.Map.Entry.comparingByKey work?")
+                .orElseThrow();
+
+        assertEquals("java.util", selector.packageName());
+        assertEquals("Map.Entry", selector.typePageName());
+        assertEquals("comparingByKey", selector.methodName());
+        assertEquals("Map.Entry.html", selector.typePageFileName());
+        assertEquals("Map.Entry", selector.sparseQueryTerms());
+    }
+
+    @Test
+    void ignoresQualifiedNamesWithoutAnExplicitTypeMethodSelector() {
+        assertTrue(
+                JavaApiMethodSelector.fromQuery("Read java.util documentation").isEmpty());
+    }
+
+    @Test
+    void rejectsFilenameShapedPseudoMethods() {
+        assertTrue(JavaApiMethodSelector.fromQuery("Read List.java").isEmpty());
+        assertTrue(JavaApiMethodSelector.fromQuery("Read String.html").isEmpty());
+    }
+
+    @Test
+    void requiresCaseSensitiveJavadocTypePageNames() {
+        JavaApiMethodSelector selector = new JavaApiMethodSelector("java.util", "List", "of");
+
+        assertFalse(selector.matchesJavadocPath("/java.base/java/util/list.html"));
+    }
+}

--- a/src/test/java/com/williamcallahan/javachat/application/search/JavaApiMethodSelectorTest.java
+++ b/src/test/java/com/williamcallahan/javachat/application/search/JavaApiMethodSelectorTest.java
@@ -49,6 +49,18 @@ class JavaApiMethodSelectorTest {
     }
 
     @Test
+    void normalizesWhitespaceWhenConstructedDirectly() {
+        JavaApiMethodSelector selector = new JavaApiMethodSelector(" java.util ", " List ", " of ");
+
+        assertEquals("java.util", selector.packageName());
+        assertEquals("List", selector.typePageName());
+        assertEquals("of", selector.methodName());
+        assertEquals("List.html", selector.typePageFileName());
+        assertEquals("List", selector.sparseQueryTerms());
+        assertTrue(selector.matchesJavadocPath("/java.base/java/util/List.html"));
+    }
+
+    @Test
     void ignoresQualifiedNamesWithoutAnExplicitTypeMethodSelector() {
         assertTrue(
                 JavaApiMethodSelector.fromQuery("Read java.util documentation").isEmpty());

--- a/src/test/java/com/williamcallahan/javachat/domain/SearchQualityLevelTest.java
+++ b/src/test/java/com/williamcallahan/javachat/domain/SearchQualityLevelTest.java
@@ -2,6 +2,7 @@ package com.williamcallahan.javachat.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.williamcallahan.javachat.service.QdrantPayloadFieldSchema;
 import com.williamcallahan.javachat.support.DocumentContentAdapter;
 import java.util.List;
 import java.util.Map;
@@ -27,7 +28,8 @@ class SearchQualityLevelTest {
 
     @Test
     void determineReturnsKeywordSearchWhenUrlContainsKeyword() {
-        Document keywordDoc = new Document("some content", Map.of("url", "local-search://query"));
+        Document keywordDoc =
+                new Document("some content", Map.of(QdrantPayloadFieldSchema.URL_FIELD, "local-search://query"));
         SearchQualityLevel level =
                 SearchQualityLevel.determine(DocumentContentAdapter.fromDocuments(List.of(keywordDoc)));
         assertThat(level).isEqualTo(SearchQualityLevel.KEYWORD_SEARCH);
@@ -36,8 +38,10 @@ class SearchQualityLevelTest {
     @Test
     void determineReturnsHighQualityWhenAllDocsHaveSubstantialContent() {
         String longContent = "a".repeat(150);
-        Document doc1 = new Document(longContent, Map.of("url", "https://example.com/doc1"));
-        Document doc2 = new Document(longContent, Map.of("url", "https://example.com/doc2"));
+        Document doc1 =
+                new Document(longContent, Map.of(QdrantPayloadFieldSchema.URL_FIELD, "https://example.com/doc1"));
+        Document doc2 =
+                new Document(longContent, Map.of(QdrantPayloadFieldSchema.URL_FIELD, "https://example.com/doc2"));
         SearchQualityLevel level =
                 SearchQualityLevel.determine(DocumentContentAdapter.fromDocuments(List.of(doc1, doc2)));
         assertThat(level).isEqualTo(SearchQualityLevel.HIGH_QUALITY);
@@ -47,8 +51,10 @@ class SearchQualityLevelTest {
     void determineReturnsMixedQualityWhenSomeDocsHaveShortContent() {
         String longContent = "a".repeat(150);
         String shortContent = "short";
-        Document highQualityDoc = new Document(longContent, Map.of("url", "https://example.com/doc1"));
-        Document lowQualityDoc = new Document(shortContent, Map.of("url", "https://example.com/doc2"));
+        Document highQualityDoc =
+                new Document(longContent, Map.of(QdrantPayloadFieldSchema.URL_FIELD, "https://example.com/doc1"));
+        Document lowQualityDoc =
+                new Document(shortContent, Map.of(QdrantPayloadFieldSchema.URL_FIELD, "https://example.com/doc2"));
         SearchQualityLevel level = SearchQualityLevel.determine(
                 DocumentContentAdapter.fromDocuments(List.of(highQualityDoc, lowQualityDoc)));
         assertThat(level).isEqualTo(SearchQualityLevel.MIXED_QUALITY);

--- a/src/test/java/com/williamcallahan/javachat/service/CitationCandidateRankerTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/CitationCandidateRankerTest.java
@@ -11,13 +11,18 @@ import org.springframework.ai.document.Document;
 /** Verifies deterministic local ordering of sparse static-citation candidates. */
 class CitationCandidateRankerTest {
 
+    private static final String TUTORIAL_DOCUMENT_TYPE = "tutorial";
+
     @Test
     void prioritizesExactJavadocTypePagesOverHigherRankedMethodOnlyMatches() {
-        Document classFileCandidate =
-                javadocCandidate("class-file", "ClassFileFormatVersion factory of()", "ClassFileFormatVersion.html");
-        Document firstListCandidate = javadocCandidate("list-first", "static <E> List<E> of(E element)", "List.html");
-        Document secondListCandidate =
-                javadocCandidate("list-second", "static <E> List<E> of(E first, E second)", "List.html");
+        Document classFileCandidate = javaApiJavadocCandidate(
+                "class-file",
+                "ClassFileFormatVersion factory of()",
+                javaUtilJavadocPage("ClassFileFormatVersion.html"));
+        Document firstListCandidate = javaApiJavadocCandidate(
+                "list-first", "static <E> List<E> of(E element)", javaUtilJavadocPage("List.html"));
+        Document secondListCandidate = javaApiJavadocCandidate(
+                "list-second", "static <E> List<E> of(E first, E second)", javaUtilJavadocPage("List.html"));
 
         List<Document> orderedCandidates = CitationCandidateRanker.orderForCitationQuery(
                 "What does Java List.of() return?",
@@ -30,9 +35,10 @@ class CitationCandidateRankerTest {
 
     @Test
     void recognizesUnparenthesizedTypeMethodSelectorsDuringCandidateOrdering() {
-        Document classFileCandidate =
-                javadocCandidate("class-file", "A utility map() method", "ClassFileFormatVersion.html");
-        Document streamCandidate = javadocCandidate("stream", "<R> Stream<R> map(Function mapper)", "Stream.html");
+        Document classFileCandidate = javaApiJavadocCandidate(
+                "class-file", "A utility map() method", javaUtilJavadocPage("ClassFileFormatVersion.html"));
+        Document streamCandidate = javaApiJavadocCandidate(
+                "stream", "<R> Stream<R> map(Function mapper)", javaUtilJavadocPage("Stream.html"));
 
         List<Document> orderedCandidates = CitationCandidateRanker.orderForCitationQuery(
                 "Explain Stream.map in Java", List.of(classFileCandidate, streamCandidate));
@@ -44,10 +50,10 @@ class CitationCandidateRankerTest {
 
     @Test
     void matchesTheDeclaredPackageWhenASelectorIsFullyQualified() {
-        Document sqlDateCandidate = javadocCandidate(
-                "sql-date", "String toString()", "java.sql", "Date.html", DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE);
-        Document utilDateCandidate = javadocCandidate(
-                "util-date", "String toString()", "java.util", "Date.html", DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE);
+        Document sqlDateCandidate =
+                javaApiJavadocCandidate("sql-date", "String toString()", javadocPage("java.sql", "Date.html"));
+        Document utilDateCandidate =
+                javaApiJavadocCandidate("util-date", "String toString()", javaUtilJavadocPage("Date.html"));
 
         List<Document> orderedCandidates = CitationCandidateRanker.orderForCitationQuery(
                 "What does java.util.Date.toString return?", List.of(sqlDateCandidate, utilDateCandidate));
@@ -59,14 +65,10 @@ class CitationCandidateRankerTest {
 
     @Test
     void excludesNonApiDocumentationFromSelectorEvidence() {
-        Document apiMethodOnlyCandidate = javadocCandidate(
-                "api-method",
-                "A utility of() method",
-                "java.lang",
-                "Object.html",
-                DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE);
-        Document tutorialListCandidate = javadocCandidate(
-                "tutorial-list", "static <E> List<E> of(E element)", "java.util", "List.html", "tutorial");
+        Document apiMethodOnlyCandidate =
+                javaApiJavadocCandidate("api-method", "A utility of() method", javadocPage("java.lang", "Object.html"));
+        Document tutorialListCandidate = tutorialJavadocCandidate(
+                "tutorial-list", "static <E> List<E> of(E element)", javaUtilJavadocPage("List.html"));
 
         List<Document> orderedCandidates = CitationCandidateRanker.orderForCitationQuery(
                 "What does List.of return?", List.of(apiMethodOnlyCandidate, tutorialListCandidate));
@@ -78,10 +80,10 @@ class CitationCandidateRankerTest {
 
     @Test
     void treatsMethodDeclarationEvidenceAsCaseSensitive() {
-        Document uppercaseMethodCandidate =
-                javadocCandidate("uppercase-method", "A utility Of() method", "Object.html");
-        Document lowercaseMethodCandidate =
-                javadocCandidate("lowercase-method", "A utility of() method", "Object.html");
+        Document uppercaseMethodCandidate = javaApiJavadocCandidate(
+                "uppercase-method", "A utility Of() method", javaUtilJavadocPage("Object.html"));
+        Document lowercaseMethodCandidate = javaApiJavadocCandidate(
+                "lowercase-method", "A utility of() method", javaUtilJavadocPage("Object.html"));
 
         List<Document> orderedCandidates = CitationCandidateRanker.orderForCitationQuery(
                 "What does List.of return?", List.of(uppercaseMethodCandidate, lowercaseMethodCandidate));
@@ -93,8 +95,9 @@ class CitationCandidateRankerTest {
 
     @Test
     void retainsOriginalQdrantOrderWhenNoSelectorIsPresent() {
-        Document firstCandidate = javadocCandidate("first", "Collection overview", "Collection.html");
-        Document secondCandidate = javadocCandidate("second", "List overview", "List.html");
+        Document firstCandidate =
+                javaApiJavadocCandidate("first", "Collection overview", javaUtilJavadocPage("Collection.html"));
+        Document secondCandidate = javaApiJavadocCandidate("second", "List overview", javaUtilJavadocPage("List.html"));
 
         List<Document> orderedCandidates = CitationCandidateRanker.orderForCitationQuery(
                 "How do Java collections work?", List.of(firstCandidate, secondCandidate));
@@ -119,13 +122,17 @@ class CitationCandidateRankerTest {
                         "What does List.of return?", List.of(malformedCandidate)));
     }
 
-    private static Document javadocCandidate(String documentId, String documentText, String pageFilename) {
-        return javadocCandidate(
-                documentId, documentText, "java.util", pageFilename, DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE);
+    private static Document javaApiJavadocCandidate(String documentId, String documentText, JavadocPage javadocPage) {
+        return javadocCandidateWithDocumentType(
+                documentId, documentText, javadocPage, DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE);
     }
 
-    private static Document javadocCandidate(
-            String documentId, String documentText, String packageName, String pageFilename, String documentType) {
+    private static Document tutorialJavadocCandidate(String documentId, String documentText, JavadocPage javadocPage) {
+        return javadocCandidateWithDocumentType(documentId, documentText, javadocPage, TUTORIAL_DOCUMENT_TYPE);
+    }
+
+    private static Document javadocCandidateWithDocumentType(
+            String documentId, String documentText, JavadocPage javadocPage, String documentType) {
         DocsSourceRegistry.JavaApiDocumentationSource representedJavaApiSource =
                 DocsSourceRegistry.javaApiDocumentationSources().getFirst();
         return Document.builder()
@@ -135,10 +142,20 @@ class CitationCandidateRankerTest {
                         QdrantPayloadFieldSchema.URL_FIELD,
                         representedJavaApiSource.remoteBaseUrl()
                                 + "java.base/"
-                                + packageName.replace('.', '/')
+                                + javadocPage.packageName().replace('.', '/')
                                 + "/"
-                                + pageFilename)
+                                + javadocPage.filename())
                 .metadata(QdrantPayloadFieldSchema.DOC_TYPE_FIELD, documentType)
                 .build();
     }
+
+    private static JavadocPage javaUtilJavadocPage(String filename) {
+        return javadocPage("java.util", filename);
+    }
+
+    private static JavadocPage javadocPage(String packageName, String filename) {
+        return new JavadocPage(packageName, filename);
+    }
+
+    private record JavadocPage(String packageName, String filename) {}
 }

--- a/src/test/java/com/williamcallahan/javachat/service/CitationCandidateRankerTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/CitationCandidateRankerTest.java
@@ -1,0 +1,144 @@
+package com.williamcallahan.javachat.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.williamcallahan.javachat.config.DocsSourceRegistry;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.document.Document;
+
+/** Verifies deterministic local ordering of sparse static-citation candidates. */
+class CitationCandidateRankerTest {
+
+    @Test
+    void prioritizesExactJavadocTypePagesOverHigherRankedMethodOnlyMatches() {
+        Document classFileCandidate =
+                javadocCandidate("class-file", "ClassFileFormatVersion factory of()", "ClassFileFormatVersion.html");
+        Document firstListCandidate = javadocCandidate("list-first", "static <E> List<E> of(E element)", "List.html");
+        Document secondListCandidate =
+                javadocCandidate("list-second", "static <E> List<E> of(E first, E second)", "List.html");
+
+        List<Document> orderedCandidates = CitationCandidateRanker.orderForCitationQuery(
+                "What does Java List.of() return?",
+                List.of(classFileCandidate, firstListCandidate, secondListCandidate));
+
+        assertEquals(
+                List.of("list-first", "list-second", "class-file"),
+                orderedCandidates.stream().map(Document::getId).toList());
+    }
+
+    @Test
+    void recognizesUnparenthesizedTypeMethodSelectorsDuringCandidateOrdering() {
+        Document classFileCandidate =
+                javadocCandidate("class-file", "A utility map() method", "ClassFileFormatVersion.html");
+        Document streamCandidate = javadocCandidate("stream", "<R> Stream<R> map(Function mapper)", "Stream.html");
+
+        List<Document> orderedCandidates = CitationCandidateRanker.orderForCitationQuery(
+                "Explain Stream.map in Java", List.of(classFileCandidate, streamCandidate));
+
+        assertEquals(
+                List.of("stream", "class-file"),
+                orderedCandidates.stream().map(Document::getId).toList());
+    }
+
+    @Test
+    void matchesTheDeclaredPackageWhenASelectorIsFullyQualified() {
+        Document sqlDateCandidate = javadocCandidate(
+                "sql-date", "String toString()", "java.sql", "Date.html", DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE);
+        Document utilDateCandidate = javadocCandidate(
+                "util-date", "String toString()", "java.util", "Date.html", DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE);
+
+        List<Document> orderedCandidates = CitationCandidateRanker.orderForCitationQuery(
+                "What does java.util.Date.toString return?", List.of(sqlDateCandidate, utilDateCandidate));
+
+        assertEquals(
+                List.of("util-date", "sql-date"),
+                orderedCandidates.stream().map(Document::getId).toList());
+    }
+
+    @Test
+    void excludesNonApiDocumentationFromSelectorEvidence() {
+        Document apiMethodOnlyCandidate = javadocCandidate(
+                "api-method",
+                "A utility of() method",
+                "java.lang",
+                "Object.html",
+                DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE);
+        Document tutorialListCandidate = javadocCandidate(
+                "tutorial-list", "static <E> List<E> of(E element)", "java.util", "List.html", "tutorial");
+
+        List<Document> orderedCandidates = CitationCandidateRanker.orderForCitationQuery(
+                "What does List.of return?", List.of(apiMethodOnlyCandidate, tutorialListCandidate));
+
+        assertEquals(
+                List.of("api-method", "tutorial-list"),
+                orderedCandidates.stream().map(Document::getId).toList());
+    }
+
+    @Test
+    void treatsMethodDeclarationEvidenceAsCaseSensitive() {
+        Document uppercaseMethodCandidate =
+                javadocCandidate("uppercase-method", "A utility Of() method", "Object.html");
+        Document lowercaseMethodCandidate =
+                javadocCandidate("lowercase-method", "A utility of() method", "Object.html");
+
+        List<Document> orderedCandidates = CitationCandidateRanker.orderForCitationQuery(
+                "What does List.of return?", List.of(uppercaseMethodCandidate, lowercaseMethodCandidate));
+
+        assertEquals(
+                List.of("lowercase-method", "uppercase-method"),
+                orderedCandidates.stream().map(Document::getId).toList());
+    }
+
+    @Test
+    void retainsOriginalQdrantOrderWhenNoSelectorIsPresent() {
+        Document firstCandidate = javadocCandidate("first", "Collection overview", "Collection.html");
+        Document secondCandidate = javadocCandidate("second", "List overview", "List.html");
+
+        List<Document> orderedCandidates = CitationCandidateRanker.orderForCitationQuery(
+                "How do Java collections work?", List.of(firstCandidate, secondCandidate));
+
+        assertEquals(
+                List.of("first", "second"),
+                orderedCandidates.stream().map(Document::getId).toList());
+    }
+
+    @Test
+    void propagatesMalformedApiDocumentationUrlsInsteadOfSilentlyIgnoringTheirEvidence() {
+        Document malformedCandidate = Document.builder()
+                .id("malformed")
+                .text("static <E> List<E> of(E element)")
+                .metadata(QdrantPayloadFieldSchema.URL_FIELD, "https://docs.example.test/java util/List.html")
+                .metadata(QdrantPayloadFieldSchema.DOC_TYPE_FIELD, DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE)
+                .build();
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> CitationCandidateRanker.orderForCitationQuery(
+                        "What does List.of return?", List.of(malformedCandidate)));
+    }
+
+    private static Document javadocCandidate(String documentId, String documentText, String pageFilename) {
+        return javadocCandidate(
+                documentId, documentText, "java.util", pageFilename, DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE);
+    }
+
+    private static Document javadocCandidate(
+            String documentId, String documentText, String packageName, String pageFilename, String documentType) {
+        DocsSourceRegistry.JavaApiDocumentationSource representedJavaApiSource =
+                DocsSourceRegistry.javaApiDocumentationSources().getFirst();
+        return Document.builder()
+                .id(documentId)
+                .text(documentText)
+                .metadata(
+                        QdrantPayloadFieldSchema.URL_FIELD,
+                        representedJavaApiSource.remoteBaseUrl()
+                                + "java.base/"
+                                + packageName.replace('.', '/')
+                                + "/"
+                                + pageFilename)
+                .metadata(QdrantPayloadFieldSchema.DOC_TYPE_FIELD, documentType)
+                .build();
+    }
+}

--- a/src/test/java/com/williamcallahan/javachat/service/GuidedLearningServiceCitationTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/GuidedLearningServiceCitationTest.java
@@ -251,11 +251,13 @@ class GuidedLearningServiceCitationTest {
         return Document.builder()
                 .id("official-string-source")
                 .text(OFFICIAL_SOURCE_TEXT)
-                .metadata("url", officialSourceUrl(guidedLesson))
-                .metadata("title", "Strings")
-                .metadata("sourceKind", "official")
-                .metadata("docSet", guidedLesson.getDocSet().getFirst())
-                .metadata("docType", "tutorial")
+                .metadata(QdrantPayloadFieldSchema.URL_FIELD, officialSourceUrl(guidedLesson))
+                .metadata(QdrantPayloadFieldSchema.TITLE_FIELD, "Strings")
+                .metadata(QdrantPayloadFieldSchema.SOURCE_KIND_FIELD, "official")
+                .metadata(
+                        QdrantPayloadFieldSchema.DOC_SET_FIELD,
+                        guidedLesson.getDocSet().getFirst())
+                .metadata(QdrantPayloadFieldSchema.DOC_TYPE_FIELD, "tutorial")
                 .build();
     }
 

--- a/src/test/java/com/williamcallahan/javachat/service/HybridSearchServiceTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/HybridSearchServiceTest.java
@@ -113,7 +113,7 @@ class HybridSearchServiceTest {
         QueryPoints capturedQuery = capturedQueries.getFirst();
         assertEquals(77, capturedQuery.getQuery().getRrf().getK());
         assertTrue(capturedQuery.hasFilter());
-        assertTrue(capturedQuery.getFilter().toString().contains("docVersion"));
+        assertTrue(capturedQuery.getFilter().toString().contains(QdrantPayloadFieldSchema.DOC_VERSION_FIELD));
         assertFalse(capturedQuery.getPrefetchList().isEmpty());
         for (PrefetchQuery prefetchQuery : capturedQuery.getPrefetchList()) {
             assertTrue(prefetchQuery.hasFilter());
@@ -166,9 +166,9 @@ class HybridSearchServiceTest {
                 List.of(2, 7), citationQuery.getQuery().getNearest().getSparse().getIndicesList());
         assertTrue(citationQuery.hasFilter());
         String officialFilter = citationQuery.getFilter().toString();
-        assertTrue(officialFilter.contains("sourceKind"));
+        assertTrue(officialFilter.contains(QdrantPayloadFieldSchema.SOURCE_KIND_FIELD));
         assertTrue(officialFilter.contains("official"));
-        assertTrue(officialFilter.contains("docSet"));
+        assertTrue(officialFilter.contains(QdrantPayloadFieldSchema.DOC_SET_FIELD));
         assertTrue(officialFilter.contains(REPRESENTED_JAVA_API_SOURCE.relativeMirrorPath()));
         assertEquals(1, citationSearchOutcome.documents().size());
         assertEquals(
@@ -200,7 +200,7 @@ class HybridSearchServiceTest {
         assertEquals(1, capturedQueries.size());
         assertTrue(capturedQueries.getFirst().hasFilter());
         String versionFilter = capturedQueries.getFirst().getFilter().toString();
-        assertTrue(versionFilter.contains("docVersion"));
+        assertTrue(versionFilter.contains(QdrantPayloadFieldSchema.DOC_VERSION_FIELD));
         assertTrue(versionFilter.contains(REPRESENTED_JAVA_API_SOURCE.javaRelease()));
         verify(sparseEncoder).encode(VERSIONED_SELECTOR_CITATION_QUERY + " List");
         verifyNoInteractions(embeddingClient);
@@ -388,9 +388,13 @@ class HybridSearchServiceTest {
         return ScoredPoint.newBuilder()
                 .setId(io.qdrant.client.PointIdFactory.id(SCORED_POINT_UUID))
                 .setScore(0.9f)
-                .putPayload("doc_content", io.qdrant.client.ValueFactory.value("Java stream examples"))
-                .putPayload("url", io.qdrant.client.ValueFactory.value("https://docs.example.com/java/streams"))
-                .putPayload("title", io.qdrant.client.ValueFactory.value("Streams"))
+                .putPayload(
+                        QdrantPayloadFieldSchema.DOC_CONTENT_FIELD,
+                        io.qdrant.client.ValueFactory.value("Java stream examples"))
+                .putPayload(
+                        QdrantPayloadFieldSchema.URL_FIELD,
+                        io.qdrant.client.ValueFactory.value("https://docs.example.com/java/streams"))
+                .putPayload(QdrantPayloadFieldSchema.TITLE_FIELD, io.qdrant.client.ValueFactory.value("Streams"))
                 .build();
     }
 }

--- a/src/test/java/com/williamcallahan/javachat/service/HybridSearchServiceTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/HybridSearchServiceTest.java
@@ -21,6 +21,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.SettableFuture;
 import com.williamcallahan.javachat.application.search.LexicalSparseVectorEncoder;
 import com.williamcallahan.javachat.config.AppProperties;
+import com.williamcallahan.javachat.config.DocsSourceRegistry;
 import com.williamcallahan.javachat.config.QdrantGitHubCollectionDiscovery;
 import com.williamcallahan.javachat.support.logging.ExpectedLogEvents;
 import io.qdrant.client.QdrantClient;
@@ -48,8 +49,14 @@ class HybridSearchServiceTest {
             "[QDRANT] Search failed for collection=java-chat-books (exceptionType=RuntimeException)";
     private static final String CITATION_COLLECTION_FAILURE_WARNING =
             "[QDRANT] Search failed for collection=java-docs (exceptionType=RuntimeException)";
-    private static final String HYBRID_QUERY = "Java 25 streams";
+    private static final DocsSourceRegistry.JavaApiDocumentationSource REPRESENTED_JAVA_API_SOURCE =
+            DocsSourceRegistry.javaApiDocumentationSources().getFirst();
+    private static final List<String> OFFICIAL_DOCUMENTATION_SOURCE_IDENTITIES =
+            DocsSourceRegistry.officialDocumentationSourceIdentities();
+    private static final String HYBRID_QUERY = "Java " + REPRESENTED_JAVA_API_SOURCE.javaRelease() + " streams";
     private static final String CITATION_QUERY = "Java records";
+    private static final String VERSIONED_SELECTOR_CITATION_QUERY =
+            "Java " + REPRESENTED_JAVA_API_SOURCE.javaRelease() + " List.of";
     private static final Duration DISPATCH_BUDGET_TEST_TIMEOUT = Duration.ofMillis(500);
     private static final long FIRST_DISPATCH_DELAY_MILLIS = 50;
     private static final Duration SHARED_QUERY_TIMEOUT = Duration.ofMillis(150);
@@ -92,7 +99,8 @@ class HybridSearchServiceTest {
                 .queryAsync(notNull(), notNull());
 
         HybridSearchService hybridSearchService = buildSearchService();
-        RetrievalConstraint retrievalConstraint = RetrievalConstraint.forDocVersion("25");
+        RetrievalConstraint retrievalConstraint =
+                RetrievalConstraint.forDocVersion(REPRESENTED_JAVA_API_SOURCE.javaRelease());
 
         hybridSearchService.searchOutcome(HYBRID_QUERY, 5, retrievalConstraint);
 
@@ -133,7 +141,7 @@ class HybridSearchServiceTest {
 
         HybridSearchService hybridSearchService = buildSearchServiceWithGitHubDiscovery(gitHubCollectionDiscovery);
         RetrievalConstraint officialDocumentationConstraint =
-                RetrievalConstraint.forOfficialDocSets(List.of("dev-java", "java/java25-complete"));
+                RetrievalConstraint.forOfficialDocSets(OFFICIAL_DOCUMENTATION_SOURCE_IDENTITIES);
 
         HybridSearchService.SearchOutcome citationSearchOutcome =
                 hybridSearchService.searchDocumentationCitationsOutcome(
@@ -161,7 +169,7 @@ class HybridSearchServiceTest {
         assertTrue(officialFilter.contains("sourceKind"));
         assertTrue(officialFilter.contains("official"));
         assertTrue(officialFilter.contains("docSet"));
-        assertTrue(officialFilter.contains("dev-java"));
+        assertTrue(officialFilter.contains(REPRESENTED_JAVA_API_SOURCE.relativeMirrorPath()));
         assertEquals(1, citationSearchOutcome.documents().size());
         assertEquals(
                 appProperties.getQdrant().getCollections().getDocs(),
@@ -169,6 +177,33 @@ class HybridSearchServiceTest {
         verifyNoInteractions(embeddingClient);
         verify(gitHubCollectionDiscovery, never()).getDiscoveredCollections();
         verify(qdrantClient, never()).queryAsync(any(QueryPoints.class));
+    }
+
+    @Test
+    void citationSearchExpandsSelectorsWithoutDroppingItsExactVersionFilter() {
+        when(sparseEncoder.encode(VERSIONED_SELECTOR_CITATION_QUERY + " List"))
+                .thenReturn(new LexicalSparseVectorEncoder.SparseVector(List.of(2L, 7L), List.of(3.0f, 1.0f)));
+        List<QueryPoints> capturedQueries = new ArrayList<>();
+        doAnswer(invocation -> {
+                    capturedQueries.add(invocation.getArgument(0));
+                    return Futures.immediateFuture(List.of());
+                })
+                .when(qdrantClient)
+                .queryAsync(notNull(), notNull());
+
+        HybridSearchService hybridSearchService = buildSearchService();
+        hybridSearchService.searchDocumentationCitationsOutcome(
+                VERSIONED_SELECTOR_CITATION_QUERY,
+                3,
+                RetrievalConstraint.forDocVersion(REPRESENTED_JAVA_API_SOURCE.javaRelease()));
+
+        assertEquals(1, capturedQueries.size());
+        assertTrue(capturedQueries.getFirst().hasFilter());
+        String versionFilter = capturedQueries.getFirst().getFilter().toString();
+        assertTrue(versionFilter.contains("docVersion"));
+        assertTrue(versionFilter.contains(REPRESENTED_JAVA_API_SOURCE.javaRelease()));
+        verify(sparseEncoder).encode(VERSIONED_SELECTOR_CITATION_QUERY + " List");
+        verifyNoInteractions(embeddingClient);
     }
 
     @Test
@@ -181,7 +216,7 @@ class HybridSearchServiceTest {
                 .queryAsync(notNull(), notNull());
         HybridSearchService hybridSearchService = buildSearchService();
         RetrievalConstraint officialDocumentationConstraint =
-                RetrievalConstraint.forOfficialDocSets(List.of("dev-java"));
+                RetrievalConstraint.forOfficialDocSets(OFFICIAL_DOCUMENTATION_SOURCE_IDENTITIES);
 
         HybridSearchPartialFailureException citationSearchFailure;
         try (ExpectedLogEvents expectedLogEvents = ExpectedLogEvents.capture(HYBRID_SEARCH_LOGGER)) {

--- a/src/test/java/com/williamcallahan/javachat/service/QdrantRetrievalConstraintBuilderTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/QdrantRetrievalConstraintBuilderTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.williamcallahan.javachat.config.DocsSourceRegistry;
 import io.qdrant.client.grpc.Common.Condition;
 import io.qdrant.client.grpc.Common.Filter;
 import java.util.List;
@@ -27,9 +28,15 @@ class QdrantRetrievalConstraintBuilderTest {
 
     @Test
     void buildsMustConditionsForConstrainedInput() {
-        List<String> allowedDocSet = List.of("dev-java", "java/java25-complete");
-        RetrievalConstraint retrievalConstraint =
-                new RetrievalConstraint("25", "official", "api-docs", "", allowedDocSet);
+        DocsSourceRegistry.JavaApiDocumentationSource representedJavaApiSource =
+                DocsSourceRegistry.javaApiDocumentationSources().getFirst();
+        List<String> allowedDocSet = DocsSourceRegistry.officialDocumentationSourceIdentities();
+        RetrievalConstraint retrievalConstraint = new RetrievalConstraint(
+                representedJavaApiSource.javaRelease(),
+                "official",
+                DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE,
+                "",
+                allowedDocSet);
         Optional<Filter> optionalFilter = builder.buildFilter(retrievalConstraint);
 
         assertTrue(optionalFilter.isPresent());

--- a/src/test/java/com/williamcallahan/javachat/service/QdrantRetrievalConstraintBuilderTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/QdrantRetrievalConstraintBuilderTest.java
@@ -41,12 +41,12 @@ class QdrantRetrievalConstraintBuilderTest {
         assertTrue(optionalFilter.isPresent());
         Filter qdrantFilter = optionalFilter.get();
         assertFalse(qdrantFilter.getMustList().isEmpty());
-        assertTrue(qdrantFilter.toString().contains("docVersion"));
-        assertTrue(qdrantFilter.toString().contains("sourceKind"));
-        assertTrue(qdrantFilter.toString().contains("docType"));
+        assertTrue(qdrantFilter.toString().contains(QdrantPayloadFieldSchema.DOC_VERSION_FIELD));
+        assertTrue(qdrantFilter.toString().contains(QdrantPayloadFieldSchema.SOURCE_KIND_FIELD));
+        assertTrue(qdrantFilter.toString().contains(QdrantPayloadFieldSchema.DOC_TYPE_FIELD));
         Condition docSetCondition = qdrantFilter.getMustList().stream()
-                .filter(mustCondition ->
-                        "docSet".equals(mustCondition.getField().getKey()))
+                .filter(mustCondition -> QdrantPayloadFieldSchema.DOC_SET_FIELD.equals(
+                        mustCondition.getField().getKey()))
                 .findFirst()
                 .orElseThrow();
         assertEquals(

--- a/src/test/java/com/williamcallahan/javachat/service/QdrantRetrievalConstraintBuilderTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/QdrantRetrievalConstraintBuilderTest.java
@@ -17,6 +17,9 @@ import org.junit.jupiter.api.Test;
  */
 class QdrantRetrievalConstraintBuilderTest {
 
+    private static final String OFFICIAL_DOCUMENTATION_SOURCE_KIND = "official";
+    private static final String UNCONSTRAINED_SOURCE_NAME = "";
+
     private final QdrantRetrievalConstraintBuilder builder = new QdrantRetrievalConstraintBuilder();
 
     @Test
@@ -30,13 +33,9 @@ class QdrantRetrievalConstraintBuilderTest {
     void buildsMustConditionsForConstrainedInput() {
         DocsSourceRegistry.JavaApiDocumentationSource representedJavaApiSource =
                 DocsSourceRegistry.javaApiDocumentationSources().getFirst();
-        List<String> allowedDocSet = DocsSourceRegistry.officialDocumentationSourceIdentities();
-        RetrievalConstraint retrievalConstraint = new RetrievalConstraint(
-                representedJavaApiSource.javaRelease(),
-                "official",
-                DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE,
-                "",
-                allowedDocSet);
+        List<String> allowedDocumentationSets = DocsSourceRegistry.officialDocumentationSourceIdentities();
+        RetrievalConstraint retrievalConstraint =
+                officialJavaApiRetrievalConstraint(representedJavaApiSource, allowedDocumentationSets);
         Optional<Filter> optionalFilter = builder.buildFilter(retrievalConstraint);
 
         assertTrue(optionalFilter.isPresent());
@@ -51,12 +50,22 @@ class QdrantRetrievalConstraintBuilderTest {
                 .findFirst()
                 .orElseThrow();
         assertEquals(
-                allowedDocSet,
+                allowedDocumentationSets,
                 docSetCondition.getField().getMatch().getKeywords().getStringsList());
     }
 
     @Test
     void rejectsEmptyOfficialDocSetConstraint() {
         assertThrows(IllegalArgumentException.class, () -> RetrievalConstraint.forOfficialDocSets(List.of()));
+    }
+
+    private static RetrievalConstraint officialJavaApiRetrievalConstraint(
+            DocsSourceRegistry.JavaApiDocumentationSource javaApiDocumentationSource,
+            List<String> allowedDocumentationSets) {
+        String documentVersion = javaApiDocumentationSource.javaRelease();
+        String sourceKind = OFFICIAL_DOCUMENTATION_SOURCE_KIND;
+        String documentType = DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE;
+        String sourceName = UNCONSTRAINED_SOURCE_NAME;
+        return new RetrievalConstraint(documentVersion, sourceKind, documentType, sourceName, allowedDocumentationSets);
     }
 }

--- a/src/test/java/com/williamcallahan/javachat/service/RetrievalServiceCitationTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/RetrievalServiceCitationTest.java
@@ -96,7 +96,7 @@ class RetrievalServiceCitationTest {
                 .text("return equals(this.SomeField, r.OTHER_FIELD);")
                 .metadata("url", recordJavadocUrl)
                 .metadata("package", "java.lang")
-                .metadata("docType", "api-docs")
+                .metadata("docType", DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE)
                 .build();
 
         RetrievalService.CitationOutcome citationOutcome = citationService().toCitations(List.of(recordDocument));
@@ -198,7 +198,7 @@ class RetrievalServiceCitationTest {
 
         Document validDocument =
                 Document.builder().id("valid-doc").text("Valid snippet").build();
-        validDocument.getMetadata().put("url", "https://docs.oracle.com/javase/8/docs/api/java/lang/String.html");
+        validDocument.getMetadata().put("url", javaLangStringJavadocUrl());
         validDocument.getMetadata().put("title", "String");
 
         RetrievalService.CitationOutcome citationOutcome;
@@ -249,7 +249,7 @@ class RetrievalServiceCitationTest {
                 .text(sourceText)
                 .metadata("url", javaLangStringJavadocUrl())
                 .metadata("package", "java.lang")
-                .metadata("docType", "api-docs")
+                .metadata("docType", DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE)
                 .build();
     }
 

--- a/src/test/java/com/williamcallahan/javachat/service/RetrievalServiceCitationTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/RetrievalServiceCitationTest.java
@@ -71,9 +71,9 @@ class RetrievalServiceCitationTest {
         Document encodedAnchorDocument = Document.builder()
                 .id("encoded-anchor-document")
                 .text("Array method reference")
-                .metadata("url", citationPageUrl + "#" + encodedCitationAnchor)
-                .metadata("title", "Array method")
-                .metadata("docType", "tutorial")
+                .metadata(QdrantPayloadFieldSchema.URL_FIELD, citationPageUrl + "#" + encodedCitationAnchor)
+                .metadata(QdrantPayloadFieldSchema.TITLE_FIELD, "Array method")
+                .metadata(QdrantPayloadFieldSchema.DOC_TYPE_FIELD, "tutorial")
                 .build();
 
         Citation projectedCitation = citationService()
@@ -94,9 +94,9 @@ class RetrievalServiceCitationTest {
         Document recordDocument = Document.builder()
                 .id("record-equals-invocation")
                 .text("return equals(this.SomeField, r.OTHER_FIELD);")
-                .metadata("url", recordJavadocUrl)
-                .metadata("package", "java.lang")
-                .metadata("docType", DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE)
+                .metadata(QdrantPayloadFieldSchema.URL_FIELD, recordJavadocUrl)
+                .metadata(QdrantPayloadFieldSchema.PACKAGE_FIELD, "java.lang")
+                .metadata(QdrantPayloadFieldSchema.DOC_TYPE_FIELD, DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE)
                 .build();
 
         RetrievalService.CitationOutcome citationOutcome = citationService().toCitations(List.of(recordDocument));
@@ -113,9 +113,9 @@ class RetrievalServiceCitationTest {
         Document tutorialDocument = Document.builder()
                 .id("tutorial-substring-chunk")
                 .text("substring(int,int)")
-                .metadata("url", stringJavadocUrl)
-                .metadata("package", "java.lang")
-                .metadata("docType", "tutorial")
+                .metadata(QdrantPayloadFieldSchema.URL_FIELD, stringJavadocUrl)
+                .metadata(QdrantPayloadFieldSchema.PACKAGE_FIELD, "java.lang")
+                .metadata(QdrantPayloadFieldSchema.DOC_TYPE_FIELD, "tutorial")
                 .build();
 
         RetrievalService.CitationOutcome citationOutcome = citationService().toCitations(List.of(tutorialDocument));
@@ -134,9 +134,9 @@ class RetrievalServiceCitationTest {
         Document tutorialDocument = Document.builder()
                 .id("tutorial-map-entry-chunk")
                 .text("Map.Entry")
-                .metadata("url", mapJavadocUrl)
-                .metadata("package", "java.util")
-                .metadata("docType", "tutorial")
+                .metadata(QdrantPayloadFieldSchema.URL_FIELD, mapJavadocUrl)
+                .metadata(QdrantPayloadFieldSchema.PACKAGE_FIELD, "java.util")
+                .metadata(QdrantPayloadFieldSchema.DOC_TYPE_FIELD, "tutorial")
                 .build();
 
         RetrievalService.CitationOutcome citationOutcome = citationService().toCitations(List.of(tutorialDocument));
@@ -169,12 +169,12 @@ class RetrievalServiceCitationTest {
                         Document.builder()
                                 .id("first-pdf-page-chunk")
                                 .text("First PDF page")
-                                .metadata("url", pdfCitationUrl + "#page=1")
+                                .metadata(QdrantPayloadFieldSchema.URL_FIELD, pdfCitationUrl + "#page=1")
                                 .build(),
                         Document.builder()
                                 .id("second-pdf-page-chunk")
                                 .text("Second PDF page")
-                                .metadata("url", pdfCitationUrl + "#page=2")
+                                .metadata(QdrantPayloadFieldSchema.URL_FIELD, pdfCitationUrl + "#page=2")
                                 .build()));
 
         assertEquals(
@@ -193,13 +193,13 @@ class RetrievalServiceCitationTest {
                 .id("malformed-doc")
                 .text("Malformed metadata")
                 .build();
-        malformedDocument.getMetadata().put("url", new BrokenUrlValue());
-        malformedDocument.getMetadata().put("title", "Broken citation");
+        malformedDocument.getMetadata().put(QdrantPayloadFieldSchema.URL_FIELD, new BrokenUrlValue());
+        malformedDocument.getMetadata().put(QdrantPayloadFieldSchema.TITLE_FIELD, "Broken citation");
 
         Document validDocument =
                 Document.builder().id("valid-doc").text("Valid snippet").build();
-        validDocument.getMetadata().put("url", javaLangStringJavadocUrl());
-        validDocument.getMetadata().put("title", "String");
+        validDocument.getMetadata().put(QdrantPayloadFieldSchema.URL_FIELD, javaLangStringJavadocUrl());
+        validDocument.getMetadata().put(QdrantPayloadFieldSchema.TITLE_FIELD, "String");
 
         RetrievalService.CitationOutcome citationOutcome;
         try (ExpectedLogEvents expectedLogEvents = ExpectedLogEvents.capture(RETRIEVAL_SERVICE_LOGGER)) {
@@ -247,9 +247,9 @@ class RetrievalServiceCitationTest {
         return Document.builder()
                 .id(documentId)
                 .text(sourceText)
-                .metadata("url", javaLangStringJavadocUrl())
-                .metadata("package", "java.lang")
-                .metadata("docType", DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE)
+                .metadata(QdrantPayloadFieldSchema.URL_FIELD, javaLangStringJavadocUrl())
+                .metadata(QdrantPayloadFieldSchema.PACKAGE_FIELD, "java.lang")
+                .metadata(QdrantPayloadFieldSchema.DOC_TYPE_FIELD, DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE)
                 .build();
     }
 

--- a/src/test/java/com/williamcallahan/javachat/service/RetrievalServiceTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/RetrievalServiceTest.java
@@ -25,6 +25,11 @@ import org.springframework.ai.document.Document;
  */
 class RetrievalServiceTest {
 
+    private static final DocsSourceRegistry.JavaApiDocumentationSource REPRESENTED_JAVA_API_SOURCE =
+            DocsSourceRegistry.javaApiDocumentationSources().getFirst();
+    private static final List<String> OFFICIAL_DOCUMENTATION_SOURCE_IDENTITIES =
+            DocsSourceRegistry.officialDocumentationSourceIdentities();
+
     @Test
     void constrainedRetrievalPassesTheCallerConstraintInstanceToHybridSearch() {
         HybridSearchService hybridSearchService = mock(HybridSearchService.class);
@@ -32,7 +37,7 @@ class RetrievalServiceTest {
         RetrievalService retrievalService = new RetrievalService(
                 hybridSearchService, new AppProperties(), rerankerService, mock(DocumentFactory.class));
         RetrievalConstraint guidedConstraint =
-                RetrievalConstraint.forOfficialDocSets(List.of("dev-java", "java/java25-complete"));
+                RetrievalConstraint.forOfficialDocSets(OFFICIAL_DOCUMENTATION_SOURCE_IDENTITIES);
         when(hybridSearchService.searchOutcome(anyString(), anyInt(), same(guidedConstraint)))
                 .thenReturn(new HybridSearchService.SearchOutcome(List.of(), List.of()));
         when(rerankerService.rerank(anyString(), anyList(), anyInt())).thenReturn(List.of());
@@ -49,16 +54,18 @@ class RetrievalServiceTest {
         RetrievalService retrievalService = new RetrievalService(
                 hybridSearchService, new AppProperties(), rerankerService, mock(DocumentFactory.class));
         RetrievalConstraint officialDocumentationConstraint =
-                RetrievalConstraint.forOfficialDocSets(List.of("dev-java", "java/java17-complete"));
-        RetrievalConstraint expectedCombinedConstraint = officialDocumentationConstraint.withDocVersion("17");
+                RetrievalConstraint.forOfficialDocSets(OFFICIAL_DOCUMENTATION_SOURCE_IDENTITIES);
+        RetrievalConstraint expectedCombinedConstraint =
+                officialDocumentationConstraint.withDocVersion(REPRESENTED_JAVA_API_SOURCE.javaRelease());
+        String versionedQuery = "Java " + REPRESENTED_JAVA_API_SOURCE.javaRelease() + " List.of";
         when(hybridSearchService.searchOutcome(anyString(), anyInt(), eq(expectedCombinedConstraint)))
                 .thenReturn(new HybridSearchService.SearchOutcome(List.of(), List.of()));
         when(rerankerService.rerank(anyString(), anyList(), anyInt())).thenReturn(List.of());
 
-        retrievalService.retrieveOutcome("Java 17 List.of", officialDocumentationConstraint);
+        retrievalService.retrieveOutcome(versionedQuery, officialDocumentationConstraint);
 
         verify(hybridSearchService).searchOutcome(anyString(), anyInt(), eq(expectedCombinedConstraint));
-        assertEquals("17", expectedCombinedConstraint.docVersion());
+        assertEquals(REPRESENTED_JAVA_API_SOURCE.javaRelease(), expectedCombinedConstraint.docVersion());
         assertEquals("official", expectedCombinedConstraint.sourceKind());
         assertEquals(officialDocumentationConstraint.docSet(), expectedCombinedConstraint.docSet());
     }
@@ -73,7 +80,7 @@ class RetrievalServiceTest {
         RetrievalService retrievalService =
                 new RetrievalService(hybridSearchService, appProperties, rerankerService, mock(DocumentFactory.class));
         RetrievalConstraint guidedConstraint =
-                RetrievalConstraint.forOfficialDocSets(List.of("dev-java", "java/java25-complete"));
+                RetrievalConstraint.forOfficialDocSets(OFFICIAL_DOCUMENTATION_SOURCE_IDENTITIES);
         String repeatedCitationUrl = "https://docs.example.test/String.html#substring(int,int)";
         String uniqueCitationUrl = "https://docs.example.test/List.html#get(int)";
         List<Document> citationCandidates = List.of(
@@ -107,22 +114,59 @@ class RetrievalServiceTest {
     }
 
     @Test
+    void citationDiscoveryReranksATypePageBeyondTheFirstThreeCandidatesBeforeFinalLimiting() {
+        HybridSearchService hybridSearchService = mock(HybridSearchService.class);
+        RerankerService rerankerService = mock(RerankerService.class);
+        AppProperties appProperties = new AppProperties();
+        appProperties.getRag().setSearchTopK(4);
+        appProperties.getRag().setSearchCitations(3);
+        RetrievalService retrievalService =
+                new RetrievalService(hybridSearchService, appProperties, rerankerService, mock(DocumentFactory.class));
+        RetrievalConstraint officialDocumentationConstraint =
+                RetrievalConstraint.forOfficialDocSets(OFFICIAL_DOCUMENTATION_SOURCE_IDENTITIES);
+        String citationQuery = "What does List.of return?";
+        String listPageUrl = javaApiPageUrl("java.util", "List.html");
+        List<Document> qdrantCandidates = List.of(
+                apiDocumentationCitationCandidate(
+                        "object", "A utility of() method", javaApiPageUrl("java.lang", "Object.html")),
+                apiDocumentationCitationCandidate(
+                        "string", "A utility of() method", javaApiPageUrl("java.lang", "String.html")),
+                apiDocumentationCitationCandidate(
+                        "integer", "A utility of() method", javaApiPageUrl("java.lang", "Integer.html")),
+                apiDocumentationCitationCandidate("list", "static <E> List<E> of(E element)", listPageUrl));
+        when(hybridSearchService.searchDocumentationCitationsOutcome(
+                        eq(citationQuery), eq(4), same(officialDocumentationConstraint)))
+                .thenReturn(new HybridSearchService.SearchOutcome(qdrantCandidates, List.of()));
+
+        RetrievalService.CitationOutcome citationOutcome =
+                retrievalService.discoverCitations(citationQuery, officialDocumentationConstraint);
+
+        assertEquals(3, citationOutcome.citations().size());
+        assertEquals(listPageUrl, citationOutcome.citations().getFirst().getUrl());
+        assertTrue(citationOutcome.citations().stream().anyMatch(citation -> listPageUrl.equals(citation.getUrl())));
+        assertEquals(0, citationOutcome.failedConversionCount());
+        verify(rerankerService, never()).rerank(anyString(), anyList(), anyInt());
+    }
+
+    @Test
     void versionedCitationDiscoveryCombinesOfficialScopeAndQueryVersionBeforeDispatch() {
         HybridSearchService hybridSearchService = mock(HybridSearchService.class);
         RerankerService rerankerService = mock(RerankerService.class);
         RetrievalService retrievalService = new RetrievalService(
                 hybridSearchService, new AppProperties(), rerankerService, mock(DocumentFactory.class));
         RetrievalConstraint officialDocumentationConstraint =
-                RetrievalConstraint.forOfficialDocSets(List.of("dev-java", "java/java17-complete"));
-        RetrievalConstraint expectedCombinedConstraint = officialDocumentationConstraint.withDocVersion("17");
+                RetrievalConstraint.forOfficialDocSets(OFFICIAL_DOCUMENTATION_SOURCE_IDENTITIES);
+        RetrievalConstraint expectedCombinedConstraint =
+                officialDocumentationConstraint.withDocVersion(REPRESENTED_JAVA_API_SOURCE.javaRelease());
+        String citationQuery = "Java " + REPRESENTED_JAVA_API_SOURCE.javaRelease() + " List.of";
         when(hybridSearchService.searchDocumentationCitationsOutcome(
-                        anyString(), anyInt(), eq(expectedCombinedConstraint)))
+                        eq(citationQuery), anyInt(), eq(expectedCombinedConstraint)))
                 .thenReturn(new HybridSearchService.SearchOutcome(List.of(), List.of()));
 
-        retrievalService.discoverCitations("Java 17 List.of", officialDocumentationConstraint);
+        retrievalService.discoverCitations(citationQuery, officialDocumentationConstraint);
 
         verify(hybridSearchService)
-                .searchDocumentationCitationsOutcome(anyString(), anyInt(), eq(expectedCombinedConstraint));
+                .searchDocumentationCitationsOutcome(eq(citationQuery), anyInt(), eq(expectedCombinedConstraint));
         verify(rerankerService, never()).rerank(anyString(), anyList(), anyInt());
     }
 
@@ -134,7 +178,8 @@ class RetrievalServiceTest {
         appProperties.getRag().setSearchCitations(0);
         RetrievalService retrievalService =
                 new RetrievalService(hybridSearchService, appProperties, rerankerService, mock(DocumentFactory.class));
-        RetrievalConstraint guidedConstraint = RetrievalConstraint.forOfficialDocSets(List.of("dev-java"));
+        RetrievalConstraint guidedConstraint =
+                RetrievalConstraint.forOfficialDocSets(OFFICIAL_DOCUMENTATION_SOURCE_IDENTITIES);
 
         RetrievalService.CitationOutcome citationOutcome =
                 retrievalService.discoverCitations("Java strings", guidedConstraint);
@@ -153,7 +198,7 @@ class RetrievalServiceTest {
         RetrievalService retrievalService = new RetrievalService(
                 hybridSearchService, new AppProperties(), rerankerService, mock(DocumentFactory.class));
         RetrievalConstraint guidedConstraint =
-                RetrievalConstraint.forOfficialDocSets(List.of("dev-java", "java/java25-complete"));
+                RetrievalConstraint.forOfficialDocSets(OFFICIAL_DOCUMENTATION_SOURCE_IDENTITIES);
         HybridSearchPartialFailureException.CollectionSearchFailure collectionFailure =
                 new HybridSearchPartialFailureException.CollectionSearchFailure("java-docs", "Timeout", "5s");
         when(hybridSearchService.searchDocumentationCitationsOutcome(anyString(), anyInt(), same(guidedConstraint)))
@@ -174,6 +219,24 @@ class RetrievalServiceTest {
                 .metadata("hash", contentHash)
                 .metadata("url", sourceUrl)
                 .build();
+    }
+
+    private static Document apiDocumentationCitationCandidate(
+            String documentId, String documentText, String sourceUrl) {
+        return Document.builder()
+                .id(documentId)
+                .text(documentText)
+                .metadata(QdrantPayloadFieldSchema.URL_FIELD, sourceUrl)
+                .metadata(QdrantPayloadFieldSchema.DOC_TYPE_FIELD, DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE)
+                .build();
+    }
+
+    private static String javaApiPageUrl(String packageName, String pageFilename) {
+        return REPRESENTED_JAVA_API_SOURCE.remoteBaseUrl()
+                + "java.base/"
+                + packageName.replace('.', '/')
+                + "/"
+                + pageFilename;
     }
 
     @Test

--- a/src/test/java/com/williamcallahan/javachat/service/RetrievalServiceTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/RetrievalServiceTest.java
@@ -216,8 +216,8 @@ class RetrievalServiceTest {
         return Document.builder()
                 .id(documentId)
                 .text(sourceText)
-                .metadata("hash", contentHash)
-                .metadata("url", sourceUrl)
+                .metadata(QdrantPayloadFieldSchema.HASH_FIELD, contentHash)
+                .metadata(QdrantPayloadFieldSchema.URL_FIELD, sourceUrl)
                 .build();
     }
 
@@ -250,8 +250,10 @@ class RetrievalServiceTest {
 
         Document candidateDocument =
                 Document.builder().id("candidate-1").text("Stream tutorial").build();
-        candidateDocument.getMetadata().put("url", "https://docs.example.com/java/streams");
-        candidateDocument.getMetadata().put("hash", "hash-1");
+        candidateDocument
+                .getMetadata()
+                .put(QdrantPayloadFieldSchema.URL_FIELD, "https://docs.example.com/java/streams");
+        candidateDocument.getMetadata().put(QdrantPayloadFieldSchema.HASH_FIELD, "hash-1");
 
         HybridSearchService.HybridSearchNotice searchNotice =
                 new HybridSearchService.HybridSearchNotice("Partial retrieval failure", "Timeout: java-docs");
@@ -282,30 +284,30 @@ class RetrievalServiceTest {
         Document urlOnlyDocument = Document.builder()
                 .id("url-only")
                 .text("URL-only candidate")
-                .metadata("url", "https://example.org/java/reference")
+                .metadata(QdrantPayloadFieldSchema.URL_FIELD, "https://example.org/java/reference")
                 .build();
         Document canonicalUrlDuplicateWithoutHash = Document.builder()
                 .id("url-only-duplicate")
                 .text("URL-only duplicate candidate")
-                .metadata("url", "https://example.org//java/reference")
+                .metadata(QdrantPayloadFieldSchema.URL_FIELD, "https://example.org//java/reference")
                 .build();
         Document firstJavadocChunk = Document.builder()
                 .id("first-javadoc-chunk")
                 .text("First Javadoc chunk")
-                .metadata("url", stringJavadocUrl)
-                .metadata("hash", "first-content-hash")
+                .metadata(QdrantPayloadFieldSchema.URL_FIELD, stringJavadocUrl)
+                .metadata(QdrantPayloadFieldSchema.HASH_FIELD, "first-content-hash")
                 .build();
         Document secondJavadocChunkWithDistinctHash = Document.builder()
                 .id("second-javadoc-chunk")
                 .text("Second Javadoc chunk")
-                .metadata("url", stringJavadocUrl + "#assert(...)")
-                .metadata("hash", "second-content-hash")
+                .metadata(QdrantPayloadFieldSchema.URL_FIELD, stringJavadocUrl + "#assert(...)")
+                .metadata(QdrantPayloadFieldSchema.HASH_FIELD, "second-content-hash")
                 .build();
         Document sameContentHashWithDifferentUrl = Document.builder()
                 .id("same-content-hash")
                 .text("Duplicate content under another URL")
-                .metadata("url", javaApiBaseUrl + "java.base/java/lang/Object.html")
-                .metadata("hash", "first-content-hash")
+                .metadata(QdrantPayloadFieldSchema.URL_FIELD, javaApiBaseUrl + "java.base/java/lang/Object.html")
+                .metadata(QdrantPayloadFieldSchema.HASH_FIELD, "first-content-hash")
                 .build();
         List<Document> retrievalCandidates = List.of(
                 urlOnlyDocument,
@@ -348,12 +350,12 @@ class RetrievalServiceTest {
         Document firstUnmappedLocalDocument = Document.builder()
                 .id("first-unmapped-local")
                 .text("First local document")
-                .metadata("url", firstUnmappedLocalUrl)
+                .metadata(QdrantPayloadFieldSchema.URL_FIELD, firstUnmappedLocalUrl)
                 .build();
         Document secondUnmappedLocalDocument = Document.builder()
                 .id("second-unmapped-local")
                 .text("Second local document")
-                .metadata("url", secondUnmappedLocalUrl)
+                .metadata(QdrantPayloadFieldSchema.URL_FIELD, secondUnmappedLocalUrl)
                 .build();
         List<Document> retrievalCandidates = List.of(firstUnmappedLocalDocument, secondUnmappedLocalDocument);
         when(hybridSearchService.searchOutcome(anyString(), anyInt(), any(RetrievalConstraint.class)))

--- a/src/test/java/com/williamcallahan/javachat/service/ingestion/IngestionProvenanceDeriverTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/ingestion/IngestionProvenanceDeriverTest.java
@@ -35,11 +35,39 @@ class IngestionProvenanceDeriverTest {
     }
 
     @Test
+    void projectsTheCanonicalJavaApiDocumentTypeForJavaApiMirrors() {
+        IngestionProvenanceDeriver provenanceDeriver = new IngestionProvenanceDeriver();
+        Path documentationRoot = Path.of("data", "docs").toAbsolutePath().normalize();
+        DocsSourceRegistry.JavaApiDocumentationSource javaApiDocumentationSource =
+                DocsSourceRegistry.javaApiDocumentationSources().getFirst();
+        Path javaApiDocument = documentationRoot
+                .resolve(javaApiDocumentationSource.relativeMirrorPath())
+                .resolve("index.html");
+
+        IngestionProvenance provenance = provenanceDeriver.derive(
+                documentationRoot, javaApiDocument, javaApiDocumentationSource.remoteBaseUrl());
+
+        assertEquals(DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE, provenance.docType());
+    }
+
+    @Test
     void canonicalFingerprintEncodingSeparatesControlCharactersFromFieldBoundaries() {
-        IngestionProvenance embeddedSeparatorProvenance =
-                new IngestionProvenance("alpha\u001fbeta", "gamma", "oracle", "official", "21", "api-docs");
-        IngestionProvenance shiftedSeparatorProvenance =
-                new IngestionProvenance("beta", "gamma", "oracle", "official", "21", "api-docs");
+        String representedJavaRelease =
+                DocsSourceRegistry.javaApiDocumentationSources().getFirst().javaRelease();
+        IngestionProvenance embeddedSeparatorProvenance = new IngestionProvenance(
+                "alpha\u001fbeta",
+                "gamma",
+                "oracle",
+                "official",
+                representedJavaRelease,
+                DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE);
+        IngestionProvenance shiftedSeparatorProvenance = new IngestionProvenance(
+                "beta",
+                "gamma",
+                "oracle",
+                "official",
+                representedJavaRelease,
+                DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE);
 
         String embeddedSeparatorFingerprintInput = embeddedSeparatorProvenance.fingerprintInput("fingerprint");
         String shiftedSeparatorFingerprintInput = shiftedSeparatorProvenance.fingerprintInput("fingerprint\u001falpha");

--- a/src/test/java/com/williamcallahan/javachat/service/ingestion/IngestionProvenanceDeriverTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/ingestion/IngestionProvenanceDeriverTest.java
@@ -13,6 +13,10 @@ import org.junit.jupiter.api.Test;
 /** Verifies that manifest-governed mirrors retain their declared ingestion provenance. */
 class IngestionProvenanceDeriverTest {
 
+    private static final String FINGERPRINT_TEST_DOCUMENT_PATH = "gamma";
+    private static final String FINGERPRINT_TEST_SOURCE_NAME = "oracle";
+    private static final String FINGERPRINT_TEST_SOURCE_KIND = "official";
+
     @Test
     void usesCanonicalManifestMetadataForEveryDocumentationSource() {
         IngestionProvenanceDeriver provenanceDeriver = new IngestionProvenanceDeriver();
@@ -54,20 +58,10 @@ class IngestionProvenanceDeriverTest {
     void canonicalFingerprintEncodingSeparatesControlCharactersFromFieldBoundaries() {
         String representedJavaRelease =
                 DocsSourceRegistry.javaApiDocumentationSources().getFirst().javaRelease();
-        IngestionProvenance embeddedSeparatorProvenance = new IngestionProvenance(
-                "alpha\u001fbeta",
-                "gamma",
-                "oracle",
-                "official",
-                representedJavaRelease,
-                DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE);
-        IngestionProvenance shiftedSeparatorProvenance = new IngestionProvenance(
-                "beta",
-                "gamma",
-                "oracle",
-                "official",
-                representedJavaRelease,
-                DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE);
+        IngestionProvenance embeddedSeparatorProvenance =
+                javaApiProvenanceForDocumentSet("alpha\u001fbeta", representedJavaRelease);
+        IngestionProvenance shiftedSeparatorProvenance =
+                javaApiProvenanceForDocumentSet("beta", representedJavaRelease);
 
         String embeddedSeparatorFingerprintInput = embeddedSeparatorProvenance.fingerprintInput("fingerprint");
         String shiftedSeparatorFingerprintInput = shiftedSeparatorProvenance.fingerprintInput("fingerprint\u001falpha");
@@ -75,5 +69,16 @@ class IngestionProvenanceDeriverTest {
         assertNotEquals(embeddedSeparatorFingerprintInput, shiftedSeparatorFingerprintInput);
         assertFalse(embeddedSeparatorFingerprintInput.contains("\u001f"));
         assertEquals(embeddedSeparatorFingerprintInput, embeddedSeparatorProvenance.fingerprintInput("fingerprint"));
+    }
+
+    private static IngestionProvenance javaApiProvenanceForDocumentSet(
+            String documentationSet, String representedJavaRelease) {
+        return new IngestionProvenance(
+                documentationSet,
+                FINGERPRINT_TEST_DOCUMENT_PATH,
+                FINGERPRINT_TEST_SOURCE_NAME,
+                FINGERPRINT_TEST_SOURCE_KIND,
+                representedJavaRelease,
+                DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE);
     }
 }

--- a/src/test/java/com/williamcallahan/javachat/service/ingestion/SourceCodeFileIngestionProcessorTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/ingestion/SourceCodeFileIngestionProcessorTest.java
@@ -24,6 +24,7 @@ import com.williamcallahan.javachat.service.HybridVectorService;
 import com.williamcallahan.javachat.service.LocalStoreService;
 import com.williamcallahan.javachat.service.ProgressTracker;
 import com.williamcallahan.javachat.service.QdrantCollectionRouter;
+import com.williamcallahan.javachat.service.QdrantPayloadFieldSchema;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -93,7 +94,7 @@ class SourceCodeFileIngestionProcessorTest {
         when(progressTracker.formatPercent()).thenReturn("100%");
 
         Document indexedDocument = new Document("point-1", "package demo; class Main {}", new HashMap<>());
-        indexedDocument.getMetadata().put("hash", "newhash");
+        indexedDocument.getMetadata().put(QdrantPayloadFieldSchema.HASH_FIELD, "newhash");
 
         ChunkProcessingService.ChunkProcessingOutcome chunkProcessingOutcome =
                 new ChunkProcessingService.ChunkProcessingOutcome(List.of(indexedDocument), List.of("newhash"), 1, 0);
@@ -174,7 +175,7 @@ class SourceCodeFileIngestionProcessorTest {
         when(progressTracker.formatPercent()).thenReturn("100%");
 
         Document indexedDocument = new Document("point-1", "package demo; class Main {}", new HashMap<>());
-        indexedDocument.getMetadata().put("hash", "existing-hash");
+        indexedDocument.getMetadata().put(QdrantPayloadFieldSchema.HASH_FIELD, "existing-hash");
         ChunkProcessingService.ChunkProcessingOutcome chunkProcessingOutcome =
                 new ChunkProcessingService.ChunkProcessingOutcome(
                         List.of(indexedDocument), List.of("existing-hash"), 1, 0);

--- a/src/test/java/com/williamcallahan/javachat/web/ChatControllerStreamingFailureTest.java
+++ b/src/test/java/com/williamcallahan/javachat/web/ChatControllerStreamingFailureTest.java
@@ -285,6 +285,9 @@ class ChatControllerStreamingFailureTest {
             }
             subscriptionRegistration.cancel(true);
             subscriptionExecutor.shutdownNow();
+            assertTrue(
+                    subscriptionExecutor.awaitTermination(ASYNC_ASSERTION_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    "subscription executor should terminate after cancellation");
         }
     }
 

--- a/src/test/java/com/williamcallahan/javachat/web/ChatControllerStreamingFailureTest.java
+++ b/src/test/java/com/williamcallahan/javachat/web/ChatControllerStreamingFailureTest.java
@@ -49,6 +49,14 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -59,6 +67,7 @@ import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.mock.web.MockHttpServletResponse;
+import reactor.core.Disposable;
 import reactor.core.Exceptions;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -71,6 +80,7 @@ class ChatControllerStreamingFailureTest {
     private static final String SESSION_ID = "session\nid";
     private static final String USER_QUERY = "explain sealed classes";
     private static final String UPSTREAM_SECRET_MESSAGE = "OPENAI_API_KEY=secret-body";
+    private static final int ASYNC_ASSERTION_TIMEOUT_SECONDS = 2;
 
     private final Logger pipelineLogger = (Logger) LoggerFactory.getLogger("PIPELINE");
     private final Logger reactorHooksLogger = (Logger) LoggerFactory.getLogger(ReactorHooksConfig.class);
@@ -197,6 +207,147 @@ class ChatControllerStreamingFailureTest {
                 .verify();
 
         verifyNoInteractions(chatMemoryService, chatService, streamingService, retrievalService);
+    }
+
+    @Test
+    void streamSubscriptionReturnsAfterPreparationStatusWhileRetrievalIsBlocked()
+            throws JsonProcessingException, InterruptedException, ExecutionException, TimeoutException {
+        ChatService chatService = mock(ChatService.class);
+        ChatMemoryService chatMemoryService = mock(ChatMemoryService.class);
+        OpenAIStreamingService streamingService = mock(OpenAIStreamingService.class);
+        RetrievalService retrievalService = mock(RetrievalService.class);
+        ChatController chatController = new ChatController(
+                chatService,
+                chatMemoryService,
+                streamingService,
+                retrievalService,
+                createSseSupport(),
+                new ExceptionResponseBuilder(),
+                new AppProperties());
+        CountDownLatch retrievalStarted = new CountDownLatch(1);
+        CountDownLatch releaseRetrieval = new CountDownLatch(1);
+        CountDownLatch preparationStatusObserved = new CountDownLatch(1);
+        AtomicReference<ServerSentEvent<String>> firstStreamEvent = new AtomicReference<>();
+        AtomicReference<Throwable> streamFailure = new AtomicReference<>();
+        AtomicReference<Disposable> activeSubscription = new AtomicReference<>();
+
+        when(streamingService.isAvailable()).thenReturn(true);
+        when(chatMemoryService.getHistory(SESSION_ID)).thenAnswer(ignoredInvocation -> {
+            retrievalStarted.countDown();
+            assertTrue(
+                    releaseRetrieval.await(ASYNC_ASSERTION_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    "test should release blocked retrieval");
+            return List.of();
+        });
+        when(chatService.buildStructuredPromptWithContextOutcome(
+                        anyList(), eq(USER_QUERY), eq(ModelConfiguration.DEFAULT_MODEL)))
+                .thenReturn(new ChatService.StructuredPromptOutcome(
+                        StructuredPrompt.fromRawPrompt("test", 1), List.of(), List.of()));
+        when(retrievalService.toCitations(anyList())).thenReturn(new RetrievalService.CitationOutcome(List.of(), 0));
+        when(streamingService.streamResponse(any(StructuredPrompt.class), anyDouble()))
+                .thenReturn(Mono.never());
+
+        ExecutorService subscriptionExecutor = Executors.newSingleThreadExecutor();
+        Future<?> subscriptionRegistration = subscriptionExecutor.submit(() -> activeSubscription.set(
+                chatController.stream(new ChatStreamRequest(SESSION_ID, USER_QUERY), new MockHttpServletResponse())
+                        .subscribe(
+                                streamEvent -> {
+                                    if (firstStreamEvent.compareAndSet(null, streamEvent)) {
+                                        preparationStatusObserved.countDown();
+                                    }
+                                },
+                                streamFailure::set)));
+
+        try {
+            assertTrue(
+                    preparationStatusObserved.await(ASYNC_ASSERTION_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    "preparation status should be observable before retrieval completes");
+            assertTrue(
+                    retrievalStarted.await(ASYNC_ASSERTION_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    "retrieval should start after the preparation status");
+            subscriptionRegistration.get(ASYNC_ASSERTION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+            ServerSentEvent<String> preparationEvent =
+                    Objects.requireNonNull(firstStreamEvent.get(), "first stream event");
+            assertEquals(EVENT_STATUS, preparationEvent.event());
+            SseSupport.SseEventPayload preparationStatus = objectMapper.readValue(
+                    Objects.requireNonNull(preparationEvent.data(), "preparation status event data"),
+                    SseSupport.SseEventPayload.class);
+            assertEquals(STATUS_CODE_STREAM_PREPARING, preparationStatus.code());
+            assertEquals(STATUS_STAGE_RETRIEVAL, preparationStatus.stage());
+            assertEquals(1L, releaseRetrieval.getCount(), "subscription should return while retrieval remains blocked");
+            assertNull(streamFailure.get());
+        } finally {
+            releaseRetrieval.countDown();
+            Disposable streamSubscription = activeSubscription.get();
+            if (streamSubscription != null) {
+                streamSubscription.dispose();
+            }
+            subscriptionRegistration.cancel(true);
+            subscriptionExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    void disposingStreamInterruptsBlockedPreparationAndPreventsDownstreamWork() throws InterruptedException {
+        ChatService chatService = mock(ChatService.class);
+        ChatMemoryService chatMemoryService = mock(ChatMemoryService.class);
+        OpenAIStreamingService streamingService = mock(OpenAIStreamingService.class);
+        RetrievalService retrievalService = mock(RetrievalService.class);
+        ChatController chatController = new ChatController(
+                chatService,
+                chatMemoryService,
+                streamingService,
+                retrievalService,
+                createSseSupport(),
+                new ExceptionResponseBuilder(),
+                new AppProperties());
+        CountDownLatch retrievalStarted = new CountDownLatch(1);
+        CountDownLatch releaseRetrieval = new CountDownLatch(1);
+        CountDownLatch retrievalInterrupted = new CountDownLatch(1);
+        CountDownLatch retrievalFinished = new CountDownLatch(1);
+        AtomicReference<Throwable> streamFailure = new AtomicReference<>();
+
+        when(streamingService.isAvailable()).thenReturn(true);
+        when(chatMemoryService.getHistory(SESSION_ID)).thenAnswer(ignoredInvocation -> {
+            retrievalStarted.countDown();
+            try {
+                releaseRetrieval.await();
+                return List.of();
+            } catch (InterruptedException interruptedFailure) {
+                retrievalInterrupted.countDown();
+                throw interruptedFailure;
+            } finally {
+                retrievalFinished.countDown();
+            }
+        });
+
+        Disposable streamSubscription = chatController.stream(
+                        new ChatStreamRequest(SESSION_ID, USER_QUERY), new MockHttpServletResponse())
+                .subscribe(
+                        preparationEvent -> assertEquals(EVENT_STATUS, preparationEvent.event()), streamFailure::set);
+
+        try {
+            assertTrue(
+                    retrievalStarted.await(ASYNC_ASSERTION_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    "retrieval should be blocked before cancellation");
+
+            streamSubscription.dispose();
+
+            assertTrue(
+                    retrievalInterrupted.await(ASYNC_ASSERTION_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    "disposing the stream should interrupt blocked retrieval");
+            assertTrue(
+                    retrievalFinished.await(ASYNC_ASSERTION_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                    "blocked retrieval should terminate after cancellation");
+            assertNull(streamFailure.get());
+            verifyNoInteractions(chatService, retrievalService);
+            verify(streamingService, never()).streamResponse(any(StructuredPrompt.class), anyDouble());
+            verify(chatMemoryService, never()).addExchange(eq(SESSION_ID), eq(USER_QUERY), any());
+        } finally {
+            releaseRetrieval.countDown();
+            streamSubscription.dispose();
+        }
     }
 
     @Test

--- a/src/test/java/com/williamcallahan/javachat/web/ChatPreparationSseIntegrationTest.java
+++ b/src/test/java/com/williamcallahan/javachat/web/ChatPreparationSseIntegrationTest.java
@@ -1,0 +1,258 @@
+package com.williamcallahan.javachat.web;
+
+import static com.williamcallahan.javachat.web.SseConstants.EVENT_STATUS;
+import static com.williamcallahan.javachat.web.SseConstants.STATUS_CODE_STREAM_PREPARING;
+import static com.williamcallahan.javachat.web.SseConstants.STATUS_STAGE_RETRIEVAL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.williamcallahan.javachat.config.ModelConfiguration;
+import com.williamcallahan.javachat.config.RequiredCredentialValidation;
+import com.williamcallahan.javachat.domain.prompt.StructuredPrompt;
+import com.williamcallahan.javachat.service.ChatMemoryService;
+import com.williamcallahan.javachat.service.ChatService;
+import com.williamcallahan.javachat.service.EmbeddingClient;
+import com.williamcallahan.javachat.service.EmbeddingModelKeepAlive;
+import com.williamcallahan.javachat.service.ExternalServiceHealth;
+import com.williamcallahan.javachat.service.OpenAIStreamingService;
+import com.williamcallahan.javachat.service.RateLimitService;
+import com.williamcallahan.javachat.service.RetrievalService;
+import com.williamcallahan.javachat.service.StreamingResult;
+import io.qdrant.client.QdrantClient;
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+import org.reactivestreams.Subscription;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import org.springframework.test.web.reactive.server.FluxExchangeResult;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.BaseSubscriber;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/** Verifies the embedded servlet server flushes chat admission before blocking preparation finishes. */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class ChatPreparationSseIntegrationTest {
+    private static final String CSRF_REFRESH_ENDPOINT = "/api/security/csrf";
+    private static final String CHAT_STREAM_ENDPOINT = "/api/chat/stream";
+    private static final String CSRF_COOKIE_NAME = "XSRF-TOKEN";
+    private static final String CSRF_HEADER_NAME = "X-XSRF-TOKEN";
+    private static final String SESSION_ID = "preparation-boundary-session";
+    private static final String USER_QUERY = "Explain sealed classes";
+    private static final Duration SSE_BOUNDARY_TIMEOUT = Duration.ofSeconds(5);
+    private static final ParameterizedTypeReference<ServerSentEvent<String>> SSE_EVENT_TYPE =
+            new ParameterizedTypeReference<>() {};
+
+    @Autowired
+    WebTestClient webTestClient;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockitoBean
+    ChatMemoryService chatMemoryService;
+
+    @MockitoBean
+    ChatService chatService;
+
+    @MockitoBean
+    OpenAIStreamingService streamingService;
+
+    @MockitoBean
+    RetrievalService retrievalService;
+
+    @MockitoBean
+    RequiredCredentialValidation credentialValidation;
+
+    @MockitoBean(answers = Answers.RETURNS_MOCKS)
+    EmbeddingClient embeddingClient;
+
+    @MockitoBean
+    QdrantClient qdrantClient;
+
+    @MockitoBean
+    ExternalServiceHealth externalServiceHealth;
+
+    @MockitoBean
+    EmbeddingModelKeepAlive embeddingModelKeepAlive;
+
+    @Test
+    void flushesPreparationEventWhileRetrievalRemainsBlocked() throws JsonProcessingException, InterruptedException {
+        CountDownLatch retrievalStarted = new CountDownLatch(1);
+        CountDownLatch releaseRetrieval = new CountDownLatch(1);
+        CountDownLatch retrievalFinished = new CountDownLatch(1);
+        CountDownLatch firstSseEventObserved = new CountDownLatch(1);
+        CountDownLatch chatExchangePersisted = new CountDownLatch(1);
+        CountDownLatch responseBodyTerminated = new CountDownLatch(1);
+        AtomicReference<ServerSentEvent<String>> firstSseEvent = new AtomicReference<>();
+        AtomicReference<Throwable> clientFailure = new AtomicReference<>();
+
+        when(streamingService.isAvailable()).thenReturn(true);
+        when(chatMemoryService.getHistory(SESSION_ID)).thenAnswer(ignoredInvocation -> {
+            retrievalStarted.countDown();
+            try {
+                releaseRetrieval.await();
+                return List.of();
+            } finally {
+                retrievalFinished.countDown();
+            }
+        });
+        when(chatService.buildStructuredPromptWithContextOutcome(
+                        anyList(), eq(USER_QUERY), eq(ModelConfiguration.DEFAULT_MODEL)))
+                .thenReturn(new ChatService.StructuredPromptOutcome(
+                        StructuredPrompt.fromRawPrompt("test", 1), List.of(), List.of()));
+        when(retrievalService.toCitations(anyList())).thenReturn(new RetrievalService.CitationOutcome(List.of(), 0));
+        when(streamingService.streamResponse(any(StructuredPrompt.class), anyDouble()))
+                .thenReturn(Mono.just(new StreamingResult(Flux.just("Complete"), RateLimitService.ApiProvider.OPENAI)));
+        doAnswer(ignoredInvocation -> {
+                    chatExchangePersisted.countDown();
+                    return null;
+                })
+                .when(chatMemoryService)
+                .addExchange(eq(SESSION_ID), eq(USER_QUERY), any());
+
+        WebTestClient boundaryClient =
+                webTestClient.mutate().responseTimeout(SSE_BOUNDARY_TIMEOUT).build();
+        ResponseCookie csrfCookie = requestCsrfCookie(boundaryClient);
+        FirstSseEventSubscriber firstEventSubscriber = new FirstSseEventSubscriber(
+                firstSseEvent, clientFailure, firstSseEventObserved, responseBodyTerminated);
+        boolean retrievalTerminatedCleanly;
+        boolean chatExchangePersistedCleanly;
+        boolean responseBodyTerminatedCleanly;
+
+        try {
+            FluxExchangeResult<ServerSentEvent<String>> chatStreamExchange = boundaryClient
+                    .post()
+                    .uri(CHAT_STREAM_ENDPOINT)
+                    .cookie(CSRF_COOKIE_NAME, csrfCookie.getValue())
+                    .header(CSRF_HEADER_NAME, csrfCookie.getValue())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.TEXT_EVENT_STREAM)
+                    .bodyValue(new ChatStreamRequest(SESSION_ID, USER_QUERY))
+                    .exchange()
+                    .expectStatus()
+                    .isOk()
+                    .expectHeader()
+                    .contentTypeCompatibleWith(MediaType.TEXT_EVENT_STREAM)
+                    .returnResult(SSE_EVENT_TYPE);
+            chatStreamExchange.getResponseBody().subscribe(firstEventSubscriber);
+
+            assertTrue(
+                    firstSseEventObserved.await(SSE_BOUNDARY_TIMEOUT.toSeconds(), TimeUnit.SECONDS),
+                    "the first SSE event should arrive before retrieval completes");
+            assertNull(clientFailure.get());
+            assertTrue(
+                    retrievalStarted.await(SSE_BOUNDARY_TIMEOUT.toSeconds(), TimeUnit.SECONDS),
+                    "retrieval should start after the preparation event is emitted");
+            assertEquals(1L, releaseRetrieval.getCount(), "retrieval should remain blocked after the first SSE event");
+
+            ServerSentEvent<String> preparationEvent = Objects.requireNonNull(firstSseEvent.get(), "first SSE event");
+            assertEquals(EVENT_STATUS, preparationEvent.event());
+            SseSupport.SseEventPayload preparationStatus = objectMapper.readValue(
+                    Objects.requireNonNull(preparationEvent.data(), "preparation event data"),
+                    SseSupport.SseEventPayload.class);
+            assertEquals(STATUS_CODE_STREAM_PREPARING, preparationStatus.code());
+            assertEquals(STATUS_STAGE_RETRIEVAL, preparationStatus.stage());
+        } finally {
+            releaseRetrieval.countDown();
+            firstEventSubscriber.requestUnbounded();
+            retrievalTerminatedCleanly = retrievalFinished.await(SSE_BOUNDARY_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
+            chatExchangePersistedCleanly =
+                    chatExchangePersisted.await(SSE_BOUNDARY_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
+            responseBodyTerminatedCleanly =
+                    responseBodyTerminated.await(SSE_BOUNDARY_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
+            firstEventSubscriber.dispose();
+        }
+
+        assertTrue(retrievalTerminatedCleanly, "retrieval should terminate during test cleanup");
+        assertTrue(chatExchangePersistedCleanly, "the finite server pipeline should persist its completed exchange");
+        assertTrue(responseBodyTerminatedCleanly, "the client should consume the finite SSE stream to completion");
+        assertNull(clientFailure.get());
+    }
+
+    private ResponseCookie requestCsrfCookie(WebTestClient boundaryClient) {
+        EntityExchangeResult<byte[]> csrfExchange = boundaryClient
+                .get()
+                .uri(CSRF_REFRESH_ENDPOINT)
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody()
+                .returnResult();
+        ResponseCookie csrfCookie = csrfExchange.getResponseCookies().getFirst(CSRF_COOKIE_NAME);
+        assertNotNull(csrfCookie);
+        return csrfCookie;
+    }
+
+    /** Holds demand at the first decoded frame until the test has verified the preparation boundary. */
+    private static final class FirstSseEventSubscriber extends BaseSubscriber<ServerSentEvent<String>> {
+        private final AtomicReference<ServerSentEvent<String>> firstSseEvent;
+        private final AtomicReference<Throwable> clientFailure;
+        private final CountDownLatch firstSseEventObserved;
+        private final CountDownLatch responseBodyTerminated;
+
+        private FirstSseEventSubscriber(
+                AtomicReference<ServerSentEvent<String>> firstSseEvent,
+                AtomicReference<Throwable> clientFailure,
+                CountDownLatch firstSseEventObserved,
+                CountDownLatch responseBodyTerminated) {
+            this.firstSseEvent = firstSseEvent;
+            this.clientFailure = clientFailure;
+            this.firstSseEventObserved = firstSseEventObserved;
+            this.responseBodyTerminated = responseBodyTerminated;
+        }
+
+        /** Requests exactly one decoded SSE frame so the connection remains open for the boundary assertion. */
+        @Override
+        protected void hookOnSubscribe(Subscription subscription) {
+            request(1);
+        }
+
+        /** Captures the first decoded SSE frame without requesting a second frame. */
+        @Override
+        protected void hookOnNext(ServerSentEvent<String> streamEvent) {
+            firstSseEvent.set(streamEvent);
+            firstSseEventObserved.countDown();
+        }
+
+        /** Makes HTTP or decoding failures observable to the waiting test thread. */
+        @Override
+        protected void hookOnError(Throwable streamFailure) {
+            clientFailure.set(streamFailure);
+            firstSseEventObserved.countDown();
+            responseBodyTerminated.countDown();
+        }
+
+        /** Records clean HTTP-body completion after every remaining SSE frame is consumed. */
+        @Override
+        protected void hookOnComplete() {
+            responseBodyTerminated.countDown();
+        }
+    }
+}

--- a/src/test/java/com/williamcallahan/javachat/web/GuidedSseCitationEventTest.java
+++ b/src/test/java/com/williamcallahan/javachat/web/GuidedSseCitationEventTest.java
@@ -31,6 +31,7 @@ import com.williamcallahan.javachat.service.ChatMemoryService;
 import com.williamcallahan.javachat.service.GuidedLearningService;
 import com.williamcallahan.javachat.service.MarkdownService;
 import com.williamcallahan.javachat.service.OpenAIStreamingService;
+import com.williamcallahan.javachat.service.QdrantPayloadFieldSchema;
 import com.williamcallahan.javachat.service.RateLimitService;
 import com.williamcallahan.javachat.service.RetrievalService;
 import com.williamcallahan.javachat.service.StreamingResult;
@@ -98,7 +99,7 @@ class GuidedSseCitationEventTest {
         Document lessonContextDocument = Document.builder()
                 .id("official-guided-context")
                 .text("Official lesson context")
-                .metadata("sourceKind", "official")
+                .metadata(QdrantPayloadFieldSchema.SOURCE_KIND_FIELD, "official")
                 .build();
         given(guidedLearningService.getLesson("intro")).willReturn(Optional.of(listedLesson("intro")));
         given(openAIStreamingService.isAvailable()).willReturn(true);
@@ -138,7 +139,7 @@ class GuidedSseCitationEventTest {
         Document lessonContextDocument = Document.builder()
                 .id("official-guided-context")
                 .text("Official lesson context")
-                .metadata("sourceKind", "official")
+                .metadata(QdrantPayloadFieldSchema.SOURCE_KIND_FIELD, "official")
                 .build();
         given(guidedLearningService.getLesson("intro")).willReturn(Optional.of(listedLesson("intro")));
         given(openAIStreamingService.isAvailable()).willReturn(true);


### PR DESCRIPTION
## Summary

- recognize Java API type/member queries and rank exact API pages before citation deduplication and limiting
- keep version filtering exact while removing version-text distortion from sparse citation discovery
- emit the preparation SSE event before blocking retrieval/provider work and preserve cancellation through the preparation boundary
- centralize every persisted Qdrant/document metadata field in one schema owner across production and test projections
- normalize directly constructed API selectors and harden asynchronous test cleanup

## Verification

- 661 backend tests passed
- 172 frontend tests passed
- full build passed
- frontend lint and Svelte checks passed with zero warnings or errors
- PMD and SpotBugs passed with zero findings
- random-port Tomcat/WebTestClient SSE boundary test passed
- both GitHub Docker runtime smoke jobs passed
- CodeRabbit completed; all review threads resolved
- independent final review approved with high confidence