### PR TITLE
fix: prefer canonical Javadoc type pages

### DIFF
--- a/src/main/java/com/williamcallahan/javachat/application/search/JavaApiMethodSelector.java
+++ b/src/main/java/com/williamcallahan/javachat/application/search/JavaApiMethodSelector.java
@@ -1,11 +1,11 @@
 package com.williamcallahan.javachat.application.search;
 
+import com.williamcallahan.javachat.domain.javaapi.JavaPackageName;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import javax.lang.model.SourceVersion;
 
 /**
  * Identifies an explicitly named Java API type method within a natural-language query.
@@ -95,12 +95,13 @@ public record JavaApiMethodSelector(String packageName, String typePageName, Str
     /**
      * Determines whether a Javadoc URL path identifies this selector's declaring type.
      *
-     * <p>Qualified selectors use their query package and ignore candidate metadata. Unqualified
-     * selectors require a canonical Java package supplied by the candidate metadata, which keeps
-     * package-relative API pages from being mistaken for canonical type pages.</p>
+     * <p>Qualified selectors use their query package and ignore the candidate package. Unqualified
+     * selectors require a canonical Java package derived from the candidate source URL, which
+     * keeps package-relative API pages from being mistaken for canonical type pages.</p>
      *
      * @param javadocPath decoded Javadoc URL path
-     * @param candidatePackageName candidate package metadata, or {@code null} when absent
+     * @param candidatePackageName package derived from the candidate source URL, or {@code null}
+     *     when absent
      * @return true when the path names this selector's declaring type in its expected package
      */
     public boolean matchesJavadocPath(String javadocPath, String candidatePackageName) {
@@ -119,25 +120,16 @@ public record JavaApiMethodSelector(String packageName, String typePageName, Str
         return typePageName;
     }
 
-    private Optional<String> expectedPackageName(String candidatePackageName) {
+    private Optional<JavaPackageName> expectedPackageName(String candidatePackageName) {
         if (!packageName.isBlank()) {
-            return Optional.of(packageName);
+            return JavaPackageName.from(packageName);
         }
-        return isCanonicalJavaPackageName(candidatePackageName) ? Optional.of(candidatePackageName) : Optional.empty();
+        return JavaPackageName.from(candidatePackageName);
     }
 
-    private boolean matchesPackageTypePath(String javadocPath, String expectedPackageName) {
-        String expectedPagePath = "/" + expectedPackageName.replace('.', '/') + "/" + typePageFileName();
+    private boolean matchesPackageTypePath(String javadocPath, JavaPackageName expectedPackageName) {
+        String expectedPagePath = "/" + expectedPackageName.javadocPath() + "/" + typePageFileName();
         return javadocPath.endsWith(expectedPagePath);
-    }
-
-    private static boolean isCanonicalJavaPackageName(String candidatePackageName) {
-        if (candidatePackageName == null
-                || candidatePackageName.isBlank()
-                || !candidatePackageName.equals(candidatePackageName.trim())) {
-            return false;
-        }
-        return SourceVersion.isName(candidatePackageName, SourceVersion.RELEASE_25);
     }
 
     private static ParsedQualifiedName parseQualifiedName(String query, int startIndex) {

--- a/src/main/java/com/williamcallahan/javachat/application/search/JavaApiMethodSelector.java
+++ b/src/main/java/com/williamcallahan/javachat/application/search/JavaApiMethodSelector.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import javax.lang.model.SourceVersion;
 
 /**
  * Identifies an explicitly named Java API type method within a natural-language query.
@@ -136,27 +137,7 @@ public record JavaApiMethodSelector(String packageName, String typePageName, Str
                 || !candidatePackageName.equals(candidatePackageName.trim())) {
             return false;
         }
-
-        boolean segmentStart = true;
-        for (int characterIndex = 0; characterIndex < candidatePackageName.length(); characterIndex++) {
-            char packageCharacter = candidatePackageName.charAt(characterIndex);
-            if (packageCharacter == '.') {
-                if (segmentStart) {
-                    return false;
-                }
-                segmentStart = true;
-                continue;
-            }
-            if (segmentStart) {
-                if (!Character.isJavaIdentifierStart(packageCharacter)) {
-                    return false;
-                }
-                segmentStart = false;
-            } else if (!Character.isJavaIdentifierPart(packageCharacter)) {
-                return false;
-            }
-        }
-        return !segmentStart;
+        return SourceVersion.isName(candidatePackageName, SourceVersion.RELEASE_25);
     }
 
     private static ParsedQualifiedName parseQualifiedName(String query, int startIndex) {

--- a/src/main/java/com/williamcallahan/javachat/application/search/JavaApiMethodSelector.java
+++ b/src/main/java/com/williamcallahan/javachat/application/search/JavaApiMethodSelector.java
@@ -94,25 +94,19 @@ public record JavaApiMethodSelector(String packageName, String typePageName, Str
     /**
      * Determines whether a Javadoc URL path identifies this selector's declaring type.
      *
-     * <p>Unqualified selectors match the type filename in any package. Qualified selectors require
-     * the exact package path immediately before that filename, preventing same-named JDK types in
-     * different packages from receiving the same citation priority.</p>
+     * <p>Qualified selectors use their query package and ignore candidate metadata. Unqualified
+     * selectors require a canonical Java package supplied by the candidate metadata, which keeps
+     * package-relative API pages from being mistaken for canonical type pages.</p>
      *
      * @param javadocPath decoded Javadoc URL path
-     * @return true when the path names this selector's declaring type
+     * @param candidatePackageName candidate package metadata, or {@code null} when absent
+     * @return true when the path names this selector's declaring type in its expected package
      */
-    public boolean matchesJavadocPath(String javadocPath) {
+    public boolean matchesJavadocPath(String javadocPath, String candidatePackageName) {
         Objects.requireNonNull(javadocPath, "javadocPath");
-        int filenameStartIndex = javadocPath.lastIndexOf('/') + 1;
-        String candidateFilename = javadocPath.substring(filenameStartIndex);
-        if (!typePageFileName().equals(candidateFilename)) {
-            return false;
-        }
-        if (packageName.isBlank()) {
-            return true;
-        }
-        String qualifiedPagePathSuffix = "/" + packageName.replace('.', '/') + "/" + typePageFileName();
-        return javadocPath.endsWith(qualifiedPagePathSuffix);
+        return expectedPackageName(candidatePackageName)
+                .map(expectedPackageName -> matchesPackageTypePath(javadocPath, expectedPackageName))
+                .orElse(false);
     }
 
     /**
@@ -122,6 +116,47 @@ public record JavaApiMethodSelector(String packageName, String typePageName, Str
      */
     public String sparseQueryTerms() {
         return typePageName;
+    }
+
+    private Optional<String> expectedPackageName(String candidatePackageName) {
+        if (!packageName.isBlank()) {
+            return Optional.of(packageName);
+        }
+        return isCanonicalJavaPackageName(candidatePackageName) ? Optional.of(candidatePackageName) : Optional.empty();
+    }
+
+    private boolean matchesPackageTypePath(String javadocPath, String expectedPackageName) {
+        String expectedPagePath = "/" + expectedPackageName.replace('.', '/') + "/" + typePageFileName();
+        return javadocPath.endsWith(expectedPagePath);
+    }
+
+    private static boolean isCanonicalJavaPackageName(String candidatePackageName) {
+        if (candidatePackageName == null
+                || candidatePackageName.isBlank()
+                || !candidatePackageName.equals(candidatePackageName.trim())) {
+            return false;
+        }
+
+        boolean segmentStart = true;
+        for (int characterIndex = 0; characterIndex < candidatePackageName.length(); characterIndex++) {
+            char packageCharacter = candidatePackageName.charAt(characterIndex);
+            if (packageCharacter == '.') {
+                if (segmentStart) {
+                    return false;
+                }
+                segmentStart = true;
+                continue;
+            }
+            if (segmentStart) {
+                if (!Character.isJavaIdentifierStart(packageCharacter)) {
+                    return false;
+                }
+                segmentStart = false;
+            } else if (!Character.isJavaIdentifierPart(packageCharacter)) {
+                return false;
+            }
+        }
+        return !segmentStart;
     }
 
     private static ParsedQualifiedName parseQualifiedName(String query, int startIndex) {

--- a/src/main/java/com/williamcallahan/javachat/domain/javaapi/JavaPackageName.java
+++ b/src/main/java/com/williamcallahan/javachat/domain/javaapi/JavaPackageName.java
@@ -1,0 +1,54 @@
+package com.williamcallahan.javachat.domain.javaapi;
+
+import java.util.Optional;
+import javax.lang.model.SourceVersion;
+
+/**
+ * Represents an exact, syntactically valid Java 25 package name.
+ *
+ * <p>The value preserves its source spelling so URL projections and query selectors share one
+ * package-identity boundary without trimming or accepting documentation-only path segments.</p>
+ *
+ * @param qualifiedName dot-separated Java package name
+ */
+public record JavaPackageName(String qualifiedName) {
+
+    /**
+     * Enforces exact Java 25 package-name syntax for every constructed value.
+     *
+     * @throws IllegalArgumentException when the package name is null, blank, padded, or invalid
+     */
+    public JavaPackageName {
+        if (!isValid(qualifiedName)) {
+            throw new IllegalArgumentException("qualifiedName must be an exact Java 25 package name");
+        }
+    }
+
+    /**
+     * Creates a package name only when the candidate satisfies the Java 25 name grammar exactly.
+     *
+     * @param candidateQualifiedName candidate dot-separated package name
+     * @return validated package name, or empty when the candidate is absent or invalid
+     */
+    public static Optional<JavaPackageName> from(String candidateQualifiedName) {
+        return isValid(candidateQualifiedName)
+                ? Optional.of(new JavaPackageName(candidateQualifiedName))
+                : Optional.empty();
+    }
+
+    /**
+     * Projects the package into the path syntax used by canonical Javadoc URLs.
+     *
+     * @return slash-separated package path without leading or trailing delimiters
+     */
+    public String javadocPath() {
+        return qualifiedName.replace('.', '/');
+    }
+
+    private static boolean isValid(String candidateQualifiedName) {
+        return candidateQualifiedName != null
+                && !candidateQualifiedName.isBlank()
+                && candidateQualifiedName.equals(candidateQualifiedName.trim())
+                && SourceVersion.isName(candidateQualifiedName, SourceVersion.RELEASE_25);
+    }
+}

--- a/src/main/java/com/williamcallahan/javachat/service/CitationCandidateRanker.java
+++ b/src/main/java/com/williamcallahan/javachat/service/CitationCandidateRanker.java
@@ -2,6 +2,7 @@ package com.williamcallahan.javachat.service;
 
 import com.williamcallahan.javachat.application.search.JavaApiMethodSelector;
 import com.williamcallahan.javachat.config.DocsSourceRegistry;
+import com.williamcallahan.javachat.service.ingestion.JavaPackageExtractor;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -86,8 +87,7 @@ final class CitationCandidateRanker {
         if (documentPath == null || documentPath.isBlank()) {
             return false;
         }
-        Object rawCandidatePackageName = citationCandidate.getMetadata().get(QdrantPayloadFieldSchema.PACKAGE_FIELD);
-        String candidatePackageName = rawCandidatePackageName instanceof String packageName ? packageName : null;
+        String candidatePackageName = JavaPackageExtractor.extractJavaApiPackage(sourceUrl);
         return selector.matchesJavadocPath(documentPath, candidatePackageName);
     }
 

--- a/src/main/java/com/williamcallahan/javachat/service/CitationCandidateRanker.java
+++ b/src/main/java/com/williamcallahan/javachat/service/CitationCandidateRanker.java
@@ -86,7 +86,9 @@ final class CitationCandidateRanker {
         if (documentPath == null || documentPath.isBlank()) {
             return false;
         }
-        return selector.matchesJavadocPath(documentPath);
+        Object rawCandidatePackageName = citationCandidate.getMetadata().get(QdrantPayloadFieldSchema.PACKAGE_FIELD);
+        String candidatePackageName = rawCandidatePackageName instanceof String packageName ? packageName : null;
+        return selector.matchesJavadocPath(documentPath, candidatePackageName);
     }
 
     private static boolean hasMethodDeclarationEvidence(JavaApiMethodSelector selector, Document citationCandidate) {

--- a/src/main/java/com/williamcallahan/javachat/service/RetrievalService.java
+++ b/src/main/java/com/williamcallahan/javachat/service/RetrievalService.java
@@ -4,6 +4,7 @@ import com.williamcallahan.javachat.config.AppProperties;
 import com.williamcallahan.javachat.config.DocsSourceRegistry;
 import com.williamcallahan.javachat.config.ModelConfiguration;
 import com.williamcallahan.javachat.model.Citation;
+import com.williamcallahan.javachat.service.ingestion.JavaPackageExtractor;
 import com.williamcallahan.javachat.util.QueryVersionExtractor;
 import com.williamcallahan.javachat.util.QueryVersionExtractor.VersionFilterPatterns;
 import java.util.ArrayList;
@@ -415,10 +416,8 @@ public class RetrievalService {
                 Map<String, ?> sourceDocMetadata = sourceDocument.getMetadata();
                 String rawUrl = stringMetadataValue(sourceDocMetadata, QdrantPayloadFieldSchema.URL_FIELD);
                 String title = stringMetadataValue(sourceDocMetadata, QdrantPayloadFieldSchema.TITLE_FIELD);
-                String packageName = stringMetadataValue(sourceDocMetadata, QdrantPayloadFieldSchema.PACKAGE_FIELD);
                 String documentType = stringMetadataValue(sourceDocMetadata, QdrantPayloadFieldSchema.DOC_TYPE_FIELD);
-                String refinedCitationUrl =
-                        refineCitationUrl(rawUrl, sourceDocument.getText(), packageName, documentType);
+                String refinedCitationUrl = refineCitationUrl(rawUrl, sourceDocument.getText(), documentType);
                 String citationIdentity = citationIdentityFor(rawUrl, refinedCitationUrl);
                 if (!citationIdentity.isBlank() && !retainedCitationIdentities.add(citationIdentity)) {
                     continue;
@@ -478,10 +477,11 @@ public class RetrievalService {
      * Refines a raw document URL and gates Javadoc member anchors to {@code api-docs} metadata.
      *
      */
-    private String refineCitationUrl(String rawUrl, String documentText, String packageName, String documentType) {
+    private String refineCitationUrl(String rawUrl, String documentText, String documentType) {
         String normalizedUrl = DocsSourceRegistry.normalizeDocUrl(rawUrl);
         String citationUrl = normalizedUrl;
         if (DOCUMENT_TYPE_API_DOCS.equals(documentType)) {
+            String packageName = JavaPackageExtractor.extractJavaApiPackage(normalizedUrl);
             String nestedTypeRefinedUrl = com.williamcallahan.javachat.util.JavadocLinkResolver.refineNestedTypeUrl(
                     citationUrl, documentText);
             citationUrl = com.williamcallahan.javachat.util.JavadocLinkResolver.refineMemberAnchorUrl(

--- a/src/main/java/com/williamcallahan/javachat/service/ingestion/JavaPackageExtractor.java
+++ b/src/main/java/com/williamcallahan/javachat/service/ingestion/JavaPackageExtractor.java
@@ -2,6 +2,7 @@ package com.williamcallahan.javachat.service.ingestion;
 
 import com.williamcallahan.javachat.config.DocsSourceRegistry;
 import com.williamcallahan.javachat.config.DocsSourceRegistry.JavaApiDocumentationSource;
+import com.williamcallahan.javachat.domain.javaapi.JavaPackageName;
 import com.williamcallahan.javachat.support.AsciiTextNormalizer;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -35,6 +36,25 @@ public final class JavaPackageExtractor {
     }
 
     /**
+     * Derives the Java package encoded by a manifest-governed Java API source URL.
+     *
+     * <p>URL consumers use this projection instead of persisted package metadata so package
+     * identity follows the canonical source path across ingestion generations.</p>
+     *
+     * @param url source URL
+     * @return package encoded by the canonical Java API path, or an empty string when the URL is
+     *     not a canonical Java API source or its path does not identify a package
+     */
+    public static String extractJavaApiPackage(String url) {
+        Objects.requireNonNull(url, "url");
+        return findJavaApiSourceUrl(url)
+                .map(JavaPackageExtractor::extractPackageFromJavaApiPath)
+                .flatMap(JavaPackageName::from)
+                .map(JavaPackageName::qualifiedName)
+                .orElse("");
+    }
+
+    /**
      * Attempts to derive a package name from the URL and extracted page text.
      *
      * @param url source URL
@@ -45,9 +65,7 @@ public final class JavaPackageExtractor {
         Objects.requireNonNull(url, "url");
         Objects.requireNonNull(bodyText, "bodyText");
 
-        String pathDerivedPackageName = findJavaApiSourceUrl(url)
-                .map(JavaPackageExtractor::extractPackageFromJavaApiPath)
-                .orElse("");
+        String pathDerivedPackageName = extractJavaApiPackage(url);
         if (!pathDerivedPackageName.isBlank()) {
             return pathDerivedPackageName;
         }
@@ -58,7 +76,10 @@ public final class JavaPackageExtractor {
             String snippet = bodyText.substring(packageIndex, end);
             for (String token : snippet.split("\\s+")) {
                 if (AsciiTextNormalizer.toLowerAscii(token).startsWith("java.")) {
-                    return token.replaceAll("[,.;]$", "");
+                    String candidatePackageName = token.replaceAll("[,.;]$", "");
+                    return JavaPackageName.from(candidatePackageName)
+                            .map(JavaPackageName::qualifiedName)
+                            .orElse("");
                 }
             }
         }

--- a/src/main/java/com/williamcallahan/javachat/util/JavadocLinkResolver.java
+++ b/src/main/java/com/williamcallahan/javachat/util/JavadocLinkResolver.java
@@ -24,7 +24,7 @@ public final class JavadocLinkResolver {
      *
      * @param url         Javadoc page URL ending with .html
      * @param text        Extracted chunk text from the same page
-     * @param packageName Package name of the type (from metadata), can be empty
+     * @param packageName Java package derived from the canonical Javadoc source URL, can be empty
      * @return URL with a fragment to the member if a confident match is found; original URL otherwise
      */
     public static String refineMemberAnchorUrl(String url, String text, String packageName) {

--- a/src/test/java/com/williamcallahan/javachat/application/search/JavaApiMethodSelectorTest.java
+++ b/src/test/java/com/williamcallahan/javachat/application/search/JavaApiMethodSelectorTest.java
@@ -57,7 +57,7 @@ class JavaApiMethodSelectorTest {
         assertEquals("of", selector.methodName());
         assertEquals("List.html", selector.typePageFileName());
         assertEquals("List", selector.sparseQueryTerms());
-        assertTrue(selector.matchesJavadocPath("/java.base/java/util/List.html"));
+        assertTrue(selector.matchesJavadocPath("/java.base/java/util/List.html", null));
     }
 
     @Test
@@ -76,6 +76,25 @@ class JavaApiMethodSelectorTest {
     void requiresCaseSensitiveJavadocTypePageNames() {
         JavaApiMethodSelector selector = new JavaApiMethodSelector("java.util", "List", "of");
 
-        assertFalse(selector.matchesJavadocPath("/java.base/java/util/list.html"));
+        assertFalse(selector.matchesJavadocPath("/java.base/java/util/list.html", null));
+    }
+
+    @Test
+    void requiresCanonicalCandidatePackageMetadataForUnqualifiedSelectors() {
+        JavaApiMethodSelector selector = new JavaApiMethodSelector("", "List", "of");
+
+        assertTrue(selector.matchesJavadocPath("/java.base/java/util/List.html", "java.util"));
+        assertFalse(selector.matchesJavadocPath("/java.base/java/util/class-use/List.html", "java.util.class-use"));
+        assertFalse(selector.matchesJavadocPath("/List.html", ""));
+        assertFalse(selector.matchesJavadocPath("/java.base/java/util/List.html", null));
+    }
+
+    @Test
+    void matchesQualifiedSelectorsByPathRegardlessOfCandidateMetadata() {
+        JavaApiMethodSelector selector = new JavaApiMethodSelector("java.util", "Date", "toString");
+
+        assertTrue(selector.matchesJavadocPath("/java.base/java/util/Date.html", null));
+        assertTrue(selector.matchesJavadocPath("/java.base/java/util/Date.html", "java.sql"));
+        assertFalse(selector.matchesJavadocPath("/java.sql/java/sql/Date.html", "java.util"));
     }
 }

--- a/src/test/java/com/williamcallahan/javachat/application/search/JavaApiMethodSelectorTest.java
+++ b/src/test/java/com/williamcallahan/javachat/application/search/JavaApiMethodSelectorTest.java
@@ -87,6 +87,10 @@ class JavaApiMethodSelectorTest {
         assertFalse(selector.matchesJavadocPath("/java.base/java/util/class-use/List.html", "java.util.class-use"));
         assertFalse(selector.matchesJavadocPath("/List.html", ""));
         assertFalse(selector.matchesJavadocPath("/java.base/java/util/List.html", null));
+        assertFalse(selector.matchesJavadocPath("/java.base/java/class/List.html", "java.class"));
+        assertFalse(selector.matchesJavadocPath("/java.base/java/true/List.html", "java.true"));
+        assertFalse(selector.matchesJavadocPath("/java.base/java/false/List.html", "java.false"));
+        assertFalse(selector.matchesJavadocPath("/java.base/java/null/List.html", "java.null"));
     }
 
     @Test

--- a/src/test/java/com/williamcallahan/javachat/application/search/JavaApiMethodSelectorTest.java
+++ b/src/test/java/com/williamcallahan/javachat/application/search/JavaApiMethodSelectorTest.java
@@ -80,17 +80,13 @@ class JavaApiMethodSelectorTest {
     }
 
     @Test
-    void requiresCanonicalCandidatePackageMetadataForUnqualifiedSelectors() {
+    void requiresCanonicalCandidatePackageForUnqualifiedSelectors() {
         JavaApiMethodSelector selector = new JavaApiMethodSelector("", "List", "of");
 
         assertTrue(selector.matchesJavadocPath("/java.base/java/util/List.html", "java.util"));
         assertFalse(selector.matchesJavadocPath("/java.base/java/util/class-use/List.html", "java.util.class-use"));
         assertFalse(selector.matchesJavadocPath("/List.html", ""));
         assertFalse(selector.matchesJavadocPath("/java.base/java/util/List.html", null));
-        assertFalse(selector.matchesJavadocPath("/java.base/java/class/List.html", "java.class"));
-        assertFalse(selector.matchesJavadocPath("/java.base/java/true/List.html", "java.true"));
-        assertFalse(selector.matchesJavadocPath("/java.base/java/false/List.html", "java.false"));
-        assertFalse(selector.matchesJavadocPath("/java.base/java/null/List.html", "java.null"));
     }
 
     @Test

--- a/src/test/java/com/williamcallahan/javachat/domain/javaapi/JavaPackageNameTest.java
+++ b/src/test/java/com/williamcallahan/javachat/domain/javaapi/JavaPackageNameTest.java
@@ -1,0 +1,45 @@
+package com.williamcallahan.javachat.domain.javaapi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/** Verifies exact Java 25 package validation and Javadoc path projection. */
+class JavaPackageNameTest {
+
+    @Test
+    void acceptsJavaPackageNamesAndProjectsJavadocPaths() {
+        JavaPackageName packageName =
+                JavaPackageName.from("java.util.concurrent").orElseThrow();
+
+        assertEquals("java.util.concurrent", packageName.qualifiedName());
+        assertEquals("java/util/concurrent", packageName.javadocPath());
+    }
+
+    @Test
+    void rejectsAbsentPaddedAndInvalidPackageNames() {
+        List<String> invalidPackageNames = List.of(
+                "",
+                " ",
+                " java.util",
+                "java.util ",
+                "java..util",
+                "java.util.class-use",
+                "java.class",
+                "java.true",
+                "java.false",
+                "java.null");
+
+        assertTrue(JavaPackageName.from(null).isEmpty());
+        invalidPackageNames.forEach(candidatePackageName ->
+                assertTrue(JavaPackageName.from(candidatePackageName).isEmpty()));
+    }
+
+    @Test
+    void preventsDirectConstructionOfInvalidPackageNames() {
+        assertThrows(IllegalArgumentException.class, () -> new JavaPackageName("java.util.class-use"));
+    }
+}

--- a/src/test/java/com/williamcallahan/javachat/service/CitationCandidateRankerTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/CitationCandidateRankerTest.java
@@ -34,13 +34,19 @@ class CitationCandidateRankerTest {
     }
 
     @Test
-    void prioritizesCanonicalTypePagesOverClassUseAndRootPageCandidates() {
-        Document classUseCandidate = javaApiJavadocCandidate(
-                "class-use", "static <E> List<E> of(E element)", javadocPage("java.util.class-use", "List.html"));
+    void derivesCanonicalPackageFromSourceUrlsInsteadOfLegacyPackageMetadata() {
+        Document classUseCandidate = javaApiJavadocCandidateWithPackageMetadata(
+                "class-use",
+                "static <E> List<E> of(E element)",
+                javadocPage("java.util.class-use", "List.html"),
+                "java.util");
         Document rootPageCandidate =
-                javaApiRootJavadocCandidate("root-page", "static <E> List<E> of(E element)", "List.html");
-        Document canonicalListCandidate = javaApiJavadocCandidate(
-                "canonical-list", "static <E> List<E> of(E element)", javaUtilJavadocPage("List.html"));
+                javaApiRootJavadocCandidate("root-page", "static <E> List<E> of(E element)", "List.html", "java.util");
+        Document canonicalListCandidate = javaApiJavadocCandidateWithPackageMetadata(
+                "canonical-list",
+                "static <E> List<E> of(E element)",
+                javaUtilJavadocPage("List.html"),
+                "java.base.java.util");
 
         List<Document> orderedCandidates = CitationCandidateRanker.orderForCitationQuery(
                 "What does Java List.of() return?",
@@ -198,7 +204,8 @@ class CitationCandidateRankerTest {
                 .build();
     }
 
-    private static Document javaApiRootJavadocCandidate(String documentId, String documentText, String filename) {
+    private static Document javaApiRootJavadocCandidate(
+            String documentId, String documentText, String filename, String candidatePackageName) {
         DocsSourceRegistry.JavaApiDocumentationSource representedJavaApiSource =
                 DocsSourceRegistry.javaApiDocumentationSources().getFirst();
         return Document.builder()
@@ -206,7 +213,7 @@ class CitationCandidateRankerTest {
                 .text(documentText)
                 .metadata(QdrantPayloadFieldSchema.URL_FIELD, representedJavaApiSource.remoteBaseUrl() + filename)
                 .metadata(QdrantPayloadFieldSchema.DOC_TYPE_FIELD, DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE)
-                .metadata(QdrantPayloadFieldSchema.PACKAGE_FIELD, "")
+                .metadata(QdrantPayloadFieldSchema.PACKAGE_FIELD, candidatePackageName)
                 .build();
     }
 

--- a/src/test/java/com/williamcallahan/javachat/service/CitationCandidateRankerTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/CitationCandidateRankerTest.java
@@ -34,6 +34,24 @@ class CitationCandidateRankerTest {
     }
 
     @Test
+    void prioritizesCanonicalTypePagesOverClassUseAndRootPageCandidates() {
+        Document classUseCandidate = javaApiJavadocCandidate(
+                "class-use", "static <E> List<E> of(E element)", javadocPage("java.util.class-use", "List.html"));
+        Document rootPageCandidate =
+                javaApiRootJavadocCandidate("root-page", "static <E> List<E> of(E element)", "List.html");
+        Document canonicalListCandidate = javaApiJavadocCandidate(
+                "canonical-list", "static <E> List<E> of(E element)", javaUtilJavadocPage("List.html"));
+
+        List<Document> orderedCandidates = CitationCandidateRanker.orderForCitationQuery(
+                "What does Java List.of() return?",
+                List.of(classUseCandidate, rootPageCandidate, canonicalListCandidate));
+
+        assertEquals(
+                List.of("canonical-list", "class-use", "root-page"),
+                orderedCandidates.stream().map(Document::getId).toList());
+    }
+
+    @Test
     void recognizesUnparenthesizedTypeMethodSelectorsDuringCandidateOrdering() {
         Document classFileCandidate = javaApiJavadocCandidate(
                 "class-file", "A utility map() method", javaUtilJavadocPage("ClassFileFormatVersion.html"));
@@ -57,6 +75,22 @@ class CitationCandidateRankerTest {
 
         List<Document> orderedCandidates = CitationCandidateRanker.orderForCitationQuery(
                 "What does java.util.Date.toString return?", List.of(sqlDateCandidate, utilDateCandidate));
+
+        assertEquals(
+                List.of("util-date", "sql-date"),
+                orderedCandidates.stream().map(Document::getId).toList());
+    }
+
+    @Test
+    void matchesQualifiedSelectorsByUrlWhenCandidatePackageMetadataIsAbsentOrWrong() {
+        Document incorrectSqlDateCandidate = javaApiJavadocCandidateWithPackageMetadata(
+                "sql-date", "String toString()", javadocPage("java.sql", "Date.html"), "java.util");
+        Document correctUtilDateCandidate = javaApiJavadocCandidateWithoutPackageMetadata(
+                "util-date", "String toString()", javaUtilJavadocPage("Date.html"));
+
+        List<Document> orderedCandidates = CitationCandidateRanker.orderForCitationQuery(
+                "What does java.util.Date.toString return?",
+                List.of(incorrectSqlDateCandidate, correctUtilDateCandidate));
 
         assertEquals(
                 List.of("util-date", "sql-date"),
@@ -114,6 +148,7 @@ class CitationCandidateRankerTest {
                 .text("static <E> List<E> of(E element)")
                 .metadata(QdrantPayloadFieldSchema.URL_FIELD, "https://docs.example.test/java util/List.html")
                 .metadata(QdrantPayloadFieldSchema.DOC_TYPE_FIELD, DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE)
+                .metadata(QdrantPayloadFieldSchema.PACKAGE_FIELD, "java.util")
                 .build();
 
         assertThrows(
@@ -127,26 +162,62 @@ class CitationCandidateRankerTest {
                 documentId, documentText, javadocPage, DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE);
     }
 
+    private static Document javaApiJavadocCandidateWithPackageMetadata(
+            String documentId, String documentText, JavadocPage javadocPage, String candidatePackageName) {
+        return Document.builder()
+                .id(documentId)
+                .text(documentText)
+                .metadata(QdrantPayloadFieldSchema.URL_FIELD, javaApiJavadocUrl(javadocPage))
+                .metadata(QdrantPayloadFieldSchema.DOC_TYPE_FIELD, DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE)
+                .metadata(QdrantPayloadFieldSchema.PACKAGE_FIELD, candidatePackageName)
+                .build();
+    }
+
+    private static Document javaApiJavadocCandidateWithoutPackageMetadata(
+            String documentId, String documentText, JavadocPage javadocPage) {
+        return Document.builder()
+                .id(documentId)
+                .text(documentText)
+                .metadata(QdrantPayloadFieldSchema.URL_FIELD, javaApiJavadocUrl(javadocPage))
+                .metadata(QdrantPayloadFieldSchema.DOC_TYPE_FIELD, DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE)
+                .build();
+    }
+
     private static Document tutorialJavadocCandidate(String documentId, String documentText, JavadocPage javadocPage) {
         return javadocCandidateWithDocumentType(documentId, documentText, javadocPage, TUTORIAL_DOCUMENT_TYPE);
     }
 
     private static Document javadocCandidateWithDocumentType(
             String documentId, String documentText, JavadocPage javadocPage, String documentType) {
+        return Document.builder()
+                .id(documentId)
+                .text(documentText)
+                .metadata(QdrantPayloadFieldSchema.URL_FIELD, javaApiJavadocUrl(javadocPage))
+                .metadata(QdrantPayloadFieldSchema.DOC_TYPE_FIELD, documentType)
+                .metadata(QdrantPayloadFieldSchema.PACKAGE_FIELD, javadocPage.packageName())
+                .build();
+    }
+
+    private static Document javaApiRootJavadocCandidate(String documentId, String documentText, String filename) {
         DocsSourceRegistry.JavaApiDocumentationSource representedJavaApiSource =
                 DocsSourceRegistry.javaApiDocumentationSources().getFirst();
         return Document.builder()
                 .id(documentId)
                 .text(documentText)
-                .metadata(
-                        QdrantPayloadFieldSchema.URL_FIELD,
-                        representedJavaApiSource.remoteBaseUrl()
-                                + "java.base/"
-                                + javadocPage.packageName().replace('.', '/')
-                                + "/"
-                                + javadocPage.filename())
-                .metadata(QdrantPayloadFieldSchema.DOC_TYPE_FIELD, documentType)
+                .metadata(QdrantPayloadFieldSchema.URL_FIELD, representedJavaApiSource.remoteBaseUrl() + filename)
+                .metadata(QdrantPayloadFieldSchema.DOC_TYPE_FIELD, DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE)
+                .metadata(QdrantPayloadFieldSchema.PACKAGE_FIELD, "")
                 .build();
+    }
+
+    private static String javaApiJavadocUrl(JavadocPage javadocPage) {
+        DocsSourceRegistry.JavaApiDocumentationSource representedJavaApiSource =
+                DocsSourceRegistry.javaApiDocumentationSources().getFirst();
+        return representedJavaApiSource.remoteBaseUrl()
+                + "java.base/"
+                + javadocPage.packageName().replace('.', '/')
+                + "/"
+                + javadocPage.filename();
     }
 
     private static JavadocPage javaUtilJavadocPage(String filename) {

--- a/src/test/java/com/williamcallahan/javachat/service/RetrievalServiceCitationTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/RetrievalServiceCitationTest.java
@@ -65,6 +65,25 @@ class RetrievalServiceCitationTest {
     }
 
     @Test
+    void derivesMemberAnchorPackageFromCanonicalUrlInsteadOfLegacyMetadata() {
+        String mapJavadocUrl = javaUtilMapJavadocUrl();
+        Document legacyMapDocument = Document.builder()
+                .id("legacy-map-package")
+                .text("copyOf(Map.Entry entry)")
+                .metadata(QdrantPayloadFieldSchema.URL_FIELD, mapJavadocUrl)
+                .metadata(QdrantPayloadFieldSchema.PACKAGE_FIELD, "java.base.java.util")
+                .metadata(QdrantPayloadFieldSchema.DOC_TYPE_FIELD, DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE)
+                .build();
+
+        Citation citation = citationService()
+                .toCitations(List.of(legacyMapDocument))
+                .citations()
+                .getFirst();
+
+        assertEquals("copyOf(java.util.Map.Entry)", citation.getAnchor());
+    }
+
+    @Test
     void serializedCitationSplitsAtTheFirstFragmentDelimiterWithoutDecodingTheAnchor() {
         String citationPageUrl = "https://example.test/reference/arrays";
         String encodedCitationAnchor = "method%28java.lang.String%5B%5D%29#details%20section";
@@ -256,6 +275,11 @@ class RetrievalServiceCitationTest {
     private static String javaLangStringJavadocUrl() {
         return DocsSourceRegistry.javaApiDocumentationSources().getFirst().remoteBaseUrl()
                 + "java.base/java/lang/String.html";
+    }
+
+    private static String javaUtilMapJavadocUrl() {
+        return DocsSourceRegistry.javaApiDocumentationSources().getFirst().remoteBaseUrl()
+                + "java.base/java/util/Map.html";
     }
 
     /** Simulates malformed metadata values whose string conversion fails at runtime. */

--- a/src/test/java/com/williamcallahan/javachat/service/RetrievalServiceTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/RetrievalServiceTest.java
@@ -127,13 +127,11 @@ class RetrievalServiceTest {
         String citationQuery = "What does List.of return?";
         String listPageUrl = javaApiPageUrl("java.util", "List.html");
         List<Document> qdrantCandidates = List.of(
+                apiDocumentationCitationCandidate("object", "A utility of() method", "java.lang", "Object.html"),
+                apiDocumentationCitationCandidate("string", "A utility of() method", "java.lang", "String.html"),
+                apiDocumentationCitationCandidate("integer", "A utility of() method", "java.lang", "Integer.html"),
                 apiDocumentationCitationCandidate(
-                        "object", "A utility of() method", javaApiPageUrl("java.lang", "Object.html")),
-                apiDocumentationCitationCandidate(
-                        "string", "A utility of() method", javaApiPageUrl("java.lang", "String.html")),
-                apiDocumentationCitationCandidate(
-                        "integer", "A utility of() method", javaApiPageUrl("java.lang", "Integer.html")),
-                apiDocumentationCitationCandidate("list", "static <E> List<E> of(E element)", listPageUrl));
+                        "list", "static <E> List<E> of(E element)", "java.util", "List.html"));
         when(hybridSearchService.searchDocumentationCitationsOutcome(
                         eq(citationQuery), eq(4), same(officialDocumentationConstraint)))
                 .thenReturn(new HybridSearchService.SearchOutcome(qdrantCandidates, List.of()));
@@ -222,12 +220,13 @@ class RetrievalServiceTest {
     }
 
     private static Document apiDocumentationCitationCandidate(
-            String documentId, String documentText, String sourceUrl) {
+            String documentId, String documentText, String packageName, String pageFilename) {
         return Document.builder()
                 .id(documentId)
                 .text(documentText)
-                .metadata(QdrantPayloadFieldSchema.URL_FIELD, sourceUrl)
+                .metadata(QdrantPayloadFieldSchema.URL_FIELD, javaApiPageUrl(packageName, pageFilename))
                 .metadata(QdrantPayloadFieldSchema.DOC_TYPE_FIELD, DocsSourceRegistry.JAVA_API_DOCUMENT_TYPE)
+                .metadata(QdrantPayloadFieldSchema.PACKAGE_FIELD, packageName)
                 .build();
     }
 

--- a/src/test/java/com/williamcallahan/javachat/service/ingestion/JavaPackageExtractorTest.java
+++ b/src/test/java/com/williamcallahan/javachat/service/ingestion/JavaPackageExtractorTest.java
@@ -25,7 +25,23 @@ class JavaPackageExtractorTest {
                 + "?redirect=/api/#append-java.lang.String-";
 
         assertTrue(JavaPackageExtractor.isJavaApiUrl(javadocUrl));
-        assertEquals("java.lang", JavaPackageExtractor.extractPackage(javadocUrl, ""));
+        assertEquals("java.lang", JavaPackageExtractor.extractJavaApiPackage(javadocUrl));
+        assertEquals("java.lang", JavaPackageExtractor.extractPackage(javadocUrl, "Package java.fake"));
+    }
+
+    @Test
+    void derivesOnlyValidPackagesEncodedByCanonicalJavaApiPaths() {
+        String javaApiBaseUrl =
+                DocsSourceRegistry.javaApiDocumentationSources().getFirst().remoteBaseUrl();
+
+        assertEquals(
+                "java.util",
+                JavaPackageExtractor.extractJavaApiPackage(javaApiBaseUrl + "java.base/java/util/List.html"));
+        assertEquals(
+                "",
+                JavaPackageExtractor.extractJavaApiPackage(javaApiBaseUrl + "java.base/java/util/class-use/List.html"));
+        assertEquals("", JavaPackageExtractor.extractJavaApiPackage(javaApiBaseUrl + "List.html"));
+        assertEquals("", JavaPackageExtractor.extractJavaApiPackage(SPRING_BOOT_API_URL));
     }
 
     @Test
@@ -43,5 +59,14 @@ class JavaPackageExtractorTest {
         String springBootReferenceUrl = "https://docs.spring.io/spring-boot/reference/?redirect=/api/#/api/";
 
         assertFalse(JavaPackageExtractor.isJavaApiUrl(springBootReferenceUrl));
+    }
+
+    @Test
+    void validatesBodyTextPackageFallbackThroughTheCanonicalPackageOwner() {
+        String referenceUrl = "https://example.test/java/reference";
+
+        assertEquals("java.util", JavaPackageExtractor.extractPackage(referenceUrl, "Package java.util,"));
+        assertEquals("", JavaPackageExtractor.extractPackage(referenceUrl, "Package java.util.class-use"));
+        assertEquals("", JavaPackageExtractor.extractPackage(referenceUrl, "Package java.class"));
     }
 }


### PR DESCRIPTION
## Summary

- derive Java API package identity from manifest-governed canonical source URLs
- validate Java 25 package names through one framework-free domain value type
- demote auxiliary `class-use` and root redirect pages behind canonical type pages
- derive member-anchor packages from canonical URLs instead of stale persisted metadata

## Root cause

Unqualified selectors originally matched only the final filename, so auxiliary `class-use/List.html` and root redirects could receive the canonical type-page tier. The first package-aware correction trusted persisted Qdrant package metadata, but live dev data still contained an older module-prefixed form such as `java.base.java.util`. That prevented canonical pages from being promoted and could also produce incorrect same-package member anchors.

The final implementation uses the canonical Java API URL as the single runtime package source. `JavaPackageName` owns Java 25 package validation; `JavaPackageExtractor` owns manifest URL-to-package projection; ranking and anchor generation no longer read the persisted package field.

## Verification

- 42 focused package, selector, extractor, ranker, citation, and canonicalizer tests
- 665 backend tests
- frontend production build
- PMD and SpotBugs main/test
- frontend lint, type-aware lint, AST rules, and Svelte checks
- signed commits and repository hooks
- live dev regression check against pre-existing indexed metadata
