### PR TITLE
Fix async guided-learning CI race

### DIFF
--- a/src/test/java/com/williamcallahan/javachat/web/GuidedLearningControllerCuratedContentTest.java
+++ b/src/test/java/com/williamcallahan/javachat/web/GuidedLearningControllerCuratedContentTest.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.MockMvcPrint;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -36,6 +38,7 @@ import reactor.core.publisher.Flux;
 
 /** Verifies guided content HTTP contracts resolve only authoritative curated lesson markdown. */
 @WebMvcTest(controllers = GuidedLearningController.class)
+@AutoConfigureMockMvc(print = MockMvcPrint.NONE)
 @Import({AppProperties.class, WebMvcConfig.class, SseSupport.class, SimpleMeterRegistry.class})
 @org.springframework.security.test.context.support.WithMockUser
 class GuidedLearningControllerCuratedContentTest {


### PR DESCRIPTION
## Summary
- disable MockMvc result printing in the async curated-content SSE test
- prevent the result handler from iterating headers while the async response is still mutating
- preserve the controller and SSE production behavior

## Verification
- bash scripts/test_documentation_fetch_projection.sh



PASS: explicit fetch options, pinned source selection, version rejection, and Java seed safety are wired.
bash scripts/test_documentation_fetch_publication.sh
PASS: failed documentation publication retains staging and restores active and superseded roots.
bash scripts/test_embedding_preflight.sh
PASS: gateway preflight requires the canonical model/dimensions, batch tier, paced batches 1/4, Retry-After, ordering, and numeric values.
bash scripts/test_github_sync_failure_contract.sh
PASS: GitHub sync validates the exact Qdrant generation schema before network access and propagates dependency failures.
bash scripts/test_ingestion_pid_safety.sh
PASS: ingestion PID files fail closed without signaling or replacing another run.
bash scripts/test_make_local_qdrant_bootstrap.sh
PASS: local Make commands bootstrap loopback Qdrant only.
bash scripts/test_make_port_safety.sh
PASS: Make port checks fail closed without signaling listeners.
bash scripts/test_process_all_to_qdrant_environment.sh
PASS: arbitrary DOCS_DIR is exported to a servlet-free ingestion child after fail-fast validation.
bash scripts/test_process_all_to_qdrant_postconditions.sh
PASS: every emitted docSet requires a valid nonzero exact count across the active collections.
bash scripts/test_prune_retired_java_api_vectors.sh
PASS: retired Java API vector prune tests
To honour the JVM settings for this build a single-use Daemon process will be forked. For more on this, please refer to https://docs.gradle.org/9.2.1/userguide/gradle_daemon.html#sec:disabling_the_daemon in the Gradle documentation.


[2A[1B[1m> Starting Daemon[m[17D[1B[1A> IDLE[0K[6D[1B[2ADaemon will be stopped at the end of the build 
[1B[0K
[2A[0K[1B> IDLE[6D[1B[2A[1m<[0;1m-------------> 0% INITIALIZING [98ms][m[38D[2B[2A[1m<[0;1m-------------> 0% INITIALIZING [201ms][m[39D[2B[2A[1m<[0;1m-------------> 0% INITIALIZING [296ms][m[39D[2B[2A[1m<[0;1m-------------> 0% INITIALIZING [396ms][m[39D[2B[2A[1m<[0;1m-------------> 0% INITIALIZING [498ms][m[39D[2B[2A[1m<[0;1m-------------> 0% INITIALIZING [594ms][m[39D[2B[2A[1m<[0;1m-------------> 0% INITIALIZING [699ms][m[39D[2B[2A[1m<[0;1m-------------> 0% INITIALIZING [796ms][m[39D[2B[2A[1m<[0;1m-------------> 0% INITIALIZING [899ms][m[39D[2B[2A[1m<[0;1m-------------> 0% INITIALIZING [995ms][m[39D[2B[2A[1m<[0;1m-------------> 0% INITIALIZING [1s][m[0K[36D[2B[2A[1m<[0;1m-------------> 0% INITIALIZING [2s][m[36D[2B[2AReusing configuration cache.[0K
[1B[0K
[2A[1m<[0;1m-------------> 0% INITIALIZING [3s][m[36D[1B> IDLE[6D[1B[1A[1m> Loading configuration cache state[m[35D[1B[2A[1m<[0;1m-------------> 0% INITIALIZING [4s][m[36D[2B[1A[1m> Loading configuration cache state > :[m[39D[1B[2A[1m<[0;1m-------------> 0% INITIALIZING [5s][m[36D[2B[1A[1m> Loading configuration cache state[m[0K[35D[1B[2A[1m<[0;1m-------------> 0% EXECUTING [5s][m[0K[33D[1B> IDLE[0K[6D[1B


[4A[1m> :cleanTest[m[12D[1B[1m> :processTestResources[m[23D[1B[1m> :compileJava[m[14D[1B[1m> :processResources[m[19D[1B[5A[1m<[0;32;1m=[0;39;1m------------> 11% EXECUTING [5s][m[34D[2B> IDLE[0K[6D[3B[5A[1m<[0;32;1m==[0;39;1m-----------> 22% EXECUTING [5s][m[34D[1B> IDLE[0K[6D[4B[5A[1m<[0;32;1m====[0;39;1m---------> 33% EXECUTING [5s][m[34D[3B> IDLE[0K[6D[2B[5A[1m<[0;32;1m====[0;39;1m---------> 33% EXECUTING [6s][m[34D[5B[5A[1m<[0;32;1m=====[0;39;1m--------> 44% EXECUTING [6s][m[34D[4B[1m> :bootBuildInfo[m[0K[16D[1B[5A[1m<[0;32;1m========[0;39;1m-----> 66% EXECUTING [6s][m[34D[4B[1m> :compileTestJava[m[18D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [6s][m[34D[4B[1m> :test[m[0K[7D[1B[1A[1m> :test > 0 tests completed[m[27D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [7s][m[34D[5B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [8s][m[34D[5B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [9s][m[34D[5B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [10s][m[35D[5B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [11s][m[35D[5B[2A[1m> :test > Executing test com.williamcallahan.javachat.JavaChatApplicationTests[m[78D[2B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [12s][m[35D[5B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [13s][m[35D[5B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [14s][m[35D[5B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [15s][m[35D[5B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [16s][m[35D[5B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [17s][m[35D[5B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [18s][m[35D[5B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [19s][m[35D[5B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [20s][m[35D[5B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [21s][m[35D[5B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [22s][m[35D[5B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [23s][m[35D[5B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [24s][m[35D[5B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [25s][m[35D[5B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [26s][m[35D[5B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [27s][m[35D[5B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [28s][m[35D[5B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [29s][m[35D[5B[1A[1m> :test > 1 test completed[m[0K[26D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [30s][m[35D[4B[1m> :test > 2 tests completed[m[27D[1B[2A[1m> :test > Executing test com.williamcallahan...search.JavaApiMethodSelectorTest[m[79D[1B[1m> :test > 36 tests completed[m[28D[1B[2A[1m> :test > Executing test com...cli.DocumentProcessorFailureContractTest[m[0K[71D[1B[1m> :test > 55 tests completed[m[28D[1B[2A[1m> :test > Executing test com.williamcallahan...cli.DocumentProcessorSelectionTe[m[79D[1B[1m> :test > 59 tests completed[m[28D[1B[2A[1m> :test > Executing test com.williamcallahan...cli.GitHubRepoProcessorIsolation[m[79D[1B[1m> :test > 61 tests completed[m[28D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [31s][m[35D[3B[1m> :test > Executing test com.williamcallahan...config.EmbeddingConfigStartupTes[m[79D[1B[1m> :test > 99 tests completed[m[28D[1B[1A[1m> :test > 100 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan...config.QdrantCredentialValidatio[m[79D[1B[1m> :test > 106 tests completed[m[29D[1B[2A[1m> :test > Executing test com...config.QdrantGitHubCollectionDiscoveryTest[m[0K[73D[1B[1m> :test > 107 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan...config.QdrantHealthIndicatorTest[m[79D[1B[1m> :test > 110 tests completed[m[29D[1B[1A[1m> :test > 111 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan...config.QdrantIndexInitializerTes[m[79D[1B[1m> :test > 117 tests completed[m[29D[1B[1A[1m> :test > 128 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan...config.RuntimeNameValidationTest[m[79D[1B[1m> :test > 156 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [32s][m[35D[3B[1m> :test > Executing test com.williamcallahan.javachat.config.SecurityConfigTest[m[79D[1B[1m> :test > 157 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [33s][m[35D[3B[1m> :test > Executing test com.williamcallahan.javachat.domain.SearchQualityLevel[m[79D[1B[1m> :test > 169 tests completed[m[29D[1B[2A[1m> :test > Executing test com...ingestion.GitHubCollectionNamingScriptTest[m[0K[73D[1B[1m> :test > 176 tests completed[m[29D[1B[1A[1m> :test > 177 tests completed[m[29D[1B[1A[1m> :test > 178 tests completed[m[29D[1B[1A[1m> :test > 180 tests completed[m[29D[1B[1A[1m> :test > 181 tests completed[m[29D[1B[2A[1m> :test > Executing test com...ingestion.GitHubRepositoryIdentityTest[m[0K[69D[1B[1m> :test > 182 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan.javachat.service.AuditServiceTest[m[78D[1B[1m> :test > 213 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [34s][m[35D[5B[2A[1m> :test > Executing test com.williamcallahan.javachat.service.ChatServiceTest[m[0K[77D[1B[1m> :test > 223 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan...service.ChunkProcessingServiceTe[m[79D[1B[1m> :test > 226 tests completed[m[29D[1B[2A[1m> :test > Executing test com...service.ComprehensiveListFormattingTest[m[0K[70D[1B[1m> :test > 252 tests completed[m[29D[1B[1A[1m> :test > 258 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan...service.DocsIngestionServiceTest[m[79D[1B[1m> :test > 267 tests completed[m[29D[1B[1A[1m> :test > 271 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [35s][m[35D[4B[1m> :test > 272 tests completed[m[29D[1B[1A[1m> :test > 276 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan...service.EmbeddingBatchEmbedderTe[m[79D[1B[1m> :test > 295 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan...service.EmbeddingProviderFailure[m[79D[1B[1m> :test > 305 tests completed[m[29D[1B[2A> IDLE[0K[6D[1B[1m> :test > 307 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan...service.EnrichmentServiceCacheTe[m[79D[2B[2A[1m> :test > Executing test com...service.GuidedLearningServiceCitationTest[m[0K[72D[1B[1m> :test > 324 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [36s][m[35D[5B[1A[1m> :test > 326 tests completed[m[29D[1B[1A[1m> :test > 327 tests completed[m[29D[1B[1A[1m> :test > 332 tests completed[m[29D[1B[2A[1m> :test > Executing test com...service.GuidedLessonCuratedContentTest[m[0K[69D[1B[1m> :test > 338 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan.javachat.service.GuidedTOCProvider[m[79D[1B[1m> :test > 343 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan.javachat.service.HybridSearchServi[m[79D[1B[1m> :test > 350 tests completed[m[29D[1B[1A[1m> :test > 351 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [37s][m[35D[4B[1m> :test > 355 tests completed[m[29D[1B[1A[1m> :test > 359 tests completed[m[29D[1B[1A[1m> :test > 363 tests completed[m[29D[1B[1A[1m> :test > 364 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan.javachat.service.HybridVectorServi[m[79D[1B[1m> :test > 374 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [38s][m[35D[5B[1A[1m> :test > 377 tests completed[m[29D[1B[1A[1m> :test > 379 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [39s][m[35D[5B[2A[1m> :test > Executing test com.williamcallahan...service.LocalEmbeddingClientTest[m[79D[1B[1m> :test > 389 tests completed[m[29D[1B[2A[1m> :test > Executing test com...service.LocalStoreServiceFileMarkerTest[m[0K[70D[1B[1m> :test > 393 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan...service.MarkdownPreprocessingTes[m[79D[1B[1m> :test > 412 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan.javachat.service.MarkdownServiceTe[m[79D[1B[1m> :test > 439 tests completed[m[29D[1B[1A[1m> :test > 455 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [40s][m[35D[3B[1m> :test > Executing test com.williamcallahan...service.OpenAICompletionStatusTe[m[79D[1B[1m> :test > 461 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [41s][m[35D[5B[1A[1m> :test > 462 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [42s][m[35D[4B[1m> :test > 463 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [43s][m[35D[5B[1A[1m> :test > 464 tests completed[m[29D[1B[1A[1m> :test > 465 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [44s][m[35D[5B[1A[1m> :test > 466 tests completed[m[29D[1B[1A[1m> :test > 467 tests completed[m[29D[1B[1A[1m> :test > 468 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [45s][m[35D[5B[1A[1m> :test > 469 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [46s][m[35D[4B[1m> :test > 470 tests completed[m[29D[1B[2A[1m> :test > Executing test com...service.OpenAIStreamingProviderFailureTest[m[0K[73D[1B[1m> :test > 471 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [47s][m[35D[4B[1m> :test > 472 tests completed[m[29D[1B[1A[1m> :test > 473 tests completed[m[29D[1B[1A[1m> :test > 474 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [48s][m[35D[5B[1A[1m> :test > 475 tests completed[m[29D[1B[1A[1m> :test > 476 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan...service.OpenAIStreamingServiceTe[m[79D[1B[1m> :test > 477 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [49s][m[35D[5B[1A[1m> :test > 478 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [50s][m[35D[4B[1m> :test > 479 tests completed[m[29D[1B[1A[1m> :test > 480 tests completed[m[29D[1B[1A[1m> :test > 481 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [51s][m[35D[4B[1m> :test > 482 tests completed[m[29D[1B[1A[1m> :test > 483 tests completed[m[29D[1B[1A[1m> :test > 484 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [52s][m[35D[5B[1A[1m> :test > 485 tests completed[m[29D[1B[1A[1m> :test > 486 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [53s][m[35D[5B[1A[1m> :test > 487 tests completed[m[29D[1B[1A[1m> :test > 488 tests completed[m[29D[1B[1A[1m> :test > 489 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [54s][m[35D[5B[1A[1m> :test > 490 tests completed[m[29D[1B[1A[1m> :test > 491 tests completed[m[29D[1B[1A[1m> :test > 492 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [55s][m[35D[5B[1A[1m> :test > 493 tests completed[m[29D[1B[1A[1m> :test > 494 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [56s][m[35D[5B[1A[1m> :test > 495 tests completed[m[29D[1B[1A[1m> :test > 496 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [57s][m[35D[5B[1A[1m> :test > 497 tests completed[m[29D[1B[1A[1m> :test > 498 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [58s][m[35D[5B[2A[1m> :test > Executing test com...service.OpenAIStreamingTimeoutContractTest[m[0K[73D[1B[1m> :test > 499 tests completed[m[29D[1B[2A[1m> :test > Executing test com...service.OpenAiCompatibleEmbeddingClientTest[m[74D[1B[1m> :test > 500 tests completed[m[29D[1B[1A[1m> :test > 503 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [59s][m[35D[5B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m][m[0K[34D[5B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 1s][m[37D[5B[1A[1m> :test > 508 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 2s][m[37D[5B[1A[1m> :test > 514 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 3s][m[37D[4B[1m> :test > 518 tests completed[m[29D[1B[1A[1m> :test > 521 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 4s][m[37D[5B[1A[1m> :test > 524 tests completed[m[29D[1B[2A[1m> :test > Executing test com...service.OpenAiCompatibleEmbeddingClientWireTest[m[78D[1B[1m> :test > 525 tests completed[m[29D[1B[2A[1m> :test > Executing test com...service.OpenAiProviderRoutingServiceTest[m[0K[71D[1B[1m> :test > 543 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan...service.OpenAiRequestFactoryTest[m[79D[1B[1m> :test > 550 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 5s][m[37D[5B[1A[1m> :test > 551 tests completed[m[29D[1B[1A[1m> :test > 553 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 6s][m[37D[5B[1A[1m> :test > 554 tests completed[m[29D[1B[1A[1m> :test > 555 tests completed[m[29D[1B[1A[1m> :test > 556 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 7s][m[37D[5B[1A[1m> :test > 558 tests completed[m[29D[1B[1A[1m> :test > 559 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 8s][m[37D[5B[1A[1m> :test > 560 tests completed[m[29D[1B[1A[1m> :test > 562 tests completed[m[29D[1B[1A[1m> :test > 563 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 9s][m[37D[5B[1A[1m> :test > 564 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 10s][m[38D[5B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 11s][m[38D[5B[1A[1m> :test > 565 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 12s][m[38D[3B[1m> :test > Executing test com.williamcallahan...service.ProviderCircuitStateTest[m[79D[1B[1m> :test > 568 tests completed[m[29D[1B[2A[1m> :test > Executing test com...service.QdrantListenableFutureBridgeTest[m[0K[71D[1B[1m> :test > 573 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan.javachat.service.RateLimitServiceT[m[79D[1B[1m> :test > 600 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan.javachat.service.RateLimitStateTes[m[79D[1B[1m> :test > 605 tests completed[m[29D[1B[1A[1m> :test > 611 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan.javachat.service.RerankerServiceTe[m[79D[1B[1m> :test > 618 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 13s][m[38D[5B[1A[1m> :test > 623 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 14s][m[38D[5B[1A[1m> :test > 628 tests completed[m[29D[1B[1A[1m> :test > 629 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan...service.RetrievalServiceCitation[m[79D[1B[1m> :test > 636 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 15s][m[38D[5B[2A[1m> :test > Executing test com.williamcallahan.javachat.service.RetrievalServiceT[m[79D[1B[1m> :test > 658 tests completed[m[29D[1B[1A[1m> :test > 662 tests completed[m[29D[1B[2A> IDLE[0K[6D[1B[1m> :test > 682 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan...ingestion.HtmlContentGuardTest[m[77D[1B[1m> :test > 689 tests completed[m[29D[1B[2A[1m> :test > Executing test com...ingestion.IngestedFilePruneServiceTest[m[0K[69D[1B[1m> :test > 697 tests completed[m[29D[1B[2A[1m> :test > Executing test com...ingestion.IngestionQuarantineServiceTest[m[71D[1B[1m> :test > 712 tests completed[m[29D[1B[1A[1m> :test > 718 tests completed[m[29D[1B[1A[1m> :test > 720 tests completed[m[29D[1B[2A[1m> :test > Executing test com...ingestion.LocalDocsDirectoryIngestionServiceTest[m[79D[1B[1m> :test > 727 tests completed[m[29D[1B[1A[1m> :test > 728 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 16s][m[38D[5B[2A[1m> :test > Executing test com...ingestion.LocalDocsFileIngestionProcessorTest[m[0K[76D[1B[1m> :test > 734 tests completed[m[29D[1B[1A[1m> :test > 735 tests completed[m[29D[1B[1A[1m> :test > 743 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 17s][m[38D[5B[1A[1m> :test > 749 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan...ingestion.LocalIngestionRunStore[m[79D[1B[1m> :test > 755 tests completed[m[29D[1B[1A[1m> :test > 759 tests completed[m[29D[1B[2A[1m> :test > Executing test com...ingestion.SourceCodeFileIngestionProcessorTest[m[0K[77D[1B[1m> :test > 761 tests completed[m[29D[1B[2A[1m> :test > Executing test com...markdown.EnrichmentPlaceholderizerTest[m[0K[69D[1B[1m> :test > 786 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 18s][m[38D[5B[1A[1m> :test > 787 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan...service.markdown.InlineListParse[m[79D[1B[1m> :test > 819 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan...markdown.MarkdownNormalizerTest[m[0K[78D[1B[1m> :test > 843 tests completed[m[29D[1B[2A[1m> :test > Executing test com...support.EnvironmentVariablePrecedenceTest[m[0K[72D[1B[1m> :test > 875 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan...support.OpenAiSdkUrlNormalizerTe[m[79D[1B[1m> :test > 880 tests completed[m[29D[1B[2A[1m> :test > Executing test com...AuthenticatedUserEndpointClerkDisabledIntegratio[m[79D[1B[1m> :test > 907 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 19s][m[38D[5B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 20s][m[38D[5B[2A[1m> :test > Executing test com...web.AuthenticatedUserEndpointSecurityIntegration[m[79D[1B[1m> :test > 911 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 21s][m[38D[5B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 22s][m[38D[5B[1A[1m> :test > 913 tests completed[m[29D[1B[2A[1m> :test > Executing test com...web.BrowserErrorResponseIntegrationTest[m[0K[70D[1B[1m> :test > 914 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 23s][m[38D[5B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 24s][m[38D[5B[1A[1m> :test > 915 tests completed[m[29D[1B[1A[1m> :test > 918 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 25s][m[38D[3B[1m> :test > Executing test com...web.ChatControllerRetrievalDiagnosticsTest[m[73D[1B[1m> :test > 920 tests completed[m[29D[1B[2A[1m> :test > Executing test com...web.ChatControllerStreamingFailureTest[m[0K[69D[1B[1m> :test > 930 tests completed[m[29D[1B[1A[1m> :test > 931 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan...web.ChatPreparationSseIntegratio[m[79D[1B[1m> :test > 937 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 26s][m[38D[5B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 27s][m[38D[5B[1A[1m> :test > 938 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 28s][m[38D[5B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 29s][m[38D[5B[2A[1m> :test > Executing test com.williamcallahan.javachat.web.ChatStreamRequestTest[m[79D[2B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 30s][m[38D[5B[1A[1m> :test > 939 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan.javachat.web.CustomErrorController[m[79D[1B[1m> :test > 954 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan.javachat.web.EnrichmentControllerT[m[79D[1B[1m> :test > 967 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 31s][m[38D[5B[2A[1m> :test > Executing test com...web.GuidedLearningControllerBackpressureOverflow[m[79D[1B[1m> :test > 972 tests completed[m[29D[1B[2A[1m> :test > Executing test com...web.GuidedLearningControllerCuratedContentTest[m[0K[77D[1B[1m> :test > 973 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan...web.GuidedLearningControllerTest[m[79D[1B[1m> :test > 983 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 32s][m[38D[5B[1A[1m> :test > 985 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan.javachat.web.GuidedSseCitationEven[m[79D[1B[1m> :test > 986 tests completed[m[29D[1B[1A[1m> :test > 988 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan.javachat.web.IngestionControllerTe[m[79D[1B[1m> :test > 989 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 33s][m[38D[5B[2A[1m> :test > Executing test com.williamcallahan.javachat.web.MarkdownApiIntegratio[m[79D[1B[1m> :test > 996 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan...web.OpenGraphImageControllerTest[m[79D[1B[1m> :test > 997 tests completed[m[29D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 34s][m[38D[5B[2A[1m> :test > Executing test com.williamcallahan.javachat.web.OpenGraphImageRendere[m[79D[1B[1m> :test > 999 tests completed[m[29D[1B[2A[1m> :test > Executing test com.williamcallahan.javachat.web.RobotsControllerTest[m[0K[78D[1B[1m> :test > 1001 tests completed[m[30D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 35s][m[38D[5B[2A[1m> :test > Executing test com.williamcallahan.javachat.web.SeoControllerTest[m[0K[75D[1B[1m> :test > 1002 tests completed[m[30D[1B[2A[1m> :test > Executing test com.williamcallahan.javachat.web.SitemapControllerTest[m[79D[1B[1m> :test > 1005 tests completed[m[30D[1B[2A[1m> :test > Executing test com.williamcallahan.javachat.web.SseSupportTest[m[0K[72D[1B[1m> :test > 1014 tests completed[m[30D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 36s][m[38D[5B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 37s][m[38D[5B[2A> IDLE[0K[6D[1B[1m> :test > 1019 tests completed[m[30D[1B[5A17:46:19.679 [SpringApplicationShutdownHook] INFO  o.s.b.w.e.tomcat.GracefulShutdown - Commencing graceful shutdown. Waiting for active requests to complete [0K
[4B[0K
[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 37s][m[38D[1B> IDLE[6D[1B> IDLE[6D[1B> IDLE[0K[6D[1B[1m> :test > 1019 tests completed[m[30D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 38s][m[38D[5B[5A17:46:20.690 [tomcat-shutdown] INFO  o.s.b.w.e.tomcat.GracefulShutdown - Graceful shutdown complete [0K
[4B[0K
[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 38s][m[38D[1B> IDLE[6D[1B> IDLE[6D[1B> IDLE[0K[6D[1B[1m> :test > 1019 tests completed[m[30D[1B[1A[1m> :test[m[0K[7D[1B[5A[1m<[0;32;1m===========[0;39;1m--> 88% EXECUTING [1m 39s][m[38D[5B[1A[1m> :test > Packing build cache entry[m[35D[1B[5A[1m<[0;32;1m=============[0;39;1m> 100% EXECUTING [1m 39s][m[39D[4B> IDLE[0K[6D[1B[5A[0K
[32;1mBUILD SUCCESSFUL[0;39m in 1m 44s[0K
7 actionable tasks: 3 executed, 4 up-to-date[0K
Configuration cache entry reused.[0K
[1B[0K
[0K
[0K
[0K
[5A[1m<[0;1m-------------> 0% WAITING[m[26D[1B> IDLE[6D[1B> IDLE[6D[1B> IDLE[6D[1B> IDLE[6D[1B[5A[2K[1B[2K[1B[2K[1B[2K[1B[2K[1B[2K[5A (1019 tests)
- pre-push build-and-test and lint
- 3 repeated focused test runs
- SpotBugs, PMD, Spotless