### PR TITLE
fix: atomic contact-form rate limiting, JavaChat crawler metadata, and new-tab menu links

### DIFF
--- a/frontend/src/lib/components/HeaderMenu.svelte
+++ b/frontend/src/lib/components/HeaderMenu.svelte
@@ -59,6 +59,10 @@
   }
 
   function navigateToSiteLink(clickEvent: MouseEvent, siteLink: SiteLink): void {
+    // Modified or non-primary clicks must keep native anchor semantics (new tab/window).
+    if (clickEvent.button !== 0 || clickEvent.metaKey || clickEvent.ctrlKey || clickEvent.shiftKey || clickEvent.altKey) {
+      return
+    }
     clickEvent.preventDefault()
     currentView = siteLink.view
     closeMenu()

--- a/frontend/src/lib/components/HeaderMenu.test.ts
+++ b/frontend/src/lib/components/HeaderMenu.test.ts
@@ -113,4 +113,16 @@ describe("HeaderMenu page links", () => {
     expect(contactLink).toHaveAttribute("aria-current", "page");
     expect(getByRole("menuitem", { name: "Privacy" })).not.toHaveAttribute("aria-current");
   });
+
+  it("leaves modified clicks to the browser so links can open in a new tab", async () => {
+    const { getByRole } = render(HeaderMenu, { props: { currentView: "chat" } });
+
+    await fireEvent.click(getByRole("button", { name: "Settings and pages menu" }));
+    const contactLink = getByRole("menuitem", { name: "Contact" });
+    const clickEvent = new MouseEvent("click", { bubbles: true, cancelable: true, metaKey: true });
+    await fireEvent(contactLink, clickEvent);
+
+    expect(clickEvent.defaultPrevented).toBe(false);
+    expect(contactLink).not.toHaveAttribute("aria-current");
+  });
 });

--- a/mobile/iosApp/JavaChat/Info.plist
+++ b/mobile/iosApp/JavaChat/Info.plist
@@ -37,6 +37,8 @@
 	<string>public.app-category.productivity</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>UILaunchScreen</key>
 	<dict/>
 	<key>UISupportedInterfaceOrientations~ipad</key>

--- a/src/main/java/com/williamcallahan/javachat/application/contact/ContactSubmissionUseCase.java
+++ b/src/main/java/com/williamcallahan/javachat/application/contact/ContactSubmissionUseCase.java
@@ -10,6 +10,7 @@ import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.mail.MailException;
 import org.springframework.mail.MailParseException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
