### PR TITLE
fix(analytics): CSP-safe Clicky loader; Zod jitless under eval-less CSP

### DIFF
--- a/frontend/src/lib/validation/schemas.ts
+++ b/frontend/src/lib/validation/schemas.ts
@@ -9,6 +9,13 @@
 
 import { z } from "zod/v4";
 
+// The deployed CSP (`app.content-security-policy`) has no 'unsafe-eval', so
+// Zod's JIT fast path can never activate; without `jitless` its cached
+// `allowsEval` probe calls `new Function("")` once per page load, which the
+// browser reports as a `securitypolicyviolation` even though Zod swallows the
+// throw (zod/v4/core/util.cjs `allowsEval`).
+z.config({ jitless: true });
+
 // =============================================================================
 // SSE Stream Event Schemas
 // =============================================================================

--- a/src/main/java/com/williamcallahan/javachat/web/ClickyAnalyticsInjector.java
+++ b/src/main/java/com/williamcallahan/javachat/web/ClickyAnalyticsInjector.java
@@ -7,11 +7,14 @@ import org.jsoup.nodes.Element;
 import org.springframework.stereotype.Component;
 
 /**
- * Injects or removes Clicky analytics script tags from server-rendered HTML documents.
+ * Injects or removes the Clicky analytics loader in server-rendered HTML documents.
  *
- * <p>When Clicky analytics is enabled, this component appends the site-ID initializer
- * and the async script loader to the document {@code <head>}. When disabled, it strips
- * any existing Clicky tags to prevent double-injection from cached templates.
+ * <p>The site ID rides on the loader tag's {@code data-id} attribute instead of an
+ * inline initializer script: the deployed CSP restricts {@code script-src} to
+ * {@code 'self'} plus allowlisted origins, so any inline script is blocked and would
+ * leave Clicky without a site ID. Clicky's loader reads the attribute itself via
+ * {@code document.currentScript.getAttribute("data-id")} and pushes it into
+ * {@code clicky_site_ids} (verified against https://static.getclicky.com/js).
  *
  * <p>Owns all Clicky-specific DOM mutations so that controllers remain free of
  * analytics concerns.
@@ -20,8 +23,7 @@ import org.springframework.stereotype.Component;
 public class ClickyAnalyticsInjector {
 
     private static final String CLICKY_SCRIPT_URL = "https://static.getclicky.com/js";
-    private static final String CLICKY_INITIALIZER_TEMPLATE =
-            "var clicky_site_ids = clicky_site_ids || []; clicky_site_ids.push(%d);";
+    private static final String CLICKY_SITE_ID_ATTRIBUTE = "data-id";
 
     private final boolean clickyEnabled;
     private final long clickySiteId;
@@ -37,34 +39,38 @@ public class ClickyAnalyticsInjector {
     }
 
     /**
-     * Applies Clicky analytics to the document: injects tags when enabled, removes them when disabled.
+     * Applies Clicky analytics to the document: ensures a CSP-safe loader tag when enabled,
+     * removes all Clicky tags when disabled. Legacy inline {@code clicky_site_ids}
+     * initializers are stripped unconditionally because the CSP blocks them either way.
      *
      * @param document the Jsoup document whose {@code <head>} will be modified in place
      */
     public void applyTo(Document document) {
+        removeLegacyInitializers(document);
         Element existingClickyLoader = document.head().selectFirst("script[src=\"" + CLICKY_SCRIPT_URL + "\"]");
 
         if (!clickyEnabled) {
-            removeClickyTags(document, existingClickyLoader);
+            if (existingClickyLoader != null) {
+                existingClickyLoader.remove();
+            }
             return;
         }
 
         if (existingClickyLoader != null) {
+            existingClickyLoader.attr(CLICKY_SITE_ID_ATTRIBUTE, Long.toString(clickySiteId));
             return;
         }
 
-        String initializer = String.format(CLICKY_INITIALIZER_TEMPLATE, clickySiteId);
-        document.head().appendElement("script").text(initializer);
-        document.head().appendElement("script").attr("async", "").attr("src", CLICKY_SCRIPT_URL);
+        document.head()
+                .appendElement("script")
+                .attr("async", "")
+                .attr(CLICKY_SITE_ID_ATTRIBUTE, Long.toString(clickySiteId))
+                .attr("src", CLICKY_SCRIPT_URL);
     }
 
-    private void removeClickyTags(Document document, Element existingLoader) {
-        if (existingLoader != null) {
-            existingLoader.remove();
-        }
+    private void removeLegacyInitializers(Document document) {
         document.head().select("script").forEach(scriptTag -> {
-            String scriptBody = scriptTag.html();
-            if (scriptBody != null && scriptBody.contains("clicky_site_ids")) {
+            if (scriptTag.html().contains("clicky_site_ids")) {
                 scriptTag.remove();
             }
         });

--- a/src/test/java/com/williamcallahan/javachat/web/SeoControllerTest.java
+++ b/src/test/java/com/williamcallahan/javachat/web/SeoControllerTest.java
@@ -1,7 +1,9 @@
 package com.williamcallahan.javachat.web;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -93,6 +95,24 @@ class SeoControllerTest {
                 "og:description",
                 "Contact the JavaChat team with questions, feedback, or privacy requests.");
         assertMetaContent(htmlDocument, "property", "og:url", "https://example.com/contact");
+    }
+
+    /**
+     * The deployed CSP blocks inline scripts, so the Clicky site ID must travel on the
+     * loader tag's {@code data-id} attribute — never as an inline initializer script.
+     */
+    @Test
+    void injects_clicky_loader_without_inline_initializer() throws Exception {
+        Document htmlDocument = loadSeoDocument("/");
+
+        Element clickyLoader = htmlDocument.head().selectFirst("script[src=\"https://static.getclicky.com/js\"]");
+        assertNotNull(clickyLoader, "Missing Clicky loader script tag");
+        assertEquals("101501246", clickyLoader.attr("data-id"));
+        assertTrue(clickyLoader.hasAttr("async"), "Clicky loader must load asynchronously");
+
+        boolean inlineInitializerPresent = htmlDocument.head().select("script").stream()
+                .anyMatch(scriptTag -> scriptTag.html().contains("clicky_site_ids"));
+        assertFalse(inlineInitializerPresent, "Inline Clicky initializer violates the CSP");
     }
 
     private Document loadSeoDocument(String path) throws Exception {


### PR DESCRIPTION
Fixes the two Content-Security-Policy violations found while dogfooding the PR #163 prod deployment.

## Changes

- **Clicky inline initializer blocked by CSP (analytics silently dead in prod).** The backend injected `var clicky_site_ids = ...push(<site-id>)` as an inline script, which `script-src 'self' ...` blocks, so Clicky never received a site ID. The site ID now rides on the async loader tag's `data-id` attribute — Clicky's loader reads `document.currentScript.getAttribute("data-id")` itself (verified against https://static.getclicky.com/js). Legacy inline initializers are stripped from served documents unconditionally.
- **Zod eval probe reported as a CSP violation on every page load.** The CSP has no `'unsafe-eval'`, so Zod's JIT fast path can never activate; its cached `allowsEval` probe still called `new Function("")` once per load, surfacing a `securitypolicyviolation`. `z.config({ jitless: true })` in the canonical schemas module skips the probe.

## Validation

- `make build` (incl. Spotless) green
- `SeoControllerTest` green, including new `injects_clicky_loader_without_inline_initializer` asserting the `data-id` loader and the absence of any inline initializer
- Frontend `npm run validate` green; vitest 337/337