@@ -83,7 +84,7 @@ public class ContactSubmissionUseCase {
 
         try {
             javaMailSender.send(buildMimeMessage(contactSubmission));
-        } catch (RuntimeException deliveryFailure) {
+        } catch (MailException deliveryFailure) {
             acceptedSubmissionCount.decrementAndGet();
             throw deliveryFailure;
         }

--- a/src/main/java/com/williamcallahan/javachat/application/contact/ContactSubmissionUseCase.java
+++ b/src/main/java/com/williamcallahan/javachat/application/contact/ContactSubmissionUseCase.java
@@ -74,13 +74,19 @@ public class ContactSubmissionUseCase {
 
         AtomicInteger acceptedSubmissionCount =
                 acceptedSubmissionsPerIp.get(contactSubmission.remoteAddress(), remoteAddress -> new AtomicInteger());
-        if (acceptedSubmissionCount.get() >= MAX_ACCEPTED_SUBMISSIONS_PER_IP) {
+        int reservedSubmissionSlot = acceptedSubmissionCount.incrementAndGet();
+        if (reservedSubmissionSlot > MAX_ACCEPTED_SUBMISSIONS_PER_IP) {
+            acceptedSubmissionCount.decrementAndGet();
             log.info("Contact submission rate limited");
             throw new ContactRateLimitExceededException();
         }
 
-        javaMailSender.send(buildMimeMessage(contactSubmission));
-        acceptedSubmissionCount.incrementAndGet();
+        try {
+            javaMailSender.send(buildMimeMessage(contactSubmission));
+        } catch (RuntimeException deliveryFailure) {
+            acceptedSubmissionCount.decrementAndGet();
+            throw deliveryFailure;
+        }
         log.info("Contact message delivered");
     }
 

--- a/src/main/java/com/williamcallahan/javachat/web/SeoController.java
+++ b/src/main/java/com/williamcallahan/javachat/web/SeoController.java
@@ -60,35 +60,35 @@ public class SeoController {
         String defaultImage = "/og-image.png";
 
         PageMetadata base = new PageMetadata(
-                "Java Chat - AI-Powered Java Learning With Citations",
-                "Learn Java faster with an AI tutor: streaming answers, code examples, and citations to official docs.",
+                "JavaChat - AI Learning",
+                "Learn Java with an AI tutor: streaming answers cited to official JDK docs, plus guided lessons on Spring Boot, Quarkus, Kotlin, virtual threads, records, and pattern matching.",
                 defaultImage);
 
         metadataMap.put("/", base);
         metadataMap.put(
                 "/chat",
                 new PageMetadata(
-                        "Java Chat - Streaming Java Tutor With Citations",
+                        "JavaChat - Streaming Java Tutor With Citations",
                         "Ask Java questions and get streaming answers with citations to official docs and practical examples.",
                         defaultImage));
 
         PageMetadata guided = new PageMetadata(
-                "Guided Java Learning - Java Chat",
-                "Structured, step-by-step Java learning paths with examples and explanations.",
+                "Guided Java Learning - JavaChat",
+                "Guided Java lessons with examples and explanations: Spring Boot, Quarkus, Kotlin and other JVM languages, virtual threads, records, pattern matching, and JUnit testing.",
                 defaultImage);
         metadataMap.put("/guided", guided);
         metadataMap.put("/learn", guided);
         metadataMap.put(
                 "/privacy",
                 new PageMetadata(
-                        "Privacy Policy - Java Chat",
-                        "How Java Chat collects, uses, discloses, retains, and protects personal information.",
+                        "Privacy Policy - JavaChat",
+                        "How JavaChat collects, uses, discloses, retains, and protects personal information.",
                         defaultImage));
         metadataMap.put(
                 "/contact",
                 new PageMetadata(
-                        "Contact - Java Chat",
-                        "Contact the Java Chat team with questions, feedback, or privacy requests.",
+                        "Contact - JavaChat",
+                        "Contact the JavaChat team with questions, feedback, or privacy requests.",
                         defaultImage));
     }
 
@@ -174,7 +174,7 @@ public class SeoController {
                 {
                   "@context": "https://schema.org",
                   "@type": "WebApplication",
-                  "name": "Java Chat",
+                  "name": "JavaChat",
                   "url": "__FULL_URL__",
                   "applicationCategory": "EducationalApplication",
                   "operatingSystem": "Web",

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -109,11 +109,13 @@ app.cors.allow-credentials=true
 app.cors.max-age-seconds=3600
 
 # Contact/support form email delivery (self-hosted SMTP, STARTTLS on submission port)
+# Non-secret defaults live here per policy; deployments override host/port through Spring
+# relaxed binding (SPRING_MAIL_HOST / SPRING_MAIL_PORT) without placeholders in this file.
 # SMTP credentials are PROHIBITED here: they come only from the environment via Spring
 # relaxed binding (SPRING_MAIL_USERNAME / SPRING_MAIL_PASSWORD). Prod fails fast at
 # startup when they are absent (RequiredMailCredentialValidation).
-spring.mail.host=${SPRING_MAIL_HOST:localhost}
-spring.mail.port=${SPRING_MAIL_PORT:587}
+spring.mail.host=localhost
+spring.mail.port=587
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 app.contact.recipient-email=support@javachat.ai

--- a/src/test/java/com/williamcallahan/javachat/web/SeoControllerTest.java
+++ b/src/test/java/com/williamcallahan/javachat/web/SeoControllerTest.java
@@ -39,7 +39,7 @@ class SeoControllerTest {
                 .andReturn();
         Document htmlDocument = Jsoup.parse(mvcOutcome.getResponse().getContentAsString());
 
-        assertEquals("Java Chat - AI-Powered Java Learning With Citations", htmlDocument.title());
+        assertEquals("JavaChat - AI Learning", htmlDocument.title());
         assertMetaContent(htmlDocument, "property", "og:url", "https://example.com");
         assertMetaContent(htmlDocument, "property", "og:image", "https://example.com/og-image.png");
         assertMetaContent(htmlDocument, "property", "og:image:width", "1200");
@@ -52,7 +52,7 @@ class SeoControllerTest {
     void serves_chat_with_specific_metadata() throws Exception {
         Document htmlDocument = loadSeoDocument("/chat");
 
-        assertEquals("Java Chat - Streaming Java Tutor With Citations", htmlDocument.title());
+        assertEquals("JavaChat - Streaming Java Tutor With Citations", htmlDocument.title());
         assertMetaContent(htmlDocument, "property", "og:url", "https://example.com/chat");
     }
 
@@ -60,12 +60,12 @@ class SeoControllerTest {
     void serves_guided_with_specific_metadata() throws Exception {
         Document htmlDocument = loadSeoDocument("/guided");
 
-        assertEquals("Guided Java Learning - Java Chat", htmlDocument.title());
+        assertEquals("Guided Java Learning - JavaChat", htmlDocument.title());
         assertMetaContent(
                 htmlDocument,
                 "property",
                 "og:description",
-                "Structured, step-by-step Java learning paths with examples and explanations.");
+                "Guided Java lessons with examples and explanations: Spring Boot, Quarkus, Kotlin and other JVM languages, virtual threads, records, pattern matching, and JUnit testing.");
         assertMetaContent(htmlDocument, "property", "og:url", "https://example.com/guided");
     }
 
@@ -73,12 +73,12 @@ class SeoControllerTest {
     void serves_privacy_with_specific_metadata() throws Exception {
         Document htmlDocument = loadSeoDocument("/privacy");
 
-        assertEquals("Privacy Policy - Java Chat", htmlDocument.title());
+        assertEquals("Privacy Policy - JavaChat", htmlDocument.title());
         assertMetaContent(
                 htmlDocument,
                 "property",
                 "og:description",
-                "How Java Chat collects, uses, discloses, retains, and protects personal information.");
+                "How JavaChat collects, uses, discloses, retains, and protects personal information.");
         assertMetaContent(htmlDocument, "property", "og:url", "https://example.com/privacy");
     }
 
@@ -86,12 +86,12 @@ class SeoControllerTest {
     void serves_contact_with_specific_metadata() throws Exception {
         Document htmlDocument = loadSeoDocument("/contact");
 
-        assertEquals("Contact - Java Chat", htmlDocument.title());
+        assertEquals("Contact - JavaChat", htmlDocument.title());
         assertMetaContent(
                 htmlDocument,
                 "property",
                 "og:description",
-                "Contact the Java Chat team with questions, feedback, or privacy requests.");
+                "Contact the JavaChat team with questions, feedback, or privacy requests.");
         assertMetaContent(htmlDocument, "property", "og:url", "https://example.com/contact");
     }
 


### PR DESCRIPTION
## Summary

Follow-up repairs from the Codex review of #161: the contact form's per-IP rate limit can no longer be exceeded by concurrent bursts, crawlers and social previews now see the rebranded JavaChat metadata, and header menu links keep standard new-tab browser behavior — plus an iOS build setting that removes the manual encryption questionnaire from every App Store upload.

## Changes

### Bug Fixes

- **Contact rate limit could be exceeded by concurrent bursts**: multiple submissions from one IP could each observe the counter below the hourly allowance and all send before any increment landed; the allowance is now reserved with one atomic increment before sending and released when the reservation exceeds the limit or delivery fails (`ContactSubmissionUseCase.submit`)
- **Crawlers saw stale "Java Chat" branding**: `SeoController` still emitted the old titles, descriptions, and JSON-LD name, so clients that never run the SPA (crawlers, social previews) saw pre-rebrand metadata; server-rendered metadata now mirrors the frontend pageMetadata catalog for every routed path (`SeoController.initMetadata`, `SeoControllerTest`)
- **Command/Ctrl-click on menu links hijacked the current tab**: an unconditional `preventDefault()` suppressed the anchors' native new-tab behavior for Privacy and Contact; only unmodified primary-button clicks are intercepted now (`HeaderMenu.svelte.navigateToSiteLink`)

### Configuration

- **SMTP host/port defaults comply with the env-var policy**: the `${SPRING_MAIL_HOST:...}`/`${SPRING_MAIL_PORT:...}` placeholders declared a new env-var-driven settings contract; host and port are now plain property-file defaults per [EV1c], with deployment override unchanged via Spring relaxed binding — the same mechanism the SMTP credentials use (`application.properties`)

### Build

- **App Store uploads no longer prompt for export compliance**: the iOS app declares `ITSAppUsesNonExemptEncryption=false`, since it uses only platform TLS, so App Store Connect and TestFlight process builds without the manual encryption questionnaire (`mobile/iosApp/JavaChat/Info.plist`)

## Breaking Changes

None

## Related

Follow-up to #161 (merged) addressing its Codex review threads.
